### PR TITLE
docs: strengthen CLAUDE.md rules and sync references

### DIFF
--- a/.claude/skills/sync-guidelines/references/drift-checklist.md
+++ b/.claude/skills/sync-guidelines/references/drift-checklist.md
@@ -91,7 +91,7 @@ Inspect whether the content of each Skill's references/ files matches the curren
 ### Manual Inspection (Change-history-based — [REVIEW] targets)
 
 - [ ] **`review-architecture` checklist** (`checklist.md`):
-  - Count the items in CLAUDE.md's "Absolute Prohibitions" section and compare against the number of related inspection items in checklist.md
+  - Count the items in CLAUDE.md's "Absolute Prohibitions" section (expected: 5) and compare against the number of related inspection items in checklist.md
   - On mismatch: confirm with the user whether Grep patterns need to be added for new rules
 
 - [ ] **`security-review` security checklist** (`security-checklist.md`):

--- a/.serena/memories/architecture_conventions.md
+++ b/.serena/memories/architecture_conventions.md
@@ -1,6 +1,6 @@
 # Architecture Conventions
 
-> For Absolute Prohibitions, Conversion Patterns, and Write DTO criteria, refer to CLAUDE.md.
+> For Absolute Prohibitions (including CLAUDE.md modification rules), Conversion Patterns, and Write DTO criteria, refer to CLAUDE.md.
 > This memory only contains **structural context** not covered in CLAUDE.md.
 
 ## Data Flow (3-Tier Hybrid)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,8 @@ All proposals and designs must consider scalability, maintainability, and team c
 - No exposing Model objects outside the Repository
 - No separate Mapper classes (inline conversion is sufficient)
 - No Entity pattern — unified to DTO (background: [ADR 004](docs/history/004-dto-entity-responsibility.md))
+- No modifying/deleting CLAUDE.md or project-dna.md rules without cross-reference verification
+  (Run: `grep -rl "KEYWORD" .claude/skills/` to check skill dependencies before any change)
 
 ## Layer Architecture (3-Tier Hybrid)
 - Default: Router → Service (extends BaseService) → Repository (extends BaseRepository)
@@ -27,7 +29,9 @@ All proposals and designs must consider scalability, maintainability, and team c
 
 ## Claude Collaboration Rules
 - If diagnosis/review result is "adequate", do not force improvement suggestions
-- Before proposing, verify existing 4-layer coverage (CLAUDE.md / project-dna / Serena / auto-memory)
+- Before proposing changes to project rules or structure:
+  1. Grep `.claude/skills/` for keywords from the rule being changed
+  2. If any skill references the rule, it is project-level — do not relocate or weaken
 - Only propose modifying/deleting existing structures when benefits of the new structure are clear
 - Skill SKILL.md frontmatter supported attributes: name, argument-hint, description, disable-model-invocation, compatibility (allowed-tools not supported)
 - **Update related documentation when changing code** — before committing, check:
@@ -73,6 +77,8 @@ All proposals and designs must consider scalability, maintainability, and team c
 - Domain Containers themselves use `DeclarativeContainer`
 
 ## Tool Selection Guidelines
+
+> Serena and context7 are project-required MCP servers (configured via `.mcp.json`).
 
 ### Code Exploration / Reading (by priority)
 1. **Serena symbol tools** (default): `get_symbols_overview` → `find_symbol(include_body=True)`


### PR DESCRIPTION
## Related Issue
- N/A (guideline maintenance)

## Change Summary
- Add rule modification prohibition to Absolute Prohibitions with cross-reference verification step
- Replace vague "4-layer coverage" check with concrete skill-grep workflow in Collaboration Rules
- Declare Serena and context7 as project-required MCP servers
- Update drift-checklist with expected prohibition count (5)
- Update architecture_conventions memory to reference new rule

## Type of Change
- [x] docs: Documentation

## Checklist
- [x] Architecture rules followed (no Domain -> Infrastructure imports)
- [x] Tests pass
- [x] Linting passes (`ruff check src/`)

## How to Test
- Review CLAUDE.md diff for rule accuracy
- Run `/review-architecture all` to verify no drift