### PR TITLE
fix: use correct error_code attribute in ExceptionMiddleware

### DIFF
--- a/src/_core/middleware/exception_middleware.py
+++ b/src/_core/middleware/exception_middleware.py
@@ -19,8 +19,8 @@ class ExceptionMiddleware(BaseHTTPMiddleware):
             content = jsonable_encoder(
                 ErrorResponse(
                     message=f"Custom Exception: {exc.message}",
-                    error_code=getattr(exc, "code", "CUSTOM_ERROR"),
-                    error_details=getattr(exc, "details", None),
+                    error_code=exc.error_code,
+                    error_details=exc.details,
                 )
             )
             return JSONResponse(status_code=exc.status_code, content=content)


### PR DESCRIPTION
## Summary
- `ExceptionMiddleware` referenced a non-existent `code` attribute instead of `error_code` when handling `BaseCustomException`
- This caused every custom exception's `error_code` to fall back to `"CUSTOM_ERROR"` regardless of the actual value passed
- Fixed by replacing `getattr(exc, "code", ...)` with direct `exc.error_code` attribute access

## Test plan
- [ ] Raise a `BaseCustomException` subclass with a custom `error_code` (e.g. `DATABASE_UNHEALTHY`)
- [ ] Verify the error response contains the actual `error_code`, not `"CUSTOM_ERROR"`

Closes #22