### PR TITLE
feat: add embedding service abstraction (#69)

### DIFF
--- a/.agents/skills/sync-guidelines/SKILL.md
+++ b/.agents/skills/sync-guidelines/SKILL.md
@@ -7,17 +7,20 @@ metadata:
 
 # Sync Guidelines
 
-1. Read `AGENTS.md` and `docs/ai/shared/skills/sync-guidelines.md` for the full procedure.
-2. Read `docs/ai/shared/drift-checklist.md` for detailed inspection items.
-3. Compare code against:
-   - `AGENTS.md`
-   - `README.md`
-   - `docs/README.ko.md`
-   - `CONTRIBUTING.md`
-   - `CLAUDE.md`
-   - `.codex/config.toml`
-   - `.codex/hooks.json`
-   - `.agents/skills/`
-4. Use `src/user/` as the reference domain for current patterns.
-5. Report drift clearly, then update the affected docs or workflow assets.
-6. After updates, re-run the inspection until major drift is gone.
+## Procedure Overview
+1. Reference code analysis — read `src/user/` for current patterns
+2. Code ↔ Documentation consistency check — `AGENTS.md`, shared refs, harness docs, skills, `.claude/rules/` (Phase 1-3)
+3. `project-dna.md` regeneration — extract from code and update when drift exists (Phase 4)
+4. References drift inspection — report both `AUTO-FIX` and `REVIEW` targets (Phase 5)
+
+Read `AGENTS.md` and `docs/ai/shared/skills/sync-guidelines.md` for the full procedure.
+Also refer to `docs/ai/shared/drift-checklist.md` for detailed inspection items.
+
+## Completion Contract
+`$sync-guidelines` is not complete until the result explicitly reports all of:
+- `project-dna` — regenerated or confirmed unchanged
+- `AUTO-FIX` — automatic drift targets and whether they were applied
+- `REVIEW` — human-review targets and why they need review, or `none`
+- `Remaining` — unresolved drift items, or `none`
+
+If any `REVIEW` item exists, do not close with “nothing to change” or equivalent wording.

--- a/.claude/rules/architecture-conventions.md
+++ b/.claude/rules/architecture-conventions.md
@@ -1,6 +1,6 @@
 # Architecture Conventions
 
-> Last synced: 2026-04-13 via /sync-guidelines
+> Last synced: 2026-04-14 via /sync-guidelines
 > For Absolute Prohibitions, Conversion Patterns, Write DTO criteria, and common commands, refer to AGENTS.md.
 > This file only contains **structural context** that supplements AGENTS.md for Claude.
 
@@ -27,11 +27,23 @@ Key differences from RDB:
 - Cursor-based pagination via CursorPage (not offset-based)
 - BaseDynamoService/BaseDynamoRepository — mirrors RDB counterparts
 
+## S3 Vectors Data Flow
+```
+  Write: Entity → VectorStore(BaseS3VectorStore) → S3VectorModel → S3 Vectors API
+  Read:  VectorSearchResult[DTO] ← VectorStore ← DTO ← S3 Vectors API response
+```
+Key differences from RDB/DynamoDB:
+- String keys (UUID v4 hex) via `generate_vector_id`
+- Similarity search via VectorQuery (top_k, filters) → VectorSearchResult
+- Subclass must implement `_to_model()` for domain-specific DTO → S3VectorModel conversion
+- `S3VectorModelMeta.dimension` auto-derived from `settings.embedding_dimension`
+
 ## BaseService Generic Structure
 - `BaseService(Generic[CreateDTO, UpdateDTO, ReturnDTO])` — 3 TypeVars (ADR 011 update, 2026-04-09)
 - `BaseRepositoryProtocol(Generic[ReturnDTO])` / `BaseRepository(Generic[ReturnDTO])` — 1 TypeVar (Repository only calls model_dump, no field-specific access)
 - `BaseDynamoService(Generic[CreateDTO, UpdateDTO, ReturnDTO])` — mirrors BaseService
 - `BaseDynamoRepositoryProtocol(Generic[ReturnDTO])` / `BaseDynamoRepository(Generic[ReturnDTO])` — mirrors BaseRepository
+- `BaseVectorStoreProtocol(Generic[ReturnDTO])` / `BaseS3VectorStore(Generic[ReturnDTO])` — vector store pattern
 - Domain Service example: `UserService(BaseService[CreateUserRequest, UpdateUserRequest, UserDTO])`
 - DO NOT simplify back to 1 TypeVar — this was tried and reverted (see ADR 011 Post-decision Update)
 
@@ -39,6 +51,11 @@ Key differences from RDB:
 - providers.Selector in CoreContainer: SQS/RabbitMQ/InMemory by BROKER_TYPE env var
 - Task code: `from src._apps.worker.broker import broker` — no conditional logic
 - stg/prod require explicit BROKER_TYPE setting
+
+## Embedding Selection
+- providers.Selector in CoreContainer: OpenAI/Bedrock by EMBEDDING_PROVIDER env var
+- Both implement BaseEmbeddingProtocol (embed_text, embed_batch, dimension)
+- Dimension auto-derived from model name — `settings.embedding_dimension` is single source of truth
 
 ## Object Roles
 
@@ -65,6 +82,13 @@ Key differences from RDB:
 - Location: `src/{domain}/infrastructure/dynamodb/models/{domain}_model.py`
 - Uses `DynamoModelMeta` + `__dynamo_meta__` for table schema declaration
 - Must never leave the Repository layer (same rule as ORM Model)
+
+### S3VectorModel
+- Location: `src/{domain}/infrastructure/s3vectors/models/{domain}_model.py`
+- Uses `S3VectorModelMeta` + `__s3vector_meta__` for index schema declaration
+- Must never leave the VectorStore layer (same rule as ORM Model/DynamoModel)
+- Conversion: `Entity → Model: _to_model()` (abstract, subclass implements)
+- Conversion: `API response → DTO: return_entity.model_validate(metadata)`
 
 ### Admin Page Config (BaseAdminPage)
 - Config: `src/{domain}/interface/admin/configs/{domain}_admin_config.py`

--- a/.claude/rules/commands.md
+++ b/.claude/rules/commands.md
@@ -1,6 +1,6 @@
 # Suggested Commands
 
-> Last synced: 2026-04-13 via /sync-guidelines
+> Last synced: 2026-04-14 via /sync-guidelines
 > Purpose: Quick reference for Claude Code when executing shell commands.
 > Also referenced when running Skills.
 > Makefile targets (`make dev`, `make test`, etc.) are available as shortcuts — see `AGENTS.md` Common Commands.

--- a/.claude/rules/project-overview.md
+++ b/.claude/rules/project-overview.md
@@ -1,6 +1,6 @@
 # Project Overview
 
-> Last synced: 2026-04-13 via /sync-guidelines
+> Last synced: 2026-04-14 via /sync-guidelines
 > For tech stack, refer to project-dna.md §8; for layer structure, refer to §1.
 > This file only contains **project-level context** not covered in project-dna.md.
 
@@ -19,12 +19,17 @@ Interface → Application → Domain ← Infrastructure
 - RDB: PostgreSQL, MySQL, SQLite (DATABASE_ENGINE env var)
 - DynamoDB: Optional (DYNAMODB_* env vars, BaseDynamoRepository)
 - Object Storage: S3/MinIO (S3_*/MINIO_* env vars)
+- S3 Vectors: Optional (S3VECTORS_* env vars, BaseS3VectorStore)
+- Embedding: Optional (EMBEDDING_PROVIDER env var, OpenAI/Bedrock Selector)
 - Message Broker: SQS/RabbitMQ/InMemory (BROKER_TYPE env var)
 
 ## Environment Config Validation
 - Settings (pydantic-settings) with model_validator
 - stg/prod: unsafe defaults blocked, broker required, partial config groups rejected
+- Partial config group validation: S3, MinIO, DynamoDB, S3Vectors, SQS, OpenAI, Bedrock
 
 ## Key Value Objects
 - QueryFilter: Immutable filter for paginated queries (sort/search). Used in BaseRepository.select_datas_with_count() and BaseService.get_datas().
 - DynamoKey: Composite key for DynamoDB (partition_key + optional sort_key). Used in BaseDynamoRepository operations.
+- VectorQuery: Immutable vector similarity search query (vector, top_k, filters). Used in BaseS3VectorStore.search().
+- VectorSearchResult: Vector search result container (items, distances, count). CursorPage counterpart for vector search.

--- a/.claude/rules/project-status.md
+++ b/.claude/rules/project-status.md
@@ -1,11 +1,11 @@
 # Project Status
 
-> Last synced: 2026-04-13 via /sync-guidelines
+> Last synced: 2026-04-14 via /sync-guidelines
 
 ## Current Version Context
 - Latest release: v0.3.0 (2026-04-10)
 - Active domains: user (reference domain)
-- Infrastructure: RDB (PostgreSQL/MySQL/SQLite), DynamoDB, S3, Broker (SQS/RabbitMQ/InMemory)
+- Infrastructure: RDB (PostgreSQL/MySQL/SQLite), DynamoDB, S3, S3 Vectors, Embedding, Broker (SQS/RabbitMQ/InMemory)
 
 ## Recent Major Changes (since v0.3.0)
 | Feature | Issue | Impact |
@@ -19,6 +19,10 @@
 | Password Hashing | - | hash_password/verify_password in _core.common.security |
 | Serena Removal & Pyright Adoption | #63 | pyright-lsp 기본 코드 인텔리전스, PostToolUse 포맷팅 훅, tool-agnostic 스킬 전환 |
 | Codex CLI Harness & Hybrid C Skills | #66 | Shared AGENTS.md, docs/ai/shared/ reference layer, 14 Hybrid C skill migrations |
+| S3 Vectors Support | #70 | BaseS3VectorStore, S3VectorModel, S3VectorClient, VectorQuery/VectorSearchResult |
+| Embedding Service Abstraction | #69 | Selector pattern (OpenAI/Bedrock), BaseEmbeddingProtocol, auto-dimension |
+| Text Chunking | #69 | semantic-text-splitter, chunk_text/chunk_text_by_tokens |
+| ADR 035/036 | #69 | Embedding abstraction + text chunking design decisions |
 
 ## Architecture Violation Status
 - Domain → Infrastructure import: CLEAN

--- a/.claude/skills/sync-guidelines/SKILL.md
+++ b/.claude/skills/sync-guidelines/SKILL.md
@@ -19,6 +19,8 @@ description: |
 Read `docs/ai/shared/skills/sync-guidelines.md` for detailed steps.
 Also refer to `docs/ai/shared/drift-checklist.md` for inspection items.
 
+Closing summary must include: `project-dna`, `AUTO-FIX`, `REVIEW`, `Remaining` — see "Sync Completion Contract" in shared procedure.
+
 ## Claude-Specific Post-Steps
 After completing the shared procedure:
 1. Update `.claude/rules/architecture-conventions.md`

--- a/.codex/hooks/stop-sync-reminder.py
+++ b/.codex/hooks/stop-sync-reminder.py
@@ -41,11 +41,13 @@ structure = [
 if foundation:
     message = "\n".join(
         [
-            "Guideline sync strongly recommended.",
+            "Guideline sync required before closing this work.",
             "Foundation files changed:",
             *[f"- {path}" for path in foundation[:12]],
             "Codex: run $sync-guidelines",
             "Claude Code: run /sync-guidelines as well",
+            "Sync is incomplete until project-dna, AUTO-FIX, REVIEW, and Remaining are all reported.",
+            "REVIEW targets must be reported even when no automatic doc edit is needed.",
         ]
     )
     print(json.dumps({"systemMessage": message}))
@@ -55,6 +57,7 @@ elif structure:
             "Guideline sync recommended.",
             "Domain structure files changed:",
             *[f"- {path}" for path in structure[:12]],
+            "When you run sync, report both AUTO-FIX and REVIEW targets before closing.",
         ]
     )
     print(json.dumps({"systemMessage": message}))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,7 @@ Tool-specific harness files:
 
 Do not duplicate shared architecture rules into tool-specific docs. Update `AGENTS.md` first, then adjust the harness docs that reference it.
 Shared workflow references that both tools consume live under [docs/ai/shared](docs/ai/shared).
+When running `/sync-guidelines` or `$sync-guidelines`, do not stop at automatic doc edits. The final result must explicitly include `project-dna`, `AUTO-FIX`, `REVIEW`, and `Remaining`.
 
 ## Claude Minimum Setup
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ All tools should follow `AGENTS.md` for:
 - baseline run/test/lint/migration commands
 - documentation drift management principles
 
-Use `docs/ai/shared/` for the deeper workflow references that are too detailed for root `AGENTS.md`, such as `project-dna.md`, planning checklists, review checklists, and test patterns.
+Use `docs/ai/shared/` for the deeper workflow references that are too detailed for root `AGENTS.md`, such as `project-dna.md`, planning checklists, review checklists, and test patterns. When running `/sync-guidelines` or `$sync-guidelines`, always close with `project-dna`, `AUTO-FIX`, `REVIEW`, and `Remaining` so manual review items are not silently skipped.
 
 ### Claude Code
 
@@ -219,7 +219,7 @@ The `/onboard` skill adapts to your experience and learning style:
 | `/test-domain {domain}` | Generate or run domain tests |
 | `/fix-bug {description}` | Structured bug fixing workflow |
 | `/review-pr {number}` | Architecture-aware PR review |
-| `/sync-guidelines` | Sync docs after design changes |
+| `/sync-guidelines` | Sync docs after design changes; report both AUTO-FIX and REVIEW targets before closing |
 | `/migrate-domain {command}` | Alembic migration management |
 
 #### Plugin Setup (Required)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 
 - **MCP Server interface** `planned` — Expose domain services as AI agent tools via FastMCP
 - **AI agent orchestration** `planned` — PydanticAI integration for structured LLM workflows
-- **Vector search** `planned` — pgvector for semantic search, RAG, and similarity matching
+- **Vector infrastructure** `available` — AWS S3 Vectors + OpenAI/Bedrock embeddings + chunking utilities for semantic search foundations
 
 ### Production-Ready Architecture
 
@@ -430,7 +430,8 @@ All interfaces share the same Domain and Infrastructure layers -- write your bus
 |-----------|---------|
 | **FastMCP** | MCP server — expose domain services as tools for AI agents |
 | **PydanticAI** | Structured LLM orchestration with Pydantic-native outputs |
-| **pgvector** | Vector similarity search (PostgreSQL extension) |
+| **AWS S3 Vectors** | Managed vector index backend for semantic search infrastructure |
+| **OpenAI / Bedrock Embeddings** | Pluggable embedding backends selected by configuration |
 
 ### Core
 
@@ -448,7 +449,8 @@ All interfaces share the same Domain and Infrastructure layers -- write your bus
 | **PostgreSQL** + asyncpg | Primary RDBMS |
 | **Taskiq** + AWS SQS | Async task queue ([why not Celery?](docs/history/001-celery-to-taskiq.md)) |
 | **aiohttp** | Async HTTP client |
-| **aioboto3** | S3/MinIO storage |
+| **aioboto3** | DynamoDB, S3/MinIO, S3 Vectors, and Bedrock clients |
+| **semantic-text-splitter** | Character/token chunking utilities for embedding preprocessing |
 | **Alembic** | DB migrations |
 
 ### DevOps
@@ -472,12 +474,16 @@ src/
 │   └── admin/                   # NiceGUI admin app
 │
 ├── _core/                        # Shared infrastructure
+│   ├── common/                  # Pagination, security, text utils, UUID helpers
 │   ├── domain/
 │   │   ├── protocols/           # BaseRepositoryProtocol[ReturnDTO]
 │   │   └── services/            # BaseService[CreateDTO, UpdateDTO, ReturnDTO]
 │   ├── infrastructure/
 │   │   ├── database/            # Database, BaseRepository[ReturnDTO]
+│   │   ├── dynamodb/            # DynamoDBClient, BaseDynamoRepository
+│   │   ├── embedding/           # OpenAI/Bedrock embedding clients
 │   │   ├── http/                # HttpClient, BaseHttpGateway
+│   │   ├── s3vectors/           # S3VectorClient, BaseS3VectorStore
 │   │   ├── taskiq/              # Broker adapters, TaskiqManager
 │   │   ├── storage/             # S3/MinIO
 │   │   ├── di/                  # CoreContainer
@@ -514,7 +520,7 @@ src/
 |---------|:-:|:-:|:-:|:-:|
 | MCP Server interface | **Planned** | No | No | No |
 | AI orchestration (PydanticAI) | **Planned** | No | No | No |
-| Vector search (pgvector) | **Planned** | No | No | No |
+| Vector infrastructure (S3 Vectors) | **Yes** | No | No | No |
 | Zero-boilerplate CRUD (7 methods) | **Yes** | No | No | No |
 | Auto domain discovery | **Yes** | No | No | No |
 | Architecture enforcement (pre-commit) | **Yes** | No | No | No |
@@ -549,7 +555,7 @@ Every technical choice in this project is documented as an ADR (Architecture Dec
 ### Phase 1: AI Agent Foundation
 - [ ] FastMCP interface ([#18](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/18))
 - [ ] PydanticAI integration ([#15](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/15))
-- [ ] pgvector support ([#11](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/11))
+- [ ] Additional vector backend: pgvector ([#11](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/11))
 - [ ] JWT authentication ([#4](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/4))
 
 ### Phase 2: Production Readiness

--- a/_env/local.env.example
+++ b/_env/local.env.example
@@ -46,5 +46,19 @@ DYNAMODB_ACCESS_KEY=
 DYNAMODB_SECRET_KEY=
 DYNAMODB_ENDPOINT_URL=http://localhost:8000
 
+# ----------------------------------------------------------------
+# Embedding (openai / bedrock, default: openai)
+# ----------------------------------------------------------------
+# EMBEDDING_PROVIDER=openai
+# EMBEDDING_MODEL=                        (default: provider-specific, dimension auto-derived)
+
+# OpenAI (required when EMBEDDING_PROVIDER=openai)
+# EMBEDDING_OPENAI_API_KEY=
+
+# Bedrock (required when EMBEDDING_PROVIDER=bedrock)
+# EMBEDDING_BEDROCK_ACCESS_KEY=
+# EMBEDDING_BEDROCK_SECRET_KEY=
+# EMBEDDING_BEDROCK_REGION=us-east-1
+
 ALLOWED_HOSTS=["localhost","127.0.0.1"]
 ALLOW_ORIGINS=["*"]

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -188,7 +188,7 @@ Read:  Response <-- Service <-- Repository <-- DTO <-- Model
 - 기본 run/test/lint/migration 명령
 - 문서와 규칙 drift 관리 원칙
 
-루트 `AGENTS.md`에 다 담기 어려운 workflow 세부사항은 `docs/ai/shared/`에 둡니다. 예: `project-dna.md`, planning/security/review checklist, test pattern.
+루트 `AGENTS.md`에 다 담기 어려운 workflow 세부사항은 `docs/ai/shared/`에 둡니다. 예: `project-dna.md`, planning/security/review checklist, test pattern. `/sync-guidelines` 또는 `$sync-guidelines`를 실행할 때는 수동 검토 항목이 빠지지 않도록 최종 결과에 `project-dna`, `AUTO-FIX`, `REVIEW`, `Remaining`를 모두 명시해야 합니다.
 
 ### Claude Code
 
@@ -217,7 +217,7 @@ Read:  Response <-- Service <-- Repository <-- DTO <-- Model
 | `/test-domain {domain}` | 도메인 테스트 생성 또는 실행 |
 | `/fix-bug {description}` | 구조화된 버그 수정 워크플로우 |
 | `/review-pr {number}` | 아키텍처 인식 PR 리뷰 |
-| `/sync-guidelines` | 설계 변경 후 문서 동기화 |
+| `/sync-guidelines` | 설계 변경 후 문서 동기화, 종료 전에 AUTO-FIX와 REVIEW를 모두 보고 |
 | `/migrate-domain {command}` | Alembic 마이그레이션 관리 |
 
 #### 플러그인 설정 (필수)

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -38,7 +38,7 @@
 
 - **MCP 서버 인터페이스** `planned` — FastMCP를 통해 도메인 서비스를 AI 에이전트 도구로 노출
 - **AI 에이전트 오케스트레이션** `planned` — 구조화된 LLM 워크플로우를 위한 PydanticAI 통합
-- **벡터 검색** `planned` — 시맨틱 검색, RAG, 유사도 매칭을 위한 pgvector
+- **벡터 인프라** `available` — AWS S3 Vectors + OpenAI/Bedrock 임베딩 + chunking 유틸리티로 시맨틱 검색 기반 제공
 
 ### 프로덕션 레디 아키텍처
 
@@ -428,7 +428,8 @@ async def create_product(
 |------|------|
 | **FastMCP** | MCP 서버 — 도메인 서비스를 AI 에이전트 도구로 노출 |
 | **PydanticAI** | Pydantic 네이티브 출력의 구조화된 LLM 오케스트레이션 |
-| **pgvector** | 벡터 유사도 검색 (PostgreSQL 확장) |
+| **AWS S3 Vectors** | 시맨틱 검색 인프라를 위한 관리형 벡터 인덱스 백엔드 |
+| **OpenAI / Bedrock Embeddings** | 설정으로 선택하는 플러그형 임베딩 백엔드 |
 
 ### Core
 
@@ -446,7 +447,8 @@ async def create_product(
 | **PostgreSQL** + asyncpg | 메인 RDBMS |
 | **Taskiq** + AWS SQS | 비동기 태스크 큐 ([왜 Celery가 아닌가?](../docs/history/001-celery-to-taskiq.md)) |
 | **aiohttp** | 비동기 HTTP 클라이언트 |
-| **aioboto3** | S3/MinIO 스토리지 |
+| **aioboto3** | DynamoDB, S3/MinIO, S3 Vectors, Bedrock 클라이언트 |
+| **semantic-text-splitter** | 임베딩 전처리를 위한 문자/토큰 chunking 유틸리티 |
 | **Alembic** | DB 마이그레이션 |
 
 ### DevOps
@@ -470,12 +472,16 @@ src/
 │   └── admin/                   # NiceGUI admin 앱
 │
 ├── _core/                        # 공통 인프라
+│   ├── common/                  # Pagination, security, text utils, UUID helper
 │   ├── domain/
 │   │   ├── protocols/           # BaseRepositoryProtocol[ReturnDTO]
 │   │   └── services/            # BaseService[CreateDTO, UpdateDTO, ReturnDTO]
 │   ├── infrastructure/
 │   │   ├── database/            # Database, BaseRepository[ReturnDTO]
+│   │   ├── dynamodb/            # DynamoDBClient, BaseDynamoRepository
+│   │   ├── embedding/           # OpenAI/Bedrock embedding client
 │   │   ├── http/                # HttpClient, BaseHttpGateway
+│   │   ├── s3vectors/           # S3VectorClient, BaseS3VectorStore
 │   │   ├── taskiq/              # Broker adapter, TaskiqManager
 │   │   ├── storage/             # S3/MinIO
 │   │   ├── di/                  # CoreContainer
@@ -512,7 +518,7 @@ src/
 |------|:-:|:-:|:-:|:-:|
 | MCP 서버 인터페이스 | **Planned** | No | No | No |
 | AI 오케스트레이션 (PydanticAI) | **Planned** | No | No | No |
-| 벡터 검색 (pgvector) | **Planned** | No | No | No |
+| 벡터 인프라 (S3 Vectors) | **Yes** | No | No | No |
 | 보일러플레이트 제로 CRUD (7개 메서드) | **Yes** | No | No | No |
 | 도메인 자동 발견 | **Yes** | No | No | No |
 | 아키텍처 자동 강제 (pre-commit) | **Yes** | No | No | No |
@@ -547,7 +553,7 @@ src/
 ### Phase 1: AI Agent Foundation
 - [ ] FastMCP 인터페이스 ([#18](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/18))
 - [ ] PydanticAI 통합 ([#15](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/15))
-- [ ] pgvector 지원 ([#11](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/11))
+- [ ] 추가 벡터 백엔드: pgvector ([#11](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/11))
 - [ ] JWT 인증 ([#4](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/4))
 
 ### Phase 2: Production Readiness

--- a/docs/ai/shared/project-dna.md
+++ b/docs/ai/shared/project-dna.md
@@ -6,13 +6,14 @@
 > This file is auto-extracted/updated from `src/user/` (reference domain) and `src/_core/` (Base classes)
 > when `/sync-guidelines` is run. **Run `/sync-guidelines` instead of editing manually.**
 >
-> Last updated: 2026-04-13
+> Last updated: 2026-04-14
 
 ## Section Index
 §0 Project Scale and Design Philosophy |
 §1 Directory Structure | §2 Base Class Path | §3 Generic Type Signatures | §4 CRUD Methods
 §5 DI Pattern | §6 Conversion Patterns | §7 Security Tools | §8 Active Features
 §9 Router Pattern | §10 Exception Pattern | §11 Admin Page Pattern
+§12 S3 Vector Store Pattern | §13 Embedding Pattern
 
 ---
 
@@ -133,6 +134,20 @@ src/{name}/
 | make_pagination | `src._core.common.pagination.make_pagination` |
 | hash_password | `src._core.common.security.hash_password` |
 | verify_password | `src._core.common.security.verify_password` |
+| BaseVectorStoreProtocol | `src._core.domain.protocols.vector_store_protocol.BaseVectorStoreProtocol` |
+| BaseEmbeddingProtocol | `src._core.domain.protocols.embedding_protocol.BaseEmbeddingProtocol` |
+| BaseS3VectorStore | `src._core.infrastructure.s3vectors.base_s3vector_store.BaseS3VectorStore` |
+| S3VectorModel | `src._core.infrastructure.s3vectors.s3vector_model.S3VectorModel` |
+| S3VectorModelMeta | `src._core.infrastructure.s3vectors.s3vector_model.S3VectorModelMeta` |
+| S3VectorData | `src._core.infrastructure.s3vectors.s3vector_model.S3VectorData` |
+| S3VectorClient | `src._core.infrastructure.s3vectors.s3vector_client.S3VectorClient` |
+| VectorQuery | `src._core.domain.value_objects.vector_query.VectorQuery` |
+| VectorSearchResult | `src._core.domain.value_objects.vector_search_result.VectorSearchResult` |
+| OpenAIEmbeddingClient | `src._core.infrastructure.embedding.openai_embedding_client.OpenAIEmbeddingClient` |
+| BedrockEmbeddingClient | `src._core.infrastructure.embedding.bedrock_embedding_client.BedrockEmbeddingClient` |
+| chunk_text | `src._core.common.text_utils.chunk_text` |
+| chunk_text_by_tokens | `src._core.common.text_utils.chunk_text_by_tokens` |
+| generate_vector_id | `src._core.common.uuid_utils.generate_vector_id` |
 | CoreContainer | `src._core.infrastructure.di.core_container.CoreContainer` |
 
 ### Inheritance Chain
@@ -185,6 +200,31 @@ class BaseDynamoService(Generic[CreateDTO, UpdateDTO, ReturnDTO]): ...
 class ChatRoomRepositoryProtocol(BaseDynamoRepositoryProtocol[ChatRoomDTO]): pass
 class ChatRoomRepository(BaseDynamoRepository[ChatRoomDTO]): ...
 class ChatRoomService(BaseDynamoService[CreateChatRoomRequest, UpdateChatRoomRequest, ChatRoomDTO]): ...
+```
+
+### S3 Vector Store Generic Type Signatures
+
+```python
+# BaseVectorStoreProtocol / BaseS3VectorStore — 1 TypeVar (ReturnDTO only)
+class BaseVectorStoreProtocol(Generic[ReturnDTO]): ...
+class BaseS3VectorStore(Generic[ReturnDTO], ABC): ...
+
+# S3 Vector domain usage example:
+class DocumentVectorStoreProtocol(BaseVectorStoreProtocol[DocumentDTO]): pass
+class DocumentS3VectorStore(BaseS3VectorStore[DocumentDTO]): ...
+```
+
+### BaseS3VectorStore.__init__ Signature
+
+```python
+def __init__(
+    self,
+    s3vector_client: S3VectorClient,
+    *,
+    model: type[S3VectorModel],
+    return_entity: type[ReturnDTO],
+    bucket_name: str,
+) -> None:
 ```
 
 ### BaseRepository.__init__ Signature
@@ -304,6 +344,8 @@ class {Name}Container(containers.DeclarativeContainer):
 | App Container (Server/Worker) | `containers.DynamicContainer` (factory function) |
 | Domain auto-discovery | `src._core.infrastructure.discovery.discover_domains()` |
 | Dynamic Container loading | `src._core.infrastructure.discovery.load_domain_container()` |
+| S3VectorClient | `providers.Singleton` | S3 Vectors API wrapper |
+| Embedding (multi-backend) | `providers.Selector` | Selects OpenAI/Bedrock by config |
 | Broker (multi-backend) | `providers.Selector` | Selects SQS/RabbitMQ/InMemory by config |
 
 ### App-level Container (Auto-discovery)
@@ -351,6 +393,48 @@ broker = providers.Selector(
 - Selector evaluates at container creation time; selected Singleton is cached
 - Task code always uses `from src._apps.worker.broker import broker` — no conditional logic needed
 - stg/prod environments require explicit `BROKER_TYPE` setting
+
+### Embedding Selection Pattern (Runtime Configuration)
+
+The embedding service uses `providers.Selector` to dynamically select between embedding backends
+based on the `EMBEDDING_PROVIDER` environment variable:
+
+```python
+# src/_core/infrastructure/di/core_container.py
+embedding_client = providers.Selector(
+    lambda: (settings.embedding_provider or "openai").lower().strip(),
+    openai=providers.Singleton(OpenAIEmbeddingClient, api_key=..., model=...),
+    bedrock=providers.Singleton(BedrockEmbeddingClient, access_key=..., ...),
+)
+```
+
+| EMBEDDING_PROVIDER | Client Class | Dependency |
+|-------------------|-------------|------------|
+| `openai` (default) | `OpenAIEmbeddingClient` | `openai`, `tiktoken` (optional extra) |
+| `bedrock` | `BedrockEmbeddingClient` | `aioboto3` (main) |
+
+- Both implement `BaseEmbeddingProtocol` (embed_text, embed_batch, dimension)
+- Dimension is auto-derived from model name — not user-configurable
+- `settings.embedding_dimension` is the single source of truth for vector index dimension
+
+### S3 Vector Store DI Pattern
+
+```python
+class {Name}Container(containers.DeclarativeContainer):
+    core_container = providers.DependenciesContainer()
+
+    {name}_vector_store = providers.Singleton(
+        {Name}S3VectorStore,
+        s3vector_client=core_container.s3vector_client,
+        embedding_client=core_container.embedding_client,
+        bucket_name=settings.s3vectors_bucket_name,
+    )
+
+    {name}_service = providers.Factory(
+        {Name}Service,
+        {name}_vector_store={name}_vector_store,
+    )
+```
 
 ### Interface-Specific DI Pattern
 
@@ -417,6 +501,9 @@ broker = providers.Selector(
 | NiceGUI (BaseAdminPage) | Active | Admin dashboard (AG Grid, auto-discovery, Template Method rendering) |
 | alembic (migrations) | Active | DB migrations |
 | Password hashing (bcrypt) | Active | hash_password(), verify_password() in src._core.common.security |
+| AWS S3 Vectors (aioboto3) | Active | BaseS3VectorStore + S3VectorClient (optional infra) |
+| Embedding (OpenAI/Bedrock) | Active | Selector pattern, BaseEmbeddingProtocol, auto-dimension |
+| Text chunking (semantic-text-splitter) | Active | chunk_text(), chunk_text_by_tokens() in src._core.common.text_utils |
 | JWT/Authentication | Not implemented | |
 | File Upload (UploadFile) | Not implemented | |
 | RBAC/Permissions | Not implemented | |
@@ -554,3 +641,125 @@ For domain-specific rendering, subclass `BaseAdminPage` in the config file and o
 - `render_grid(dtos)` — custom AG Grid rendering
 - `render_detail_card(dto)` — custom detail view
 - `_fetch_list_data(page, search)` / `_fetch_detail_data(record_id)` — custom data fetching
+
+## §12. S3 Vector Store Pattern
+
+### S3VectorModel (Data Model)
+
+`DynamoModel` counterpart — subclasses define index schema via `__s3vector_meta__` and declare metadata as Pydantic fields.
+
+```python
+from typing import ClassVar
+from src._core.infrastructure.s3vectors.s3vector_model import (
+    S3VectorModel, S3VectorModelMeta, S3VectorData,
+)
+
+class {Name}S3VectorModel(S3VectorModel):
+    __s3vector_meta__: ClassVar[S3VectorModelMeta] = S3VectorModelMeta(
+        index_name="{name}-search",
+        # dimension defaults to settings.embedding_dimension (auto-derived)
+        distance_metric="cosine",
+        filter_fields=["category", "author_id"],
+        non_filter_fields=["content_preview"],
+    )
+
+    category: str
+    author_id: str
+    content_preview: str
+```
+
+- `key`: auto-generated UUID v4 hex (via `generate_vector_id`)
+- `data`: `S3VectorData(float32=[...])` — embedding vector
+- Remaining fields → metadata (filter/non-filter)
+- `to_s3vector()` serializes to S3 Vectors API format; `from_s3vector()` deserializes
+
+### S3VectorModelMeta Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `index_name` | `str` | required | S3 Vectors index name |
+| `data_type` | `Literal["float32"]` | `"float32"` | Vector data type |
+| `dimension` | `int` | `settings.embedding_dimension` | Vector dimension (auto-derived) |
+| `distance_metric` | `Literal["cosine", "euclidean"]` | `"cosine"` | Distance metric |
+| `filter_fields` | `list[str]` | `[]` | Filterable metadata fields |
+| `non_filter_fields` | `list[str]` | `[]` | Non-filterable metadata fields |
+
+### BaseS3VectorStore (Repository Counterpart)
+
+Implements `BaseVectorStoreProtocol`. Subclass must implement `_to_model()` for domain-specific conversion.
+
+```python
+from src._core.infrastructure.s3vectors.base_s3vector_store import BaseS3VectorStore
+
+class {Name}S3VectorStore(BaseS3VectorStore[{Name}DTO]):
+    def __init__(self, s3vector_client, *, bucket_name):
+        super().__init__(
+            s3vector_client=s3vector_client,
+            model={Name}S3VectorModel,
+            return_entity={Name}DTO,
+            bucket_name=bucket_name,
+        )
+
+    def _to_model(self, entity: BaseModel) -> {Name}S3VectorModel:
+        return {Name}S3VectorModel(
+            data=S3VectorData(float32=entity.embedding),
+            category=entity.category,
+            # ... map DTO fields to model metadata
+        )
+```
+
+### BaseVectorStoreProtocol Methods
+
+| Method | Signature |
+|--------|---------|
+| upsert | `async (entities: Sequence[BaseModel]) -> int` |
+| search | `async (query: VectorQuery) -> VectorSearchResult[ReturnDTO]` |
+| get | `async (keys: list[str]) -> list[ReturnDTO]` |
+| delete | `async (keys: list[str]) -> bool` |
+
+### S3 Vector Domain Variant (Directory Structure)
+
+```
+src/{name}/
+├── infrastructure/
+│   ├── s3vectors/
+│   │   └── models/{name}_model.py    # extends S3VectorModel
+│   ├── repositories/{name}_vector_store.py  # extends BaseS3VectorStore
+│   └── di/{name}_container.py        # s3vector_client + embedding_client injection
+└── (나머지 동일)
+```
+
+## §13. Embedding Pattern
+
+### BaseEmbeddingProtocol
+
+Backend-agnostic protocol for embedding implementations. Both OpenAI and Bedrock implement this.
+
+```python
+class BaseEmbeddingProtocol:
+    @property
+    def dimension(self) -> int: ...
+    async def embed_text(self, text: str) -> list[float]: ...
+    async def embed_batch(self, texts: list[str]) -> list[list[float]]: ...
+```
+
+### Provider Implementations
+
+| Provider | Client Class | Batching | Dimension Source |
+|----------|-------------|----------|-----------------|
+| OpenAI | `OpenAIEmbeddingClient` | Auto (2048 items / 300K tokens) | Model lookup table |
+| Bedrock | `BedrockEmbeddingClient` | Sequential (per-text invoke) | Model lookup table |
+
+- OpenAI requires optional extras: `uv sync --extra openai` (openai + tiktoken)
+- Bedrock uses aioboto3 (already a main dependency)
+- Both raise domain exceptions: `EmbeddingRateLimitException`, `EmbeddingAuthenticationException`, `EmbeddingInputTooLongException`
+
+### Text Chunking Utilities
+
+| Function | Strategy | Use Case |
+|----------|----------|----------|
+| `chunk_text(text, chunk_size, overlap)` | Character-based (Unicode boundary aware) | General-purpose splitting |
+| `chunk_text_by_tokens(text, model, max_tokens, overlap)` | Token-based (tiktoken-rs) | Embedding preprocessing |
+
+- `semantic-text-splitter` handles Unicode word/sentence boundaries internally
+- Token-based chunking uses tiktoken-rs (built into semantic-text-splitter) — no separate tiktoken install needed

--- a/docs/ai/shared/security-checklist.md
+++ b/docs/ai/shared/security-checklist.md
@@ -229,3 +229,64 @@ Check DynamoDB client, model, and configuration files:
 - [ ] [When applicable][MEDIUM] DynamoDB IAM credentials managed via environment variables (not hardcoded)
   - Detection condition: Same as above
   - Grep: `dynamodb_access_key|dynamodb_secret_key` loaded from `Settings` (not hardcoded strings)
+
+## 10. S3 Vectors Security
+
+Check S3 Vectors client, store, and configuration files:
+
+### Access Control
+- [ ] [When applicable][HIGH] S3 Vectors AWS credentials managed via environment variables (not hardcoded)
+  - Detection condition: Check **project-dna.md section 8** "AWS S3 Vectors (aioboto3)" status -> [SKIP] if "not implemented"
+  - Grep: `s3vectors_access_key|s3vectors_secret_key` loaded from `Settings` (not hardcoded strings)
+
+### Error Information Exposure
+- [ ] [When applicable][HIGH] S3 Vectors error responses do not expose raw AWS error details in production
+  - Detection condition: Same as above
+  - Grep: `S3VectorException` wraps `ClientError` -> verify `error_message` from AWS is not exposed directly in user-facing responses
+  - Known exceptions (`S3VectorIndexNotFoundException`, `S3VectorThrottlingException`) use sanitized messages
+
+### Configuration Validation
+- [ ] [When applicable][MEDIUM] S3 Vectors configuration is complete (no partial credential sets)
+  - Detection condition: Same as above
+  - Grep: Settings `_validate_environment_safety` in `config.py` -> verify `s3vectors_*` fields validated as a group
+
+### Input Validation
+- [ ] [When applicable][MEDIUM] S3 Vectors batch operations respect API limits
+  - Detection condition: Same as above
+  - Grep: `_PUT_BATCH_SIZE|_GET_BATCH_SIZE|_DELETE_BATCH_SIZE` in `base_s3vector_store.py` -> verify batch sizes enforced (500/100/500)
+
+## 11. Embedding API Security
+
+Check Embedding client and configuration files:
+
+### API Key Management
+- [ ] [When applicable][CRITICAL] Embedding API keys (OpenAI/Bedrock) managed via environment variables (not hardcoded)
+  - Detection condition: Check **project-dna.md section 8** "Embedding (OpenAI/Bedrock)" status -> [SKIP] if "not implemented"
+  - Grep: `embedding_openai_api_key|embedding_bedrock_access_key|embedding_bedrock_secret_key` loaded from `Settings`
+  - Verify no API key hardcoded in client constructors
+
+### Input Length Validation
+- [ ] [When applicable][HIGH] Embedding input length validated before API call
+  - Detection condition: Same as above
+  - Grep: `EmbeddingInputTooLongException` raised in both OpenAI and Bedrock clients
+  - OpenAI: per-text limit 8,192 tokens, batch total 300,000 tokens
+  - Bedrock: per-text limit 50,000 characters
+
+### Rate Limit Handling
+- [ ] [When applicable][HIGH] Embedding API rate limit errors caught and wrapped into domain exceptions
+  - Detection condition: Same as above
+  - Grep: OpenAI `RateLimitError` -> `EmbeddingRateLimitException`
+  - Grep: Bedrock `ThrottlingException|TooManyRequestsException` -> `EmbeddingRateLimitException`
+
+### Error Information Exposure
+- [ ] [When applicable][HIGH] Embedding error responses do not expose raw API error details in production
+  - Detection condition: Same as above
+  - Grep: `EmbeddingException` wraps API errors -> verify raw `error_message` is not exposed in user-facing responses
+  - Known exceptions (`EmbeddingRateLimitException`, `EmbeddingAuthenticationException`, etc.) use sanitized messages
+
+### Configuration Validation
+- [ ] [When applicable][MEDIUM] Embedding provider credentials complete (no partial credential sets)
+  - Detection condition: Same as above
+  - Grep: Settings `_validate_environment_safety` in `config.py` -> verify provider-specific validation
+  - OpenAI: requires `embedding_openai_api_key` when `EMBEDDING_PROVIDER=openai`
+  - Bedrock: requires all 3 fields (`access_key`, `secret_key`, `region`) when `EMBEDDING_PROVIDER=bedrock`

--- a/docs/ai/shared/skills/sync-guidelines.md
+++ b/docs/ai/shared/skills/sync-guidelines.md
@@ -122,6 +122,33 @@ For skills that have been migrated to Hybrid C:
 References: AUTO-FIX X items | REVIEW X items | OK X items
 ```
 
+## Sync Completion Contract
+
+Do not treat the sync as complete until the closing summary includes all four sections below.
+
+```text
+project-dna: updated | unchanged
+AUTO-FIX: ...
+REVIEW: ...
+Remaining: ...
+```
+
+- **project-dna**: Whether `docs/ai/shared/project-dna.md` was regenerated, updated, or confirmed unchanged.
+- **AUTO-FIX**: Mechanically fixable drift targets and whether each fix was applied. If none: `AUTO-FIX: none`.
+- **REVIEW**: Human-review targets — explain why policy or product judgment is needed. If none: `REVIEW: none`.
+- **Remaining**: Unresolved drift that still remains after updates. If none: `Remaining: none`.
+
+If one or more `REVIEW` items exist, the sync result must not conclude with "nothing to change" or equivalent wording.
+
+Example:
+
+```text
+project-dna: updated (new Base class paths synced)
+AUTO-FIX: 2 items applied (scaffolding-layers, planning-checklists)
+REVIEW: 1 item (security-checklist lacks checks for newly active "Embedding")
+Remaining: none
+```
+
 ## When to Run
 - After architecture refactoring
 - After changes to Base classes or shared modules

--- a/docs/history/035-embedding-service-abstraction.md
+++ b/docs/history/035-embedding-service-abstraction.md
@@ -1,0 +1,169 @@
+# 035. Embedding Service Abstraction with Selector Pattern
+
+- Status: Accepted
+- Date: 2026-04-14
+- Related issue: #69
+- Related ADRs: [029](029-broker-abstraction-selector.md)(Selector pattern), [034](034-s3vectors-vectorstore-pattern.md)(VectorStore pattern)
+
+## Summary
+
+To provide shared embedding infrastructure for AI/ML applications, we added a `BaseEmbeddingProtocol` with OpenAI and Bedrock Titan implementations, selected via `providers.Selector` -- following the Broker pattern established in ADR 029. Dimension is auto-derived from the model to prevent configuration drift with vector store indexes.
+
+## Background
+
+- **Trigger**: Issue #69 -- the project supports vector storage (S3 Vectors, #11) but has no infrastructure for generating embeddings. Domain services that need to store or search vectors must bring their own embedding logic.
+
+- **Decision type**: Upfront design with iterative refinements -- the initial implementation used a configurable `EMBEDDING_DIMENSION` environment variable, but review revealed this was dangerous (changing dimension breaks existing vector indexes without warning). The design was corrected to auto-derive dimension from the model before merge.
+
+### Prior Art in the Project
+
+| Infrastructure | Selection Pattern | ADR |
+|---------------|-------------------|-----|
+| S3/MinIO | Parameter switching (endpoint_url) | [023](023-object-storage-unification.md) |
+| PostgreSQL/MySQL/SQLite | Parameter switching (engine) | [027](027-flexible-rdb-configuration.md) |
+| SQS/RabbitMQ/InMemory | `providers.Selector` (different classes) | [029](029-broker-abstraction-selector.md) |
+| **OpenAI/Bedrock Embedding** | **`providers.Selector` (different classes)** | **035 (this)** |
+
+## Problem
+
+### 1. No shared embedding infrastructure
+
+Each domain that needs embeddings must independently:
+- Set up API clients (AsyncOpenAI, aioboto3 bedrock-runtime)
+- Handle authentication, rate limiting, error mapping
+- Manage batch splitting to respect API limits
+- Track vector dimensions for index compatibility
+
+This leads to duplicated client setup across domains and makes model switching (e.g., OpenAI to Bedrock) a cross-cutting change.
+
+### 2. Different providers have fundamentally different APIs
+
+| Aspect | OpenAI | Bedrock Titan |
+|--------|--------|---------------|
+| Client | AsyncOpenAI (`openai` package) | aioboto3 `bedrock-runtime` |
+| Batch support | Native (up to 2,048 texts/request) | Single text per `invoke_model` |
+| Token limit | 8,192/text, 300,000/request total | 8,192 tokens, 50,000 chars |
+| Dimension | 1,536 (3-small), 3,072 (3-large) | 1,024 (Titan v2), 1,536 (v1) |
+| Dependency | Optional (`openai` + `tiktoken`) | Core (`aioboto3`, already present) |
+
+A factory function with mixed parameters (like the broker's rejected Alternative A in ADR 029) would grow unmanageably as providers are added.
+
+### 3. Dimension must be consistent with vector store indexes
+
+Embedding model dimension must match `S3VectorModelMeta.dimension`. If these drift apart (e.g., switching from OpenAI 1,536 to Bedrock 1,024 without updating the index), vector upserts silently fail or produce corrupted results. Making dimension a separate configuration increases this risk.
+
+## Alternatives Considered
+
+### A. LiteLLM unified gateway
+
+Use LiteLLM's `aembedding()` function which provides a single API across 20+ embedding providers.
+
+**Rejected**: (1) LiteLLM pulls in a large transitive dependency tree, violating the project's dependency minimalism. (2) It would be the only "meta-library" in the project -- every other infrastructure module (DynamoDB, S3, Broker) implements a direct client wrapper. (3) The Selector pattern cannot be demonstrated with a single implementation, reducing the blueprint's educational value. (4) LiteLLM hides provider-specific behavior (batching limits, token counting) that developers need to understand.
+
+### B. LangChain Embeddings interface
+
+Use `langchain-core`'s `Embeddings` ABC and implement providers against it.
+
+**Rejected**: Issue #69 itself noted this adds a heavy dependency for a simple interface. The project's VectorStore already diverges from LangChain's pattern (ADR 034). Coupling embedding to LangChain would create an inconsistency where VectorStore is custom but Embedding is LangChain.
+
+### C. Configurable EMBEDDING_DIMENSION environment variable (tried and corrected)
+
+The initial implementation included `EMBEDDING_DIMENSION` as a user-settable env var, passed to both clients and the DI container.
+
+**Corrected before merge**: Changing the dimension without re-embedding all existing vectors and recreating indexes causes silent data corruption. Dimension is a property of the model, not an independent configuration. The corrected design auto-derives dimension from the model name via internal lookup tables, and `S3VectorModelMeta.dimension` defaults to `settings.embedding_dimension` (a computed property).
+
+### D. Direct implementations with Selector pattern (chosen)
+
+Implement each provider as a standalone client class, selected via `providers.Selector` based on `EMBEDDING_PROVIDER` environment variable.
+
+## Decision
+
+### 1. BaseEmbeddingProtocol in domain layer
+
+```
+src/_core/domain/protocols/embedding_protocol.py
+```
+
+Three members: `dimension` (property), `embed_text(str)`, `embed_batch(list[str])`. No Generic TypeVar needed (input/output types are fixed). Domain services inject this protocol directly (like VectorStore, per ADR 034).
+
+### 2. Provider-specific clients in infrastructure layer
+
+```
+src/_core/infrastructure/embedding/
+    bedrock_embedding_client.py   # aioboto3, single invoke_model per text
+    openai_embedding_client.py    # AsyncOpenAI, token-based batch splitting
+    exceptions.py                 # EmbeddingException hierarchy
+```
+
+Each client follows the established async client pattern (ADR 009): session held as instance attribute, client created per operation via context manager, errors wrapped into domain exceptions.
+
+### 3. providers.Selector for multi-backend selection
+
+```python
+embedding_client = providers.Selector(
+    lambda: (settings.embedding_provider or "openai").lower().strip(),
+    openai=providers.Singleton(OpenAIEmbeddingClient, ...),
+    bedrock=providers.Singleton(BedrockEmbeddingClient, ...),
+)
+```
+
+Default provider is OpenAI (most accessible). Adding a new provider means adding one Singleton -- no existing providers modified.
+
+### 4. Dimension auto-derived from model
+
+Each client has an internal `_MODEL_DIMENSIONS` lookup table. The Settings class exposes a computed `embedding_dimension` property (read-only) that resolves provider + model to dimension. `S3VectorModelMeta.dimension` defaults to this property via `default_factory` with lazy import to avoid circular initialization.
+
+| Model | Dimension |
+|-------|-----------|
+| text-embedding-3-small | 1,536 |
+| text-embedding-3-large | 3,072 |
+| text-embedding-ada-002 | 1,536 |
+| amazon.titan-embed-text-v2:0 | 1,024 |
+| amazon.titan-embed-text-v1 | 1,536 |
+
+### 5. Token-based batching for OpenAI
+
+OpenAI's binding constraint is 300,000 total tokens per request (not 2,048 items). The client uses `tiktoken` to count tokens before batching. Individual texts exceeding 8,192 tokens raise `EmbeddingInputTooLongException`. Bedrock validates at 50,000 characters per text.
+
+### 6. OpenAI as optional dependency
+
+```toml
+[project.optional-dependencies]
+openai = ["openai>=1.0.0", "tiktoken>=0.7.0"]
+```
+
+Follows the broker pattern (ADR 029): lazy import with clear `ImportError` message. Bedrock requires no extra dependency (aioboto3 is already core).
+
+## Rationale
+
+### Infrastructure Selection Framework (extended)
+
+| Condition | Pattern | Example |
+|-----------|---------|---------|
+| Same class, different params | Parameter switching | S3/MinIO, PostgreSQL/MySQL |
+| Different classes, different signatures | `providers.Selector` | Broker (029), **Embedding (this)** |
+| Different paradigm (not CRUD) | Dedicated pattern | VectorStore (034) |
+
+### Why Auto-Derive Dimension?
+
+Embedding model dimension and vector store index dimension must be identical. If these are configured independently:
+
+```
+EMBEDDING_DIMENSION=1536  →  new vectors are 1536-dim
+S3VectorModelMeta(dimension=1024)  →  index expects 1024-dim
+→  silent mismatch, search quality degrades or API errors
+```
+
+By deriving both from the same source (model name), the values are always consistent. Changing the embedding model is an intentional act that requires re-embedding -- making dimension independently configurable would mask this requirement.
+
+### Trade-offs Accepted
+
+- **Two optional dependency groups for embedding**: `[openai]` for OpenAI (includes tiktoken). Bedrock needs no extra. This adds complexity to the install instructions but follows the established optional dependency pattern.
+- **No retry/backoff in v1**: The clients do not implement retry logic for transient errors. This is intentional for a blueprint -- retry strategies are domain-specific and can be added per-project. Bedrock SDK has built-in retry.
+- **Bedrock processes texts sequentially**: `invoke_model` accepts only one text per call. This is a Bedrock API constraint, not a design choice. The `embed_batch` loop is straightforward but slower than OpenAI's native batching.
+
+### Self-check
+- [x] Does this decision address the root cause, not just the symptom?
+- [x] Is this the right approach for the current project scale and team situation?
+- [x] Will a reader understand "why" 6 months from now without additional context?
+- [x] Am I recording the decision process, or justifying a conclusion I already reached?

--- a/docs/history/036-text-chunking-semantic-text-splitter.md
+++ b/docs/history/036-text-chunking-semantic-text-splitter.md
@@ -1,0 +1,167 @@
+# 036. Text Chunking with semantic-text-splitter
+
+- Status: Accepted
+- Date: 2026-04-14
+- Related issue: #69
+- Related ADRs: [035](035-embedding-service-abstraction.md)(Embedding service)
+
+## Summary
+
+To provide text chunking infrastructure for embedding pipelines, we adopted `semantic-text-splitter` -- a zero-dependency Rust library with built-in tiktoken-rs -- over LangChain's `RecursiveCharacterTextSplitter`, a custom implementation, or other alternatives. The library is wrapped in thin utility functions in `_core/common/text_utils.py`.
+
+## Background
+
+- **Trigger**: The embedding service abstraction (ADR 035) provides `embed_text` and `embed_batch`, but long documents exceed embedding model input limits (8,192 tokens for both OpenAI and Bedrock Titan). A text chunking utility is needed as the preprocessing step before embedding.
+
+- **Decision type**: Upfront design with course correction -- the initial implementation was a custom 60-line function (`chunk_text`) with character-based splitting. Review revealed that (1) character-based splitting doesn't align with token-based model limits, and (2) established libraries handle Unicode edge cases that custom code misses. The implementation was replaced with `semantic-text-splitter` before merge.
+
+### The Chunking Pipeline
+
+```
+Long Document
+    → chunk_text_by_tokens(text, model, max_tokens=8000)   ← this ADR
+    → embed_batch(chunks)                                   ← ADR 035
+    → vector_store.upsert(vectors)                          ← ADR 034
+```
+
+Text chunking is the first step. It must produce chunks that respect the embedding model's token limit while preserving semantic coherence.
+
+## Problem
+
+### 1. Embedding models have strict input limits
+
+| Model | Max Tokens/Input | What Happens on Exceed |
+|-------|-----------------|----------------------|
+| OpenAI text-embedding-3-small | 8,192 | API returns 400 error |
+| OpenAI text-embedding-3-large | 8,192 | API returns 400 error |
+| Bedrock Titan v2 | 8,192 tokens / 50,000 chars | API returns ValidationException |
+
+Documents routinely exceed these limits. A 10-page PDF can contain 50,000+ characters (~12,000 tokens). Without chunking, embedding fails.
+
+### 2. Character-based splitting misaligns with token limits
+
+The initial custom implementation split by character count (1,500 chars). But the token-to-character ratio varies significantly:
+
+| Language | Avg chars/token | 1,500 chars ≈ |
+|----------|----------------|---------------|
+| English | ~4 | ~375 tokens |
+| Korean | ~1.5 | ~1,000 tokens |
+| Code | ~3 | ~500 tokens |
+
+A 1,500-char chunk of Korean text uses ~2.7x more tokens than English. Character-based splitting provides no guarantee that chunks fit within token limits.
+
+### 3. Edge cases in text splitting
+
+Custom implementations commonly miss:
+- **CJK text**: No spaces between words; splitting on whitespace is meaningless
+- **Abbreviations**: "Dr. Smith went to Washington." -- splitting on ". " breaks "Dr."
+- **Multi-byte UTF-8**: Slicing by byte index can split characters mid-sequence
+- **Markdown structure**: Headers, code blocks, and lists need boundary awareness
+
+## Alternatives Considered
+
+### A. langchain-text-splitters (RecursiveCharacterTextSplitter)
+
+The de facto standard by download count (~29M monthly downloads). Provides `RecursiveCharacterTextSplitter` with `from_tiktoken_encoder()` for token-aware splitting.
+
+**Rejected**: Pulls in 10 transitive packages including `langchain-core` and `langsmith`. The project already rejected LangChain for embeddings (ADR 035) and VectorStore (ADR 034). Adding `langchain-text-splitters` for chunking while deliberately avoiding LangChain elsewhere creates an inconsistency. The download count is inflated by LangChain framework users who install it transitively.
+
+### B. Custom implementation (tried and replaced)
+
+A 60-line function with character-based splitting and sentence boundary detection via regex (`[.!?]\s`).
+
+**Replaced**: (1) Character-based splitting doesn't align with token-based model limits (see Problem #2). (2) Regex-based sentence detection fails on abbreviations, URLs, and non-Latin scripts. (3) No Unicode word/sentence boundary awareness (UAX #29). The function worked for English-only tests but would fail in production with multilingual content.
+
+### C. chonkie
+
+Newer library (3,900 GitHub stars) with async support and diverse chunking strategies.
+
+**Rejected**: Requires `numpy>=2.0` and `huggingface-hub` as mandatory dependencies -- contradicts the project's dependency minimalism. The `numpy` requirement alone adds a heavy compiled dependency for what is fundamentally string processing.
+
+### D. semchunk
+
+Battle-tested (used by IBM Docling, Microsoft Intelligence Toolkit) with highest RAG quality in benchmarks.
+
+**Rejected**: Requires `mpire` (multiprocessing library) with `dill` and `pygments` as dependencies. The fork-based multiprocessing model conflicts with FastAPI's asyncio event loop. Appropriate for batch document processing pipelines but overkill for a utility function.
+
+### E. semantic-text-splitter (chosen)
+
+Rust-compiled library with zero Python runtime dependencies. tiktoken-rs is compiled into the binary wheel.
+
+## Decision
+
+### 1. semantic-text-splitter as core dependency
+
+```toml
+dependencies = [
+    ...
+    "semantic-text-splitter>=0.17.0",
+]
+```
+
+Added to core (not optional) because text chunking is provider-agnostic -- it's needed regardless of whether OpenAI or Bedrock is the embedding provider. The package adds zero Python transitive dependencies (single Rust binary wheel, ~8MB).
+
+### 2. Two utility functions in _core/common/text_utils.py
+
+```python
+def chunk_text(text, chunk_size=1500, overlap=200) -> list[str]
+```
+Character-based splitting for general purposes (logging, summarization, display).
+
+```python
+def chunk_text_by_tokens(text, model="text-embedding-3-small", max_tokens=8000, overlap=200) -> list[str]
+```
+Token-based splitting for embedding preprocessing. Uses tiktoken-rs internally (no `tiktoken` Python package needed). Default `max_tokens=8000` provides 192-token safety margin below the 8,192 limit.
+
+### 3. Thin wrapper, not direct usage
+
+Domain code calls `chunk_text_by_tokens()`, not `TextSplitter.from_tiktoken_model()` directly. This provides:
+- Consistent empty-string handling (`[]` for blank input)
+- A stable API if the underlying library is ever replaced
+- Discoverability (utility functions in `_core/common/`, not scattered library imports)
+
+### 4. semantic-text-splitter handles boundaries internally
+
+The library uses Unicode Text Segmentation (UAX #29) at the Rust level:
+1. Characters
+2. Grapheme cluster boundaries
+3. Word boundaries
+4. Sentence boundaries
+5. Line breaks
+6. Paragraphs
+
+This covers CJK, abbreviations, and multi-byte characters without project-specific regex.
+
+## Rationale
+
+### Why Zero Dependencies Matters
+
+| Library | Added Python Packages | Token-aware |
+|---------|----------------------|-------------|
+| langchain-text-splitters | 10 (langchain-core, langsmith, ...) | Via tiktoken |
+| chonkie | 5+ (numpy, huggingface-hub, ...) | Via tiktoken |
+| semchunk | 5+ (mpire, dill, pygments, ...) | Via tiktoken |
+| **semantic-text-splitter** | **0** | **Built-in (tiktoken-rs)** |
+| Custom implementation | 0 | Must add tiktoken |
+
+`semantic-text-splitter` is the only option that provides token-aware splitting with zero additional Python dependencies. The tiktoken-rs tokenizer is compiled into the Rust binary, eliminating the need for the `tiktoken` Python package for chunking purposes.
+
+Note: `tiktoken` (Python) is still in `[openai]` optional extras for a different purpose -- the OpenAI embedding client uses it for API request batching (300K token limit enforcement). These are separate concerns.
+
+### The RecursiveCharacterTextSplitter Concept is Standard, Not the Package
+
+The investigation revealed an important distinction: `RecursiveCharacterTextSplitter`'s *strategy* (try paragraph breaks, then sentence breaks, then word breaks, then characters) is the industry standard. The `langchain-text-splitters` *package* is popular because it's installed transitively with LangChain. Projects moving away from LangChain (to PydanticAI, CrewAI, direct SDK usage) do not retain the package.
+
+`semantic-text-splitter` implements the same hierarchical splitting strategy (Unicode sentence > word > grapheme > character) without the LangChain dependency tree.
+
+### Trade-offs Accepted
+
+- **0.x version**: `semantic-text-splitter` is at v0.29.0 (not yet 1.0). Mitigated by 73 releases, 1,190 commits, and active maintenance. The overlap feature has been stable since v0.12.2 (April 2024).
+- **Rust binary wheel**: Requires platform-specific wheels. Pre-built wheels exist for Linux x86_64/aarch64, macOS x86_64/ARM64, and Windows x86_64. Rare platforms may need Rust toolchain for compilation.
+- **No async API**: The library is synchronous (pure CPU computation in Rust). This is acceptable -- text splitting completes in microseconds, faster than the overhead of an async context switch.
+
+### Self-check
+- [x] Does this decision address the root cause, not just the symptom?
+- [x] Is this the right approach for the current project scale and team situation?
+- [x] Will a reader understand "why" 6 months from now without additional context?
+- [x] Am I recording the decision process, or justifying a conclusion I already reached?

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -42,6 +42,8 @@ Each document captures the context and decision criteria for "why this technolog
 | [032](032-codex-native-workflow-assets.md) | Codex Native Workflow Assets After the Thin Harness Phase | Accepted | Done | 2026-04-13 |
 | [033](033-hybrid-c-skill-split-convention.md) | Hybrid C Skill Split Convention | Accepted | Done | 2026-04-13 |
 | [034](034-s3vectors-vectorstore-pattern.md) | S3 Vectors Integration with VectorStore Pattern | Accepted | Done | 2026-04-14 |
+| [035](035-embedding-service-abstraction.md) | Embedding Service Abstraction with Selector Pattern | Accepted | Done | 2026-04-14 |
+| [036](036-text-chunking-semantic-text-splitter.md) | Text Chunking with semantic-text-splitter | Accepted | Done | 2026-04-14 |
 
 ## Future Considerations (Open Issues)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,12 +25,14 @@ dependencies = [
     "nicegui>=3.5.0",
     "sqlalchemy>=2.0.40",
     "taskiq[reload]>=0.12.1",
+    "semantic-text-splitter>=0.17.0",
     "uvicorn>=0.34.1",
 ]
 
 [project.optional-dependencies]
 sqs = ["taskiq-aws>=0.4.0"]
 rabbitmq = ["taskiq-aio-pika>=0.4.0"]
+openai = ["openai>=1.0.0", "tiktoken>=0.7.0"]
 
 [dependency-groups]
 dev = [

--- a/src/_core/common/text_utils.py
+++ b/src/_core/common/text_utils.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from semantic_text_splitter import TextSplitter
+
+
+def chunk_text(
+    text: str,
+    chunk_size: int = 1500,
+    overlap: int = 200,
+) -> list[str]:
+    """문자 기반 텍스트 분할 (범용).
+
+    내부적으로 Unicode word/sentence boundary를 인식하여
+    의미 단위에서 분할을 시도한다.
+
+    Args:
+        text: 분할할 텍스트.
+        chunk_size: chunk당 최대 문자 수 (기본 1500).
+        overlap: 연속 chunk 간 겹침 문자 수 (기본 200).
+
+    Returns:
+        chunk 리스트. 빈 입력이면 ``[]``.
+    """
+    text = text.strip()
+    if not text:
+        return []
+    splitter = TextSplitter(chunk_size, overlap=overlap)
+    return splitter.chunks(text)
+
+
+def chunk_text_by_tokens(
+    text: str,
+    model: str = "text-embedding-3-small",
+    max_tokens: int = 8000,
+    overlap: int = 200,
+) -> list[str]:
+    """토큰 기반 텍스트 분할 (임베딩 전처리용).
+
+    tiktoken-rs 내장 — 별도 tiktoken 설치 불필요.
+    임베딩 모델의 입력 토큰 제한(8,192)에 맞춰 분할할 때 사용.
+
+    Args:
+        text: 분할할 텍스트.
+        model: tiktoken 모델명 (기본 "text-embedding-3-small").
+        max_tokens: chunk당 최대 토큰 수 (기본 8000, 8192 제한에 여유 확보).
+        overlap: 연속 chunk 간 겹침 토큰 수 (기본 200).
+
+    Returns:
+        chunk 리스트. 빈 입력이면 ``[]``.
+    """
+    text = text.strip()
+    if not text:
+        return []
+    splitter = TextSplitter.from_tiktoken_model(model, max_tokens, overlap=overlap)
+    return splitter.chunks(text)

--- a/src/_core/config.py
+++ b/src/_core/config.py
@@ -7,7 +7,18 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 KNOWN_ENVS = ("local", "dev", "stg", "prod")
 KNOWN_ENGINES = ("postgresql", "mysql", "sqlite")
 KNOWN_BROKER_TYPES = ("sqs", "rabbitmq", "inmemory")
+KNOWN_EMBEDDING_PROVIDERS = ("openai", "bedrock")
 STRICT_ENVS = frozenset({"stg", "prod"})
+
+_OPENAI_DIMENSIONS: dict[str, int] = {
+    "text-embedding-3-small": 1536,
+    "text-embedding-3-large": 3072,
+    "text-embedding-ada-002": 1536,
+}
+_BEDROCK_DIMENSIONS: dict[str, int] = {
+    "amazon.titan-embed-text-v2:0": 1024,
+    "amazon.titan-embed-text-v1": 1536,
+}
 
 _UNSAFE_DEFAULTS: dict[str, str] = {
     "admin_password": "admin",  # noqa: S105
@@ -140,6 +151,32 @@ class Settings(BaseSettings):
     # Messaging (RabbitMQ) — required when BROKER_TYPE=rabbitmq
     # ----------------------------------------------------------------
     rabbitmq_url: str | None = Field(default=None, validation_alias="RABBITMQ_URL")
+
+    # ----------------------------------------------------------------
+    # Embedding (Optional)
+    # ----------------------------------------------------------------
+    embedding_provider: str | None = Field(
+        default=None, validation_alias="EMBEDDING_PROVIDER"
+    )
+    embedding_model: str | None = Field(
+        default=None, validation_alias="EMBEDDING_MODEL"
+    )
+
+    # OpenAI-specific (required when EMBEDDING_PROVIDER=openai)
+    embedding_openai_api_key: str | None = Field(
+        default=None, validation_alias="EMBEDDING_OPENAI_API_KEY"
+    )
+
+    # Bedrock-specific (required when EMBEDDING_PROVIDER=bedrock)
+    embedding_bedrock_access_key: str | None = Field(
+        default=None, validation_alias="EMBEDDING_BEDROCK_ACCESS_KEY"
+    )
+    embedding_bedrock_secret_key: str | None = Field(
+        default=None, validation_alias="EMBEDDING_BEDROCK_SECRET_KEY"
+    )
+    embedding_bedrock_region: str | None = Field(
+        default=None, validation_alias="EMBEDDING_BEDROCK_REGION"
+    )
 
     # ----------------------------------------------------------------
     # Network Policy
@@ -276,6 +313,35 @@ class Settings(BaseSettings):
                 "[RabbitMQ] BROKER_TYPE=rabbitmq requires: rabbitmq_url missing"
             )
 
+        embedding = (self.embedding_provider or "").lower().strip()
+        if embedding and embedding not in KNOWN_EMBEDDING_PROVIDERS:
+            errors.append(
+                f"[embedding_provider] Unknown embedding provider "
+                f"'{self.embedding_provider}'. "
+                f"Expected one of: {', '.join(KNOWN_EMBEDDING_PROVIDERS)}"
+            )
+
+        if embedding == "openai":
+            if not self.embedding_openai_api_key:
+                errors.append(
+                    "[Embedding/OpenAI] EMBEDDING_PROVIDER=openai requires: "
+                    "embedding_openai_api_key missing"
+                )
+
+        if embedding == "bedrock":
+            bedrock_fields = {
+                "embedding_bedrock_access_key": self.embedding_bedrock_access_key,
+                "embedding_bedrock_secret_key": self.embedding_bedrock_secret_key,
+                "embedding_bedrock_region": self.embedding_bedrock_region,
+            }
+            bedrock_set = {k for k, v in bedrock_fields.items() if v is not None}
+            if bedrock_set != set(bedrock_fields):
+                missing = sorted(set(bedrock_fields) - bedrock_set)
+                errors.append(
+                    f"[Embedding/Bedrock] EMBEDDING_PROVIDER=bedrock requires: "
+                    f"{', '.join(missing)} missing"
+                )
+
         if errors:
             bullet_list = "\n  - ".join(errors)
             raise ValueError(
@@ -306,6 +372,21 @@ class Settings(BaseSettings):
         if self.minio_host and self.minio_port:
             return f"{self.minio_host}:{self.minio_port}"
         return None
+
+    @property
+    def embedding_dimension(self) -> int:
+        """Derive embedding vector dimension from provider and model.
+
+        Not user-configurable — determined by the selected model.
+        Used as the single source of truth for ``S3VectorModelMeta.dimension``.
+        """
+        provider = (self.embedding_provider or "openai").lower()
+        model = self.embedding_model
+        if provider == "bedrock":
+            return _BEDROCK_DIMENSIONS.get(
+                model or "amazon.titan-embed-text-v2:0", 1024
+            )
+        return _OPENAI_DIMENSIONS.get(model or "text-embedding-3-small", 1536)
 
 
 settings = Settings()

--- a/src/_core/domain/protocols/embedding_protocol.py
+++ b/src/_core/domain/protocols/embedding_protocol.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+
+class BaseEmbeddingProtocol:
+    """Backend-agnostic embedding protocol.
+
+    Abstraction boundary for embedding implementations.
+    Both OpenAI and Bedrock Titan implement this protocol.
+    Domain services inject this protocol directly.
+
+    ``dimension`` exposes the vector size so that callers
+    (e.g. ``S3VectorModelMeta``) can align index configuration.
+    """
+
+    @property
+    def dimension(self) -> int: ...
+
+    async def embed_text(self, text: str) -> list[float]: ...
+
+    async def embed_batch(self, texts: list[str]) -> list[list[float]]: ...

--- a/src/_core/infrastructure/di/core_container.py
+++ b/src/_core/infrastructure/di/core_container.py
@@ -5,6 +5,12 @@ from src._core.config import settings
 from src._core.infrastructure.database.config import DatabaseConfig
 from src._core.infrastructure.database.database import Database
 from src._core.infrastructure.dynamodb.dynamodb_client import DynamoDBClient
+from src._core.infrastructure.embedding.bedrock_embedding_client import (
+    BedrockEmbeddingClient,
+)
+from src._core.infrastructure.embedding.openai_embedding_client import (
+    OpenAIEmbeddingClient,
+)
 from src._core.infrastructure.http.http_client import HttpClient
 from src._core.infrastructure.s3vectors.s3vector_client import S3VectorClient
 from src._core.infrastructure.storage.object_storage import ObjectStorage
@@ -98,6 +104,26 @@ class CoreContainer(containers.DeclarativeContainer):
         access_key=settings.s3vectors_access_key,
         secret_access_key=settings.s3vectors_secret_key,
         region_name=settings.s3vectors_region,
+    )
+
+    #########################################################
+    # Embedding
+    #########################################################
+
+    embedding_client = providers.Selector(
+        lambda: (settings.embedding_provider or "openai").lower().strip(),
+        openai=providers.Singleton(
+            OpenAIEmbeddingClient,
+            api_key=settings.embedding_openai_api_key,
+            model=settings.embedding_model or "text-embedding-3-small",
+        ),
+        bedrock=providers.Singleton(
+            BedrockEmbeddingClient,
+            access_key=settings.embedding_bedrock_access_key,
+            secret_access_key=settings.embedding_bedrock_secret_key,
+            region_name=settings.embedding_bedrock_region,
+            model_id=settings.embedding_model or "amazon.titan-embed-text-v2:0",
+        ),
     )
 
     #########################################################

--- a/src/_core/infrastructure/embedding/bedrock_embedding_client.py
+++ b/src/_core/infrastructure/embedding/bedrock_embedding_client.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+
+import aioboto3
+from aiobotocore.client import AioBaseClient
+from botocore.exceptions import ClientError
+
+from src._core.infrastructure.embedding.exceptions import (
+    EmbeddingAuthenticationException,
+    EmbeddingException,
+    EmbeddingInputTooLongException,
+    EmbeddingModelNotFoundException,
+    EmbeddingRateLimitException,
+)
+
+_THROTTLE_CODES = frozenset({"ThrottlingException", "TooManyRequestsException"})
+_MAX_CHARS_PER_TEXT = 50_000  # Bedrock Titan per-text character limit
+
+_MODEL_DIMENSIONS: dict[str, int] = {
+    "amazon.titan-embed-text-v2:0": 1024,
+    "amazon.titan-embed-text-v1": 1536,
+}
+_DEFAULT_DIMENSION = 1024
+
+
+class BedrockEmbeddingClient:
+    """Async Bedrock Titan embedding client using aioboto3.
+
+    Implements ``BaseEmbeddingProtocol``.
+    Pattern identical to ``S3VectorClient``:
+    - Session held as instance attribute (Singleton in DI)
+    - Client created per operation via async context manager
+    - ``ClientError`` wrapped into domain exceptions at client level
+    - Errors only occur when ``_bedrock_client()`` is actually called,
+      not at init (allows Singleton creation with ``None`` config)
+
+    Dimension is derived automatically from ``model_id``
+    via ``_MODEL_DIMENSIONS``. Not user-configurable.
+    """
+
+    def __init__(
+        self,
+        access_key: str,
+        secret_access_key: str,
+        region_name: str = "us-east-1",
+        model_id: str = "amazon.titan-embed-text-v2:0",
+    ) -> None:
+        self.session = aioboto3.Session(
+            aws_access_key_id=access_key,
+            aws_secret_access_key=secret_access_key,
+            region_name=region_name,
+        )
+        self.model_id = model_id
+        self._dimension = _MODEL_DIMENSIONS.get(model_id, _DEFAULT_DIMENSION)
+
+    @property
+    def dimension(self) -> int:
+        return self._dimension
+
+    @asynccontextmanager
+    async def _bedrock_client(self) -> AsyncGenerator[AioBaseClient, None]:
+        try:
+            async with self.session.client("bedrock-runtime") as client:
+                yield client
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "Unknown")
+            error_message = e.response.get("Error", {}).get("Message", str(e))
+
+            if error_code in _THROTTLE_CODES:
+                raise EmbeddingRateLimitException() from e
+            if error_code == "AccessDeniedException":
+                raise EmbeddingAuthenticationException() from e
+            if error_code in ("ModelNotReadyException", "ValidationException"):
+                raise EmbeddingModelNotFoundException(self.model_id) from e
+
+            raise EmbeddingException(
+                status_code=500,
+                message="Bedrock embedding failed ["
+                + error_code
+                + "]: "
+                + error_message,
+                error_code="EMBEDDING_OPERATION_FAILED",
+            ) from e
+
+    async def embed_text(self, text: str) -> list[float]:
+        if len(text) > _MAX_CHARS_PER_TEXT:
+            raise EmbeddingInputTooLongException(
+                len(text), _MAX_CHARS_PER_TEXT, "characters"
+            )
+        async with self._bedrock_client() as client:
+            response = await client.invoke_model(
+                modelId=self.model_id,
+                contentType="application/json",
+                accept="application/json",
+                body=json.dumps(
+                    {
+                        "inputText": text,
+                        "dimensions": self._dimension,
+                    }
+                ),
+            )
+            body = json.loads(await response["body"].read())
+            return body["embedding"]
+
+    async def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        results: list[list[float]] = []
+        for text in texts:
+            embedding = await self.embed_text(text)
+            results.append(embedding)
+        return results

--- a/src/_core/infrastructure/embedding/exceptions.py
+++ b/src/_core/infrastructure/embedding/exceptions.py
@@ -1,0 +1,53 @@
+from src._core.exceptions.base_exception import BaseCustomException
+
+
+class EmbeddingException(BaseCustomException):
+    """Base exception for embedding operations."""
+
+    pass
+
+
+class EmbeddingRateLimitException(EmbeddingException):
+    def __init__(self) -> None:
+        super().__init__(
+            status_code=429,
+            message="Embedding API rate limit exceeded",
+            error_code="EMBEDDING_RATE_LIMITED",
+        )
+
+
+class EmbeddingAuthenticationException(EmbeddingException):
+    def __init__(self) -> None:
+        super().__init__(
+            status_code=401,
+            message="Embedding API authentication failed",
+            error_code="EMBEDDING_AUTH_FAILED",
+        )
+
+
+class EmbeddingModelNotFoundException(EmbeddingException):
+    def __init__(self, model_id: str = "") -> None:
+        msg = (
+            "Embedding model not found: " + model_id
+            if model_id
+            else "Embedding model not found"
+        )
+        super().__init__(
+            status_code=404,
+            message=msg,
+            error_code="EMBEDDING_MODEL_NOT_FOUND",
+        )
+
+
+class EmbeddingInputTooLongException(EmbeddingException):
+    def __init__(
+        self, input_length: int, max_length: int, unit: str = "tokens"
+    ) -> None:
+        super().__init__(
+            status_code=400,
+            message=(
+                f"Embedding input too long: {input_length} {unit} "
+                f"(max {max_length} {unit})"
+            ),
+            error_code="EMBEDDING_INPUT_TOO_LONG",
+        )

--- a/src/_core/infrastructure/embedding/openai_embedding_client.py
+++ b/src/_core/infrastructure/embedding/openai_embedding_client.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from src._core.infrastructure.embedding.exceptions import (
+    EmbeddingAuthenticationException,
+    EmbeddingException,
+    EmbeddingInputTooLongException,
+    EmbeddingRateLimitException,
+)
+
+_BATCH_SIZE = 2048  # OpenAI max texts per request
+_MAX_TOKENS_PER_BATCH = 300_000  # OpenAI total token limit per request
+_MAX_TOKENS_PER_TEXT = 8192  # OpenAI per-text token limit
+
+_MODEL_DIMENSIONS: dict[str, int] = {
+    "text-embedding-3-small": 1536,
+    "text-embedding-3-large": 3072,
+    "text-embedding-ada-002": 1536,
+}
+_DEFAULT_DIMENSION = 1536
+
+
+class OpenAIEmbeddingClient:
+    """Async OpenAI embedding client.
+
+    Implements ``BaseEmbeddingProtocol``.
+    Uses ``AsyncOpenAI`` from the ``openai`` package (optional dependency).
+
+    Pattern follows the broker lazy-import convention:
+    ``openai`` and ``tiktoken`` are imported at init time; if missing,
+    a clear ``ImportError`` with install instructions is raised.
+
+    Dimension is derived automatically from ``model``
+    via ``_MODEL_DIMENSIONS``. Not user-configurable.
+
+    Batching respects both item count (2,048) and total token count
+    (300,000) per request — the binding constraint for OpenAI.
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        model: str = "text-embedding-3-small",
+    ) -> None:
+        try:
+            from openai import AsyncOpenAI
+        except ImportError:
+            raise ImportError(
+                "openai is required for OpenAI embeddings. "
+                "Install it with: uv sync --extra openai"
+            )
+        try:
+            import tiktoken
+        except ImportError:
+            raise ImportError(
+                "tiktoken is required for OpenAI embeddings. "
+                "Install it with: uv sync --extra openai"
+            )
+        self._client = AsyncOpenAI(api_key=api_key)
+        self.model = model
+        self._dimension = _MODEL_DIMENSIONS.get(model, _DEFAULT_DIMENSION)
+        self._encoding = tiktoken.encoding_for_model(model)
+
+    @property
+    def dimension(self) -> int:
+        return self._dimension
+
+    def _count_tokens(self, text: str) -> int:
+        """Count tokens in text using tiktoken."""
+        return len(self._encoding.encode(text))
+
+    def _split_into_batches(self, texts: list[str]) -> list[list[str]]:
+        """Split texts into batches respecting both item count and token limits.
+
+        Each batch satisfies:
+        - At most ``_BATCH_SIZE`` texts (2,048)
+        - Total tokens across all texts at most ``_MAX_TOKENS_PER_BATCH`` (300,000)
+
+        Raises ``EmbeddingInputTooLongException`` if any individual text
+        exceeds ``_MAX_TOKENS_PER_TEXT`` (8,192 tokens).
+        """
+        batches: list[list[str]] = []
+        current_batch: list[str] = []
+        current_tokens = 0
+
+        for text in texts:
+            text_tokens = self._count_tokens(text)
+            if text_tokens > _MAX_TOKENS_PER_TEXT:
+                raise EmbeddingInputTooLongException(
+                    text_tokens, _MAX_TOKENS_PER_TEXT, "tokens"
+                )
+
+            would_exceed_tokens = current_tokens + text_tokens > _MAX_TOKENS_PER_BATCH
+            would_exceed_count = len(current_batch) >= _BATCH_SIZE
+
+            if current_batch and (would_exceed_tokens or would_exceed_count):
+                batches.append(current_batch)
+                current_batch = []
+                current_tokens = 0
+
+            current_batch.append(text)
+            current_tokens += text_tokens
+
+        if current_batch:
+            batches.append(current_batch)
+
+        return batches
+
+    async def embed_text(self, text: str) -> list[float]:
+        return (await self.embed_batch([text]))[0]
+
+    async def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        try:
+            from openai import APIError, AuthenticationError, RateLimitError
+        except ImportError:
+            raise ImportError(
+                "openai is required for OpenAI embeddings. "
+                "Install it with: uv sync --extra openai"
+            )
+
+        if not texts:
+            return []
+
+        batches = self._split_into_batches(texts)
+        results: list[list[float]] = []
+        try:
+            for batch in batches:
+                response = await self._client.embeddings.create(
+                    model=self.model,
+                    input=batch,
+                    dimensions=self._dimension,
+                )
+                results.extend(item.embedding for item in response.data)
+        except AuthenticationError as e:
+            raise EmbeddingAuthenticationException() from e
+        except RateLimitError as e:
+            raise EmbeddingRateLimitException() from e
+        except APIError as e:
+            raise EmbeddingException(
+                status_code=502,
+                message="OpenAI embedding failed: " + e.message,
+                error_code="EMBEDDING_OPERATION_FAILED",
+            ) from e
+
+        return results

--- a/src/_core/infrastructure/s3vectors/s3vector_model.py
+++ b/src/_core/infrastructure/s3vectors/s3vector_model.py
@@ -7,16 +7,32 @@ from pydantic import BaseModel, Field
 from src._core.common.uuid_utils import generate_vector_id
 
 
+def _default_embedding_dimension() -> int:
+    """Lazy-load settings to derive embedding dimension.
+
+    Avoids module-level ``settings`` import so that test modules
+    importing ``S3VectorModel`` do not trigger ``Settings()`` init.
+    """
+    from src._core.config import settings
+
+    return settings.embedding_dimension
+
+
 class S3VectorModelMeta(BaseModel):
     """S3 Vectors index schema metadata.
 
     ``DynamoModelMeta`` counterpart — declares index configuration
     that the migration CLI reads to create/compare indexes.
+
+    ``dimension`` defaults to ``settings.embedding_dimension``
+    (derived from ``EMBEDDING_PROVIDER`` + ``EMBEDDING_MODEL``).
+    This ensures vector index dimension always matches the
+    embedding model in use without manual synchronization.
     """
 
     index_name: str
     data_type: Literal["float32"] = "float32"
-    dimension: int = 1536
+    dimension: int = Field(default_factory=_default_embedding_dimension)
     distance_metric: Literal["cosine", "euclidean"] = "cosine"
     filter_fields: list[str] = []
     non_filter_fields: list[str] = []

--- a/tests/unit/_core/common/test_text_utils.py
+++ b/tests/unit/_core/common/test_text_utils.py
@@ -1,0 +1,82 @@
+"""Unit tests for text chunking utilities (semantic-text-splitter wrapper)."""
+
+from __future__ import annotations
+
+from src._core.common.text_utils import chunk_text, chunk_text_by_tokens
+
+
+class TestChunkText:
+    def test_empty_string_returns_empty_list(self) -> None:
+        assert chunk_text("") == []
+
+    def test_whitespace_only_returns_empty_list(self) -> None:
+        assert chunk_text("   \n\t  ") == []
+
+    def test_short_text_returns_single_chunk(self) -> None:
+        result = chunk_text("Hello world.")
+        assert result == ["Hello world."]
+
+    def test_long_text_splits_into_multiple_chunks(self) -> None:
+        text = "This is a sentence. " * 200  # ~4000 chars
+        result = chunk_text(text, chunk_size=1000, overlap=100)
+        assert len(result) > 1
+
+    def test_chunks_respect_max_size(self) -> None:
+        text = "word " * 500  # ~2500 chars
+        result = chunk_text(text, chunk_size=1000, overlap=100)
+        for chunk in result:
+            assert len(chunk) <= 1000
+
+    def test_chunks_have_overlap(self) -> None:
+        # Use simple repeating text for predictable overlap
+        text = "abcdefghij" * 50  # 500 chars
+        result = chunk_text(text, chunk_size=100, overlap=20)
+        assert len(result) > 1
+        # Verify consecutive chunks share content
+        for i in range(len(result) - 1):
+            tail = result[i][-10:]
+            assert tail in result[i + 1], (
+                f"Expected overlap between chunk {i} and {i + 1}"
+            )
+
+    def test_custom_parameters(self) -> None:
+        text = "Hello world. " * 100  # ~1300 chars
+        result = chunk_text(text, chunk_size=200, overlap=30)
+        assert len(result) > 1
+        for chunk in result:
+            assert len(chunk) <= 200
+
+
+class TestChunkTextByTokens:
+    def test_empty_string_returns_empty_list(self) -> None:
+        assert chunk_text_by_tokens("") == []
+
+    def test_short_text_returns_single_chunk(self) -> None:
+        result = chunk_text_by_tokens("Hello world.")
+        assert result == ["Hello world."]
+
+    def test_long_text_splits_by_token_count(self) -> None:
+        # ~200 tokens of text, split into chunks of max 50 tokens
+        text = "The quick brown fox jumps over the lazy dog. " * 50
+        result = chunk_text_by_tokens(text, max_tokens=50, overlap=10)
+        assert len(result) > 1
+
+    def test_custom_model_and_max_tokens(self) -> None:
+        text = "Hello world. " * 500
+        result = chunk_text_by_tokens(
+            text, model="text-embedding-3-large", max_tokens=100, overlap=20
+        )
+        assert len(result) > 1
+
+    def test_overlap_between_token_chunks(self) -> None:
+        text = "word " * 500  # many tokens
+        result = chunk_text_by_tokens(text, max_tokens=100, overlap=20)
+        assert len(result) > 1
+        # Verify consecutive chunks share some content
+        for i in range(len(result) - 1):
+            # Last few words of chunk i should appear in chunk i+1
+            last_words = result[i].split()[-3:]
+            overlap_text = " ".join(last_words)
+            assert overlap_text in result[i + 1], (
+                f"Expected token overlap between chunk {i} and {i + 1}"
+            )

--- a/tests/unit/_core/infrastructure/embedding/test_bedrock_embedding_client.py
+++ b/tests/unit/_core/infrastructure/embedding/test_bedrock_embedding_client.py
@@ -1,0 +1,183 @@
+"""Unit tests for BedrockEmbeddingClient using a fake Bedrock runtime client.
+
+This test file also serves as the usage reference for the Bedrock
+embedding integration (no real AWS credentials needed).
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager
+from typing import Any
+
+import pytest
+from botocore.exceptions import ClientError
+
+from src._core.infrastructure.embedding.bedrock_embedding_client import (
+    BedrockEmbeddingClient,
+)
+from src._core.infrastructure.embedding.exceptions import (
+    EmbeddingAuthenticationException,
+    EmbeddingInputTooLongException,
+    EmbeddingModelNotFoundException,
+    EmbeddingRateLimitException,
+)
+
+# -- Fake Bedrock Runtime Client -------------------------------------------
+
+
+class FakeBodyStream:
+    """Simulates the async-readable body stream from Bedrock response."""
+
+    def __init__(self, data: dict[str, Any]) -> None:
+        self._data = json.dumps(data).encode()
+
+    async def read(self) -> bytes:
+        return self._data
+
+
+class FakeBedrockRuntimeClient:
+    """In-memory Bedrock runtime mock that returns deterministic embeddings."""
+
+    def __init__(self, dimension: int = 4, error: ClientError | None = None) -> None:
+        self._dimension = dimension
+        self._error = error
+        self.calls: list[dict[str, Any]] = []
+
+    async def invoke_model(self, **kwargs: Any) -> dict[str, Any]:
+        if self._error:
+            raise self._error
+        body = json.loads(kwargs["body"])
+        self.calls.append(body)
+        text = body.get("inputText", "")
+        dim = body.get("dimensions", self._dimension)
+        embedding = [float(i + len(text)) * 0.01 for i in range(dim)]
+        return {"body": FakeBodyStream({"embedding": embedding})}
+
+
+class FakeBedrockSession:
+    """Wraps the fake client in the aioboto3 context-manager pattern."""
+
+    def __init__(self, fake_client: FakeBedrockRuntimeClient) -> None:
+        self._client = fake_client
+
+    @asynccontextmanager
+    async def client(self, service_name: str):  # noqa: ANN201
+        yield self._client
+
+
+def _make_client(
+    model_id: str = "amazon.titan-embed-text-v2:0",
+    error: ClientError | None = None,
+) -> tuple[BedrockEmbeddingClient, FakeBedrockRuntimeClient]:
+    fake = FakeBedrockRuntimeClient(error=error)
+    client = BedrockEmbeddingClient(
+        access_key="test",
+        secret_access_key="test",
+        region_name="us-east-1",
+        model_id=model_id,
+    )
+    client.session = FakeBedrockSession(fake)  # type: ignore[assignment]
+    return client, fake
+
+
+def _make_client_error(code: str, message: str = "error") -> ClientError:
+    return ClientError(
+        {"Error": {"Code": code, "Message": message}},
+        "InvokeModel",
+    )
+
+
+# -- Tests -----------------------------------------------------------------
+
+
+class TestEmbedText:
+    @pytest.mark.asyncio
+    async def test_embed_text_returns_vector(self) -> None:
+        client, _ = _make_client()
+        result = await client.embed_text("hello")
+        assert isinstance(result, list)
+        assert len(result) == client.dimension
+        assert all(isinstance(v, float) for v in result)
+
+    @pytest.mark.asyncio
+    async def test_embed_text_passes_dimension_in_body(self) -> None:
+        client, fake = _make_client()
+        await client.embed_text("test")
+        assert fake.calls[0]["dimensions"] == client.dimension
+
+    @pytest.mark.asyncio
+    async def test_dimension_derived_from_model_titan_v2(self) -> None:
+        client, _ = _make_client(model_id="amazon.titan-embed-text-v2:0")
+        assert client.dimension == 1024
+
+    @pytest.mark.asyncio
+    async def test_dimension_derived_from_model_titan_v1(self) -> None:
+        client, _ = _make_client(model_id="amazon.titan-embed-text-v1")
+        assert client.dimension == 1536
+
+
+class TestEmbedBatch:
+    @pytest.mark.asyncio
+    async def test_embed_batch_returns_ordered_results(self) -> None:
+        client, _ = _make_client()
+        results = await client.embed_batch(["a", "bb", "ccc"])
+        assert len(results) == 3
+        assert all(len(v) == client.dimension for v in results)
+        # Each text has different length, so embeddings should differ
+        assert results[0] != results[1]
+
+    @pytest.mark.asyncio
+    async def test_embed_batch_empty_list(self) -> None:
+        client, _ = _make_client()
+        results = await client.embed_batch([])
+        assert results == []
+
+
+class TestErrorMapping:
+    @pytest.mark.asyncio
+    async def test_throttling_raises_rate_limit(self) -> None:
+        client, _ = _make_client(error=_make_client_error("ThrottlingException"))
+        with pytest.raises(EmbeddingRateLimitException):
+            await client.embed_text("test")
+
+    @pytest.mark.asyncio
+    async def test_too_many_requests_raises_rate_limit(self) -> None:
+        client, _ = _make_client(error=_make_client_error("TooManyRequestsException"))
+        with pytest.raises(EmbeddingRateLimitException):
+            await client.embed_text("test")
+
+    @pytest.mark.asyncio
+    async def test_access_denied_raises_auth(self) -> None:
+        client, _ = _make_client(error=_make_client_error("AccessDeniedException"))
+        with pytest.raises(EmbeddingAuthenticationException):
+            await client.embed_text("test")
+
+    @pytest.mark.asyncio
+    async def test_validation_raises_model_not_found(self) -> None:
+        client, _ = _make_client(error=_make_client_error("ValidationException"))
+        with pytest.raises(EmbeddingModelNotFoundException):
+            await client.embed_text("test")
+
+
+class TestInputValidation:
+    @pytest.mark.asyncio
+    async def test_text_exceeding_max_chars_raises_exception(self) -> None:
+        client, _ = _make_client()
+        long_text = "a" * 50_001
+        with pytest.raises(EmbeddingInputTooLongException):
+            await client.embed_text(long_text)
+
+    @pytest.mark.asyncio
+    async def test_text_at_exactly_max_chars_succeeds(self) -> None:
+        client, _ = _make_client()
+        text = "a" * 50_000
+        result = await client.embed_text(text)
+        assert isinstance(result, list)
+
+    @pytest.mark.asyncio
+    async def test_embed_batch_validates_each_text(self) -> None:
+        client, _ = _make_client()
+        texts = ["short", "a" * 50_001]
+        with pytest.raises(EmbeddingInputTooLongException):
+            await client.embed_batch(texts)

--- a/tests/unit/_core/infrastructure/embedding/test_openai_embedding_client.py
+++ b/tests/unit/_core/infrastructure/embedding/test_openai_embedding_client.py
@@ -1,0 +1,208 @@
+"""Unit tests for OpenAIEmbeddingClient using a mock AsyncOpenAI client."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+openai = pytest.importorskip("openai")
+pytest.importorskip("tiktoken")
+
+from src._core.infrastructure.embedding.exceptions import (
+    EmbeddingAuthenticationException,
+    EmbeddingException,
+    EmbeddingInputTooLongException,
+    EmbeddingRateLimitException,
+)
+from src._core.infrastructure.embedding.openai_embedding_client import (
+    OpenAIEmbeddingClient,
+)
+
+# -- Helpers ---------------------------------------------------------------
+
+
+def _make_embedding_response(
+    vectors: list[list[float]],
+) -> Any:
+    """Build a mock OpenAI embedding response."""
+    data = []
+    for i, vec in enumerate(vectors):
+        item = MagicMock()
+        item.embedding = vec
+        item.index = i
+        data.append(item)
+    response = MagicMock()
+    response.data = data
+    return response
+
+
+def _make_client(
+    model: str = "text-embedding-3-small",
+    tokens_per_text: int = 10,
+) -> tuple[OpenAIEmbeddingClient, AsyncMock]:
+    client = OpenAIEmbeddingClient(
+        api_key="test-key",
+        model=model,
+    )
+    mock_create = AsyncMock()
+    client._client = MagicMock()  # type: ignore[assignment]
+    client._client.embeddings = MagicMock()
+    client._client.embeddings.create = mock_create
+    # Mock tiktoken encoding for predictable token counts
+    mock_encoding = MagicMock()
+    mock_encoding.encode = MagicMock(
+        side_effect=lambda text: (
+            [0] * (len(text) if tokens_per_text == -1 else tokens_per_text)
+        )
+    )
+    client._encoding = mock_encoding
+    return client, mock_create
+
+
+# -- Tests -----------------------------------------------------------------
+
+
+class TestEmbedText:
+    @pytest.mark.asyncio
+    async def test_embed_text_returns_vector(self) -> None:
+        client, mock_create = _make_client()
+        mock_create.return_value = _make_embedding_response([[0.1, 0.2, 0.3, 0.4]])
+
+        result = await client.embed_text("hello")
+        assert result == [0.1, 0.2, 0.3, 0.4]
+
+    @pytest.mark.asyncio
+    async def test_embed_text_delegates_to_embed_batch(self) -> None:
+        client, mock_create = _make_client()
+        mock_create.return_value = _make_embedding_response([[0.1, 0.2, 0.3, 0.4]])
+
+        await client.embed_text("hello")
+        mock_create.assert_called_once()
+        call_kwargs = mock_create.call_args
+        assert call_kwargs.kwargs["input"] == ["hello"]
+
+
+class TestEmbedBatch:
+    @pytest.mark.asyncio
+    async def test_embed_batch_returns_ordered_results(self) -> None:
+        client, mock_create = _make_client()
+        mock_create.return_value = _make_embedding_response(
+            [
+                [0.1, 0.2, 0.3, 0.4],
+                [0.5, 0.6, 0.7, 0.8],
+            ]
+        )
+
+        results = await client.embed_batch(["a", "b"])
+        assert len(results) == 2
+        assert results[0] == [0.1, 0.2, 0.3, 0.4]
+        assert results[1] == [0.5, 0.6, 0.7, 0.8]
+
+    @pytest.mark.asyncio
+    async def test_embed_batch_empty_list(self) -> None:
+        client, mock_create = _make_client()
+        results = await client.embed_batch([])
+        assert results == []
+        mock_create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_embed_batch_passes_dimension(self) -> None:
+        client, mock_create = _make_client()
+        mock_create.return_value = _make_embedding_response([[0.1] * 1536])
+
+        await client.embed_batch(["test"])
+        call_kwargs = mock_create.call_args
+        assert call_kwargs.kwargs["dimensions"] == 1536
+
+
+class TestTokenBasedBatching:
+    @pytest.mark.asyncio
+    async def test_splits_by_item_count(self) -> None:
+        """2049 texts should split into 2 batches (2048 + 1)."""
+        client, mock_create = _make_client(tokens_per_text=10)
+        mock_create.side_effect = [
+            _make_embedding_response([[0.1] * 4] * 2048),
+            _make_embedding_response([[0.1] * 4]),
+        ]
+
+        results = await client.embed_batch(["text"] * 2049)
+        assert len(results) == 2049
+        assert mock_create.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_splits_by_token_count(self) -> None:
+        """Texts with high token count should split before reaching 300K."""
+        # Each text = 1000 tokens, so 300 texts = 300K tokens → needs 2 batches
+        client, mock_create = _make_client(tokens_per_text=1000)
+        mock_create.side_effect = [
+            _make_embedding_response([[0.1] * 4] * 300),
+            _make_embedding_response([[0.1] * 4] * 10),
+        ]
+
+        results = await client.embed_batch(["text"] * 310)
+        assert len(results) == 310
+        assert mock_create.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_text_exceeding_max_tokens_raises_exception(self) -> None:
+        """A single text with > 8192 tokens should raise immediately."""
+        client, mock_create = _make_client(tokens_per_text=9000)
+        with pytest.raises(EmbeddingInputTooLongException):
+            await client.embed_batch(["very long text"])
+
+    def test_count_tokens_uses_encoding(self) -> None:
+        client, _ = _make_client()
+        result = client._count_tokens("hello")
+        client._encoding.encode.assert_called_with("hello")
+        assert isinstance(result, int)
+
+
+class TestDimensionProperty:
+    def test_dimension_derived_from_model_small(self) -> None:
+        client, _ = _make_client(model="text-embedding-3-small")
+        assert client.dimension == 1536
+
+    def test_dimension_derived_from_model_large(self) -> None:
+        client, _ = _make_client(model="text-embedding-3-large")
+        assert client.dimension == 3072
+
+    def test_dimension_default(self) -> None:
+        client = OpenAIEmbeddingClient(api_key="test-key")
+        assert client.dimension == 1536
+
+
+class TestErrorMapping:
+    @pytest.mark.asyncio
+    async def test_auth_error_raises_embedding_auth(self) -> None:
+        client, mock_create = _make_client()
+        mock_create.side_effect = openai.AuthenticationError(
+            message="invalid key",
+            response=MagicMock(status_code=401),
+            body=None,
+        )
+        with pytest.raises(EmbeddingAuthenticationException):
+            await client.embed_batch(["test"])
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_raises_embedding_rate_limit(self) -> None:
+        client, mock_create = _make_client()
+        mock_create.side_effect = openai.RateLimitError(
+            message="rate limited",
+            response=MagicMock(status_code=429),
+            body=None,
+        )
+        with pytest.raises(EmbeddingRateLimitException):
+            await client.embed_batch(["test"])
+
+    @pytest.mark.asyncio
+    async def test_api_error_raises_embedding_exception(self) -> None:
+        client, mock_create = _make_client()
+        mock_create.side_effect = openai.APIError(
+            message="server error",
+            request=MagicMock(),
+            body=None,
+        )
+        with pytest.raises(EmbeddingException):
+            await client.embed_batch(["test"])

--- a/tests/unit/_core/test_config.py
+++ b/tests/unit/_core/test_config.py
@@ -285,6 +285,99 @@ class TestBrokerConfig:
             assert s.broker_type == "inmemory"
 
 
+class TestEmbeddingConfig:
+    def test_no_embedding_provider_accepted(self):
+        env = {"ENV": "local", **_REQUIRED_VARS}
+        with patch.dict(os.environ, env, clear=True):
+            s = _create_settings()
+            assert s.embedding_provider is None
+
+    def test_unknown_embedding_provider_rejected(self):
+        env = {"ENV": "local", "EMBEDDING_PROVIDER": "cohere", **_REQUIRED_VARS}
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(ValidationError, match="Unknown embedding provider"):
+                _create_settings()
+
+    def test_openai_without_api_key_rejected(self):
+        env = {"ENV": "local", "EMBEDDING_PROVIDER": "openai", **_REQUIRED_VARS}
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(ValidationError, match=r"Embedding/OpenAI.*missing"):
+                _create_settings()
+
+    def test_openai_with_api_key_accepted(self):
+        env = {
+            "ENV": "local",
+            "EMBEDDING_PROVIDER": "openai",
+            "EMBEDDING_OPENAI_API_KEY": "sk-test",
+            **_REQUIRED_VARS,
+        }
+        with patch.dict(os.environ, env, clear=True):
+            s = _create_settings()
+            assert s.embedding_provider == "openai"
+            assert s.embedding_openai_api_key == "sk-test"
+
+    def test_embedding_dimension_property_openai_default(self):
+        env = {
+            "ENV": "local",
+            "EMBEDDING_PROVIDER": "openai",
+            "EMBEDDING_OPENAI_API_KEY": "sk-test",
+            **_REQUIRED_VARS,
+        }
+        with patch.dict(os.environ, env, clear=True):
+            s = _create_settings()
+            assert s.embedding_dimension == 1536
+
+    def test_embedding_dimension_property_openai_large_model(self):
+        env = {
+            "ENV": "local",
+            "EMBEDDING_PROVIDER": "openai",
+            "EMBEDDING_OPENAI_API_KEY": "sk-test",
+            "EMBEDDING_MODEL": "text-embedding-3-large",
+            **_REQUIRED_VARS,
+        }
+        with patch.dict(os.environ, env, clear=True):
+            s = _create_settings()
+            assert s.embedding_dimension == 3072
+
+    def test_embedding_dimension_property_bedrock_default(self):
+        env = {
+            "ENV": "local",
+            "EMBEDDING_PROVIDER": "bedrock",
+            "EMBEDDING_BEDROCK_ACCESS_KEY": "key",
+            "EMBEDDING_BEDROCK_SECRET_KEY": "secret",
+            "EMBEDDING_BEDROCK_REGION": "us-east-1",
+            **_REQUIRED_VARS,
+        }
+        with patch.dict(os.environ, env, clear=True):
+            s = _create_settings()
+            assert s.embedding_dimension == 1024
+
+    def test_bedrock_partial_config_rejected(self):
+        env = {
+            "ENV": "local",
+            "EMBEDDING_PROVIDER": "bedrock",
+            "EMBEDDING_BEDROCK_ACCESS_KEY": "key",
+            **_REQUIRED_VARS,
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(ValidationError, match=r"Embedding/Bedrock.*missing"):
+                _create_settings()
+
+    def test_bedrock_complete_config_accepted(self):
+        env = {
+            "ENV": "local",
+            "EMBEDDING_PROVIDER": "bedrock",
+            "EMBEDDING_BEDROCK_ACCESS_KEY": "key",
+            "EMBEDDING_BEDROCK_SECRET_KEY": "secret",
+            "EMBEDDING_BEDROCK_REGION": "us-east-1",
+            **_REQUIRED_VARS,
+        }
+        with patch.dict(os.environ, env, clear=True):
+            s = _create_settings()
+            assert s.embedding_provider == "bedrock"
+            assert s.embedding_bedrock_region == "us-east-1"
+
+
 class TestWarnDefaults:
     def test_task_name_prefix_warns_in_strict_env(self):
         safe = _make_safe_env("prod")

--- a/uv.lock
+++ b/uv.lock
@@ -792,6 +792,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -860,12 +869,17 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pymysql" },
     { name = "python-dotenv" },
+    { name = "semantic-text-splitter" },
     { name = "sqlalchemy" },
     { name = "taskiq", extra = ["reload"] },
     { name = "uvicorn" },
 ]
 
 [package.optional-dependencies]
+openai = [
+    { name = "openai" },
+    { name = "tiktoken" },
+]
 rabbitmq = [
     { name = "taskiq-aio-pika" },
 ]
@@ -905,17 +919,20 @@ requires-dist = [
     { name = "gunicorn", specifier = ">=23.0.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "nicegui", specifier = ">=3.5.0" },
+    { name = "openai", marker = "extra == 'openai'", specifier = ">=1.0.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.12" },
     { name = "pydantic-settings", specifier = ">=2.10.1" },
     { name = "pymysql", specifier = ">=1.1.1" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
+    { name = "semantic-text-splitter", specifier = ">=0.17.0" },
     { name = "sqlalchemy", specifier = ">=2.0.40" },
     { name = "taskiq", extras = ["reload"], specifier = ">=0.12.1" },
     { name = "taskiq-aio-pika", marker = "extra == 'rabbitmq'", specifier = ">=0.4.0" },
     { name = "taskiq-aws", marker = "extra == 'sqs'", specifier = ">=0.4.0" },
+    { name = "tiktoken", marker = "extra == 'openai'", specifier = ">=0.7.0" },
     { name = "uvicorn", specifier = ">=0.34.1" },
 ]
-provides-extras = ["sqs", "rabbitmq"]
+provides-extras = ["sqs", "rabbitmq", "openai"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1360,6 +1377,78 @@ wheels = [
 ]
 
 [[package]]
+name = "jiter"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/c1/0cddc6eb17d4c53a99840953f95dd3accdc5cfc7a337b0e9b26476276be9/jiter-0.14.0.tar.gz", hash = "sha256:e8a39e66dac7153cf3f964a12aad515afa8d74938ec5cc0018adcdae5367c79e", size = 165725, upload-time = "2026-04-10T14:28:42.01Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/68/7390a418f10897da93b158f2d5a8bd0bcd73a0f9ec3bb36917085bb759ef/jiter-0.14.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:2fb2ce3a7bc331256dfb14cefc34832366bb28a9aca81deaf43bbf2a5659e607", size = 316295, upload-time = "2026-04-10T14:26:24.887Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a0/5854ac00ff63551c52c6c89534ec6aba4b93474e7924d64e860b1c94165b/jiter-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5252a7ca23785cef5d02d4ece6077a1b556a410c591b379f82091c3001e14844", size = 315898, upload-time = "2026-04-10T14:26:26.601Z" },
+    { url = "https://files.pythonhosted.org/packages/41/a1/4f44832650a16b18e8391f1bf1d6ca4909bc738351826bcc198bba4357f4/jiter-0.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c409578cbd77c338975670ada777add4efd53379667edf0aceea730cabede6fb", size = 343730, upload-time = "2026-04-10T14:26:28.326Z" },
+    { url = "https://files.pythonhosted.org/packages/48/64/a329e9d469f86307203594b1707e11ae51c3348d03bfd514a5f997870012/jiter-0.14.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7ede4331a1899d604463369c730dbb961ffdc5312bc7f16c41c2896415b1304a", size = 370102, upload-time = "2026-04-10T14:26:30.089Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c1/5e3dfc59635aa4d4c7bd20a820ac1d09b8ed851568356802cf1c08edb3cf/jiter-0.14.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:92cd8b6025981a041f5310430310b55b25ca593972c16407af8837d3d7d2ca01", size = 461335, upload-time = "2026-04-10T14:26:31.911Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/1b/dd157009dbc058f7b00108f545ccb72a2d56461395c4fc7b9cfdccb00af4/jiter-0.14.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:351bf6eda4e3a7ceb876377840c702e9a3e4ecc4624dbfb2d6463c67ae52637d", size = 378536, upload-time = "2026-04-10T14:26:33.595Z" },
+    { url = "https://files.pythonhosted.org/packages/91/78/256013667b7c10b8834f8e6e54cd3e562d4c6e34227a1596addccc05e38c/jiter-0.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1dcfbeb93d9ecd9ca128bbf8910120367777973fa193fb9a39c31237d8df165", size = 353859, upload-time = "2026-04-10T14:26:35.098Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d9/137d65ade9093a409fe80955ce60b12bb753722c986467aeda47faf450ad/jiter-0.14.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:ae039aaef8de3f8157ecc1fdd4d85043ac4f57538c245a0afaecb8321ec951c3", size = 357626, upload-time = "2026-04-10T14:26:36.685Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/48/76750835b87029342727c1a268bea8878ab988caf81ee4e7b880900eeb5a/jiter-0.14.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7d9d51eb96c82a9652933bd769fe6de66877d6eb2b2440e281f2938c51b5643e", size = 393172, upload-time = "2026-04-10T14:26:38.097Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/60/456c4e81d5c8045279aefe60e9e483be08793828800a4e64add8fdde7f2a/jiter-0.14.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:d824ca4148b705970bf4e120924a212fdfca9859a73e42bd7889a63a4ea6bb98", size = 520300, upload-time = "2026-04-10T14:26:39.532Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/9f/2020e0984c235f678dced38fe4eec3058cf528e6af36ebf969b410305941/jiter-0.14.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:ff3a6465b3a0f54b1a430f45c3c0ba7d61ceb45cbc3e33f9e1a7f638d690baf3", size = 553059, upload-time = "2026-04-10T14:26:40.991Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/32/e2d298e1a22a4bbe6062136d1c7192db7dba003a6975e51d9a9eecabc4c2/jiter-0.14.0-cp312-cp312-win32.whl", hash = "sha256:5dec7c0a3e98d2a3f8a2e67382d0d7c3ac60c69103a4b271da889b4e8bb1e129", size = 206030, upload-time = "2026-04-10T14:26:42.517Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ac/96369141b3d8a4a8e4590e983085efe1c436f35c0cda940dd76d942e3e40/jiter-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:fc7e37b4b8bc7e80a63ad6cfa5fc11fab27dbfea4cc4ae644b1ab3f273dc348f", size = 201603, upload-time = "2026-04-10T14:26:44.328Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c3/75d847f264647017d7e3052bbcc8b1e24b95fa139c320c5f5066fa7a0bdd/jiter-0.14.0-cp312-cp312-win_arm64.whl", hash = "sha256:ee4a72f12847ef29b072aee9ad5474041ab2924106bdca9fcf5d7d965853e057", size = 191525, upload-time = "2026-04-10T14:26:46Z" },
+    { url = "https://files.pythonhosted.org/packages/97/2a/09f70020898507a89279659a1afe3364d57fc1b2c89949081975d135f6f5/jiter-0.14.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:af72f204cf4d44258e5b4c1745130ac45ddab0e71a06333b01de660ab4187a94", size = 315502, upload-time = "2026-04-10T14:26:47.697Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/be/080c96a45cd74f9fce5db4fd68510b88087fb37ffe2541ff73c12db92535/jiter-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4b77da71f6e819be5fbcec11a453fde5b1d0267ef6ed487e2a392fd8e14e4e3a", size = 314870, upload-time = "2026-04-10T14:26:49.149Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/5e/2d0fee155826a968a832cc32438de5e2a193292c8721ca70d0b53e58245b/jiter-0.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f4ea612fe8b84b8b04e51d0e78029ecf3466348e25973f953de6e6a59aa4c1", size = 343406, upload-time = "2026-04-10T14:26:50.762Z" },
+    { url = "https://files.pythonhosted.org/packages/70/af/bf9ee0d3a4f8dc0d679fc1337f874fe60cdbf841ebbb304b374e1c9aaceb/jiter-0.14.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:62fe2451f8fcc0240261e6a4df18ecbcd58327857e61e625b2393ea3b468aac9", size = 369415, upload-time = "2026-04-10T14:26:52.188Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/83/8e8561eadba31f4d3948a5b712fb0447ec71c3560b57a855449e7b8ddc98/jiter-0.14.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6112f26f5afc75bcb475787d29da3aa92f9d09c7858f632f4be6ffe607be82e9", size = 461456, upload-time = "2026-04-10T14:26:53.611Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/c9/c5299e826a5fe6108d172b344033f61c69b1bb979dd8d9ddd4278a160971/jiter-0.14.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:215a6cb8fb7dc702aa35d475cc00ddc7f970e5c0b1417fb4b4ac5d82fa2a29db", size = 378488, upload-time = "2026-04-10T14:26:55.211Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/37/c16d9d15c0a471b8644b1abe3c82668092a707d9bedcf076f24ff2e380cd/jiter-0.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc4ab96a30fb3cb2c7e0cd33f7616c8860da5f5674438988a54ac717caccdbaa", size = 353242, upload-time = "2026-04-10T14:26:56.705Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ea/8050cb0dc654e728e1bfacbc0c640772f2181af5dedd13ae70145743a439/jiter-0.14.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:3a99c1387b1f2928f799a9de899193484d66206a50e98233b6b088a7f0c1edb2", size = 356823, upload-time = "2026-04-10T14:26:58.281Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3b/cf71506d270e5f84d97326bf220e47aed9b95e9a4a060758fb07772170ab/jiter-0.14.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ab18d11074485438695f8d34a1b6da61db9754248f96d51341956607a8f39985", size = 392564, upload-time = "2026-04-10T14:27:00.018Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/cc/8c6c74a3efb5bd671bfd14f51e8a73375464ca914b1551bc3b40e26ac2c9/jiter-0.14.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:801028dcfc26ac0895e4964cbc0fd62c73be9fd4a7d7b1aaf6e5790033a719b7", size = 520322, upload-time = "2026-04-10T14:27:01.664Z" },
+    { url = "https://files.pythonhosted.org/packages/41/24/68d7b883ec959884ddf00d019b2e0e82ba81b167e1253684fa90519ce33c/jiter-0.14.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ad425b087aafb4a1c7e1e98a279200743b9aaf30c3e0ba723aec93f061bd9bc8", size = 552619, upload-time = "2026-04-10T14:27:03.316Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/89/b1a0985223bbf3150ff9e8f46f98fc9360c1de94f48abe271bbe1b465682/jiter-0.14.0-cp313-cp313-win32.whl", hash = "sha256:882bcb9b334318e233950b8be366fe5f92c86b66a7e449e76975dfd6d776a01f", size = 205699, upload-time = "2026-04-10T14:27:04.662Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/19/3f339a5a7f14a11730e67f6be34f9d5105751d547b615ef593fa122a5ded/jiter-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:9b8c571a5dba09b98bd3462b5a53f27209a5cbbe85670391692ede71974e979f", size = 201323, upload-time = "2026-04-10T14:27:06.139Z" },
+    { url = "https://files.pythonhosted.org/packages/50/56/752dd89c84be0e022a8ea3720bcfa0a8431db79a962578544812ce061739/jiter-0.14.0-cp313-cp313-win_arm64.whl", hash = "sha256:34f19dcc35cb1abe7c369b3756babf8c7f04595c0807a848df8f26ef8298ef92", size = 191099, upload-time = "2026-04-10T14:27:07.564Z" },
+    { url = "https://files.pythonhosted.org/packages/91/28/292916f354f25a1fe8cf2c918d1415c699a4a659ae00be0430e1c5d9ffea/jiter-0.14.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e89bcd7d426a75bb4952c696b267075790d854a07aad4c9894551a82c5b574ab", size = 320880, upload-time = "2026-04-10T14:27:09.326Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/c7/b002a7d8b8957ac3d469bd59c18ef4b1595a5216ae0de639a287b9816023/jiter-0.14.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b25beaa0d4447ea8c7ae0c18c688905d34840d7d0b937f2f7bdd52162c98a40", size = 346563, upload-time = "2026-04-10T14:27:11.287Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/3b/f8d07580d8706021d255a6356b8fab13ee4c869412995550ce6ed4ddf97d/jiter-0.14.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:651a8758dd413c51e3b7f6557cdc6921faf70b14106f45f969f091f5cda990ea", size = 357928, upload-time = "2026-04-10T14:27:12.729Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5b/ac1a974da29e35507230383110ffec59998b290a8732585d04e19a9eb5ba/jiter-0.14.0-cp313-cp313t-win_amd64.whl", hash = "sha256:e1a7eead856a5038a8d291f1447176ab0b525c77a279a058121b5fccee257f6f", size = 203519, upload-time = "2026-04-10T14:27:14.125Z" },
+    { url = "https://files.pythonhosted.org/packages/96/6d/9fc8433d667d2454271378a79747d8c76c10b51b482b454e6190e511f244/jiter-0.14.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e692633a12cda97e352fdcd1c4acc971b1c28707e1e33aeef782b0cbf051975", size = 190113, upload-time = "2026-04-10T14:27:16.638Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/1e/354ed92461b165bd581f9ef5150971a572c873ec3b68a916d5aa91da3cc2/jiter-0.14.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:6f396837fc7577871ca8c12edaf239ed9ccef3bbe39904ae9b8b63ce0a48b140", size = 315277, upload-time = "2026-04-10T14:27:18.109Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/95/8c7c7028aa8636ac21b7a55faef3e34215e6ed0cbf5ae58258427f621aa3/jiter-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a4d50ea3d8ba4176f79754333bd35f1bbcd28e91adc13eb9b7ca91bc52a6cef9", size = 315923, upload-time = "2026-04-10T14:27:19.603Z" },
+    { url = "https://files.pythonhosted.org/packages/47/40/e2a852a44c4a089f2681a16611b7ce113224a80fd8504c46d78491b47220/jiter-0.14.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce17f8a050447d1b4153bda4fb7d26e6a9e74eb4f4a41913f30934c5075bf615", size = 344943, upload-time = "2026-04-10T14:27:21.262Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/1f/670f92adee1e9895eac41e8a4d623b6da68c4d46249d8b556b60b63f949e/jiter-0.14.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4f1c4b125e1652aefbc2e2c1617b60a160ab789d180e3d423c41439e5f32850", size = 369725, upload-time = "2026-04-10T14:27:22.766Z" },
+    { url = "https://files.pythonhosted.org/packages/01/2f/541c9ba567d05de1c4874a0f8f8c5e3fd78e2b874266623da9a775cf46e0/jiter-0.14.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be808176a6a3a14321d18c603f2d40741858a7c4fc982f83232842689fe86dd9", size = 461210, upload-time = "2026-04-10T14:27:24.315Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/c31cbec09627e0d5de7aeaec7690dba03e090caa808fefd8133137cf45bc/jiter-0.14.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:26679d58ba816f88c3849306dd58cb863a90a1cf352cdd4ef67e30ccf8a77994", size = 380002, upload-time = "2026-04-10T14:27:26.155Z" },
+    { url = "https://files.pythonhosted.org/packages/50/02/3c05c1666c41904a2f607475a73e7a4763d1cbde2d18229c4f85b22dc253/jiter-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80381f5a19af8fa9aef743f080e34f6b25ebd89656475f8cf0470ec6157052aa", size = 354678, upload-time = "2026-04-10T14:27:27.701Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/97/e15b33545c2b13518f560d695f974b9891b311641bdcf178d63177e8801e/jiter-0.14.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:004df5fdb8ecbd6d99f3227df18ba1a259254c4359736a2e6f036c944e02d7c5", size = 358920, upload-time = "2026-04-10T14:27:29.256Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d2/8b1461def6b96ba44530df20d07ef7a1c7da22f3f9bf1727e2d611077bf1/jiter-0.14.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cff5708f7ed0fa098f2b53446c6fa74c48469118e5cd7497b4f1cd569ab06928", size = 394512, upload-time = "2026-04-10T14:27:31.344Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/88/837566dd6ed6e452e8d3205355afd484ce44b2533edfa4ed73a298ea893e/jiter-0.14.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:2492e5f06c36a976d25c7cc347a60e26d5470178d44cde1b9b75e60b4e519f28", size = 521120, upload-time = "2026-04-10T14:27:33.299Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6b/b00b45c4d1b4c031777fe161d620b755b5b02cdade1e316dcb46e4471d63/jiter-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:7609cfbe3a03d37bfdbf5052012d5a879e72b83168a363deae7b3a26564d57de", size = 553668, upload-time = "2026-04-10T14:27:34.868Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d8/6fe5b42011d19397433d345716eac16728ac241862a2aac9c91923c7509a/jiter-0.14.0-cp314-cp314-win32.whl", hash = "sha256:7282342d32e357543565286b6450378c3cd402eea333fc1ebe146f1fabb306fc", size = 207001, upload-time = "2026-04-10T14:27:36.455Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/43/5c2e08da1efad5e410f0eaaabeadd954812612c33fbbd8fd5328b489139d/jiter-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:bd77945f38866a448e73b0b7637366afa814d4617790ecd88a18ca74377e6c02", size = 202187, upload-time = "2026-04-10T14:27:38Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1f/6e39ac0b4cdfa23e606af5b245df5f9adaa76f35e0c5096790da430ca506/jiter-0.14.0-cp314-cp314-win_arm64.whl", hash = "sha256:f2d4c61da0821ee42e0cdf5489da60a6d074306313a377c2b35af464955a3611", size = 192257, upload-time = "2026-04-10T14:27:39.504Z" },
+    { url = "https://files.pythonhosted.org/packages/05/57/7dbc0ffbbb5176a27e3518716608aa464aee2e2887dc938f0b900a120449/jiter-0.14.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1bf7ff85517dd2f20a5750081d2b75083c1b269cf75afc7511bdf1f9548beb3b", size = 323441, upload-time = "2026-04-10T14:27:41.039Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6e/7b3314398d8983f06b557aa21b670511ec72d3b79a68ee5e4d9bff972286/jiter-0.14.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c8ef8791c3e78d6c6b157c6d360fbb5c715bebb8113bc6a9303c5caff012754a", size = 348109, upload-time = "2026-04-10T14:27:42.552Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/4f/8dc674bcd7db6dba566de73c08c763c337058baff1dbeb34567045b27cdc/jiter-0.14.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e74663b8b10da1fe0f4e4703fd7980d24ad17174b6bb35d8498d6e3ebce2ae6a", size = 368328, upload-time = "2026-04-10T14:27:44.574Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5f/188e09a1f20906f98bbdec44ed820e19f4e8eb8aff88b9d1a5a497587ff3/jiter-0.14.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1aca29ba52913f78362ec9c2da62f22cdc4c3083313403f90c15460979b84d9b", size = 463301, upload-time = "2026-04-10T14:27:46.717Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/f0/19046ef965ed8f349e8554775bb12ff4352f443fbe12b95d31f575891256/jiter-0.14.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8b39b7d87a952b79949af5fef44d2544e58c21a28da7f1bae3ef166455c61746", size = 378891, upload-time = "2026-04-10T14:27:48.32Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c3/da43bd8431ee175695777ee78cf0e93eacbb47393ff493f18c45231b427d/jiter-0.14.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78d918a68b26e9fab068c2b5453577ef04943ab2807b9a6275df2a812599a310", size = 360749, upload-time = "2026-04-10T14:27:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/72/26/e054771be889707c6161dbdec9c23d33a9ec70945395d70f07cfea1e9a6f/jiter-0.14.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:b08997c35aee1201c1a5361466a8fb9162d03ae7bf6568df70b6c859f1e654a4", size = 358526, upload-time = "2026-04-10T14:27:51.504Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/0f/7bea65ea2a6d91f2bf989ff11a18136644392bf2b0497a1fa50934c30a9c/jiter-0.14.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:260bf7ca20704d58d41f669e5e9fe7fe2fa72901a6b324e79056f5d52e9c9be2", size = 393926, upload-time = "2026-04-10T14:27:53.368Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/b1ff7d70deef61ac0b7c6c2f12d2ace950cdeecb4fdc94500a0926802857/jiter-0.14.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:37826e3df29e60f30a382f9294348d0238ef127f4b5d7f5f8da78b5b9e050560", size = 521052, upload-time = "2026-04-10T14:27:55.058Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7b/3b0649983cbaf15eda26a414b5b1982e910c67bd6f7b1b490f3cfc76896a/jiter-0.14.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:645be49c46f2900937ba0eaf871ad5183c96858c0af74b6becc7f4e367e36e06", size = 553716, upload-time = "2026-04-10T14:27:57.269Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f8/33d78c83bd93ae0c0af05293a6660f88a1977caef39a6d72a84afab94ce0/jiter-0.14.0-cp314-cp314t-win32.whl", hash = "sha256:2f7877ed45118de283786178eceaf877110abacd04fde31efff3940ae9672674", size = 207957, upload-time = "2026-04-10T14:27:59.285Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ac/2b760516c03e2227826d1f7025d89bf6bf6357a28fe75c2a2800873c50bf/jiter-0.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:14c0cb10337c49f5eafe8e7364daca5e29a020ea03580b8f8e6c597fed4e1588", size = 204690, upload-time = "2026-04-10T14:28:00.962Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/2e/a44c20c58aeed0355f2d326969a181696aeb551a25195f47563908a815be/jiter-0.14.0-cp314-cp314t-win_arm64.whl", hash = "sha256:5419d4aa2024961da9fe12a9cfe7484996735dca99e8e090b5c88595ef1951ff", size = 191338, upload-time = "2026-04-10T14:28:02.853Z" },
+    { url = "https://files.pythonhosted.org/packages/21/42/9042c3f3019de4adcb8c16591c325ec7255beea9fcd33a42a43f3b0b1000/jiter-0.14.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:fbd9e482663ca9d005d051330e4d2d8150bb208a209409c10f7e7dfdf7c49da9", size = 308810, upload-time = "2026-04-10T14:28:34.673Z" },
+    { url = "https://files.pythonhosted.org/packages/60/cf/a7e19b308bd86bb04776803b1f01a5f9a287a4c55205f4708827ee487fbf/jiter-0.14.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:33a20d838b91ef376b3a56896d5b04e725c7df5bc4864cc6569cf046a8d73b6d", size = 308443, upload-time = "2026-04-10T14:28:36.658Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/44/e26ede3f0caeff93f222559cb0cc4ca68579f07d009d7b6010c5b586f9b1/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:432c4db5255d86a259efde91e55cb4c8d18c0521d844c9e2e7efcce3899fb016", size = 343039, upload-time = "2026-04-10T14:28:38.356Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e9/1f9ada30cef7b05e74bb06f52127e7a724976c225f46adb65c37b1dadfb6/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67f00d94b281174144d6532a04b66a12cb866cbdc47c3af3bfe2973677f9861a", size = 349613, upload-time = "2026-04-10T14:28:40.066Z" },
+]
+
+[[package]]
 name = "jmespath"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1786,6 +1875,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "openai"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/fe/64b3d035780b3188f86c4f6f1bc202e7bb74757ef028802112273b9dcacf/openai-2.31.0.tar.gz", hash = "sha256:43ca59a88fc973ad1848d86b98d7fac207e265ebbd1828b5e4bdfc85f79427a5", size = 684772, upload-time = "2026-04-08T21:01:41.797Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/bc/a8f7c3aa03452fedbb9af8be83e959adba96a6b4a35e416faffcc959c568/openai-2.31.0-py3-none-any.whl", hash = "sha256:44e1344d87e56a493d649b17e2fac519d1368cbb0745f59f1957c4c26de50a0a", size = 1153479, upload-time = "2026-04-08T21:01:39.217Z" },
 ]
 
 [[package]]
@@ -2523,6 +2631,94 @@ wheels = [
 ]
 
 [[package]]
+name = "regex"
+version = "2026.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/0e/3a246dbf05666918bd3664d9d787f84a9108f6f43cc953a077e4a7dfdb7e/regex-2026.4.4.tar.gz", hash = "sha256:e08270659717f6973523ce3afbafa53515c4dc5dcad637dc215b6fd50f689423", size = 416000, upload-time = "2026-04-03T20:56:28.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/28/b972a4d3df61e1d7bcf1b59fdb3cddef22f88b6be43f161bb41ebc0e4081/regex-2026.4.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c07ab8794fa929e58d97a0e1796b8b76f70943fa39df225ac9964615cf1f9d52", size = 490434, upload-time = "2026-04-03T20:53:40.219Z" },
+    { url = "https://files.pythonhosted.org/packages/84/20/30041446cf6dc3e0eab344fc62770e84c23b6b68a3b657821f9f80cb69b4/regex-2026.4.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c785939dc023a1ce4ec09599c032cc9933d258a998d16ca6f2b596c010940eb", size = 292061, upload-time = "2026-04-03T20:53:41.862Z" },
+    { url = "https://files.pythonhosted.org/packages/62/c8/3baa06d75c98c46d4cc4262b71fd2edb9062b5665e868bca57859dadf93a/regex-2026.4.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1b1ce5c81c9114f1ce2f9288a51a8fd3aeea33a0cc440c415bf02da323aa0a76", size = 289628, upload-time = "2026-04-03T20:53:43.701Z" },
+    { url = "https://files.pythonhosted.org/packages/31/87/3accf55634caad8c0acab23f5135ef7d4a21c39f28c55c816ae012931408/regex-2026.4.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:760ef21c17d8e6a4fe8cf406a97cf2806a4df93416ccc82fc98d25b1c20425be", size = 796651, upload-time = "2026-04-03T20:53:45.379Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/0c/aaa2c83f34efedbf06f61cb1942c25f6cf1ee3b200f832c4d05f28306c2e/regex-2026.4.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7088fcdcb604a4417c208e2169715800d28838fefd7455fbe40416231d1d47c1", size = 865916, upload-time = "2026-04-03T20:53:47.064Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/f6/8c6924c865124643e8f37823eca845dc27ac509b2ee58123685e71cd0279/regex-2026.4.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:07edca1ba687998968f7db5bc355288d0c6505caa7374f013d27356d93976d13", size = 912287, upload-time = "2026-04-03T20:53:49.422Z" },
+    { url = "https://files.pythonhosted.org/packages/11/0e/a9f6f81013e0deaf559b25711623864970fe6a098314e374ccb1540a4152/regex-2026.4.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:993f657a7c1c6ec51b5e0ba97c9817d06b84ea5fa8d82e43b9405de0defdc2b9", size = 801126, upload-time = "2026-04-03T20:53:51.096Z" },
+    { url = "https://files.pythonhosted.org/packages/71/61/3a0cc8af2dc0c8deb48e644dd2521f173f7e6513c6e195aad9aa8dd77ac5/regex-2026.4.4-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2b69102a743e7569ebee67e634a69c4cb7e59d6fa2e1aa7d3bdbf3f61435f62d", size = 776788, upload-time = "2026-04-03T20:53:52.889Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0b/8bb9cbf21ef7dee58e49b0fdb066a7aded146c823202e16494a36777594f/regex-2026.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6dac006c8b6dda72d86ea3d1333d45147de79a3a3f26f10c1cf9287ca4ca0ac3", size = 785184, upload-time = "2026-04-03T20:53:55.627Z" },
+    { url = "https://files.pythonhosted.org/packages/99/c2/d3e80e8137b25ee06c92627de4e4d98b94830e02b3e6f81f3d2e3f504cf5/regex-2026.4.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:50a766ee2010d504554bfb5f578ed2e066898aa26411d57e6296230627cdefa0", size = 859913, upload-time = "2026-04-03T20:53:57.249Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/9d5d876157d969c804622456ef250017ac7a8f83e0e14f903b9e6df5ce95/regex-2026.4.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:9e2f5217648f68e3028c823df58663587c1507a5ba8419f4fdfc8a461be76043", size = 765732, upload-time = "2026-04-03T20:53:59.428Z" },
+    { url = "https://files.pythonhosted.org/packages/82/80/b568935b4421388561c8ed42aff77247285d3ae3bb2a6ca22af63bae805e/regex-2026.4.4-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:39d8de85a08e32632974151ba59c6e9140646dcc36c80423962b1c5c0a92e244", size = 852152, upload-time = "2026-04-03T20:54:01.505Z" },
+    { url = "https://files.pythonhosted.org/packages/39/29/f0f81217e21cd998245da047405366385d5c6072048038a3d33b37a79dc0/regex-2026.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:55d9304e0e7178dfb1e106c33edf834097ddf4a890e2f676f6c5118f84390f73", size = 789076, upload-time = "2026-04-03T20:54:03.323Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1d/1d957a61976ab9d4e767dd4f9d04b66cc0c41c5e36cf40e2d43688b5ae6f/regex-2026.4.4-cp312-cp312-win32.whl", hash = "sha256:04bb679bc0bde8a7bfb71e991493d47314e7b98380b083df2447cda4b6edb60f", size = 266700, upload-time = "2026-04-03T20:54:05.639Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/5c/bf575d396aeb58ea13b06ef2adf624f65b70fafef6950a80fc3da9cae3bc/regex-2026.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:db0ac18435a40a2543dbb3d21e161a6c78e33e8159bd2e009343d224bb03bb1b", size = 277768, upload-time = "2026-04-03T20:54:07.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/27/049df16ec6a6828ccd72add3c7f54b4df029669bea8e9817df6fff58be90/regex-2026.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:4ce255cc05c1947a12989c6db801c96461947adb7a59990f1360b5983fab4983", size = 270568, upload-time = "2026-04-03T20:54:09.484Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/83/c4373bc5f31f2cf4b66f9b7c31005bd87fe66f0dce17701f7db4ee79ee29/regex-2026.4.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:62f5519042c101762509b1d717b45a69c0139d60414b3c604b81328c01bd1943", size = 490273, upload-time = "2026-04-03T20:54:11.202Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f8/fe62afbcc3cf4ad4ac9adeaafd98aa747869ae12d3e8e2ac293d0593c435/regex-2026.4.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:3790ba9fb5dd76715a7afe34dbe603ba03f8820764b1dc929dd08106214ed031", size = 291954, upload-time = "2026-04-03T20:54:13.412Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/92/4712b9fe6a33d232eeb1c189484b80c6c4b8422b90e766e1195d6e758207/regex-2026.4.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8fae3c6e795d7678963f2170152b0d892cf6aee9ee8afc8c45e6be38d5107fe7", size = 289487, upload-time = "2026-04-03T20:54:15.824Z" },
+    { url = "https://files.pythonhosted.org/packages/88/2c/f83b93f85e01168f1070f045a42d4c937b69fdb8dd7ae82d307253f7e36e/regex-2026.4.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:298c3ec2d53225b3bf91142eb9691025bab610e0c0c51592dde149db679b3d17", size = 796646, upload-time = "2026-04-03T20:54:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/df/55/61a2e17bf0c4dc57e11caf8dd11771280d8aaa361785f9e3bc40d653f4a7/regex-2026.4.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e9638791082eaf5b3ac112c587518ee78e083a11c4b28012d8fe2a0f536dfb17", size = 865904, upload-time = "2026-04-03T20:54:20.019Z" },
+    { url = "https://files.pythonhosted.org/packages/45/32/1ac8ed1b5a346b5993a3d256abe0a0f03b0b73c8cc88d928537368ac65b6/regex-2026.4.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae3e764bd4c5ff55035dc82a8d49acceb42a5298edf6eb2fc4d328ee5dd7afae", size = 912304, upload-time = "2026-04-03T20:54:22.403Z" },
+    { url = "https://files.pythonhosted.org/packages/26/47/2ee5c613ab546f0eddebf9905d23e07beb933416b1246c2d8791d01979b4/regex-2026.4.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ffa81f81b80047ba89a3c69ae6a0f78d06f4a42ce5126b0eb2a0a10ad44e0b2e", size = 801126, upload-time = "2026-04-03T20:54:24.308Z" },
+    { url = "https://files.pythonhosted.org/packages/75/cd/41dacd129ca9fd20bd7d02f83e0fad83e034ac8a084ec369c90f55ef37e2/regex-2026.4.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f56ebf9d70305307a707911b88469213630aba821e77de7d603f9d2f0730687d", size = 776772, upload-time = "2026-04-03T20:54:26.319Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6d/5af0b588174cb5f46041fa7dd64d3fd5cd2fe51f18766703d1edc387f324/regex-2026.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:773d1dfd652bbffb09336abf890bfd64785c7463716bf766d0eb3bc19c8b7f27", size = 785228, upload-time = "2026-04-03T20:54:28.387Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/3b/f5a72b7045bd59575fc33bf1345f156fcfd5a8484aea6ad84b12c5a82114/regex-2026.4.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d51d20befd5275d092cdffba57ded05f3c436317ee56466c8928ac32d960edaf", size = 860032, upload-time = "2026-04-03T20:54:30.641Z" },
+    { url = "https://files.pythonhosted.org/packages/39/a4/72a317003d6fcd7a573584a85f59f525dfe8f67e355ca74eb6b53d66a5e2/regex-2026.4.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:0a51cdb3c1e9161154f976cb2bef9894bc063ac82f31b733087ffb8e880137d0", size = 765714, upload-time = "2026-04-03T20:54:32.789Z" },
+    { url = "https://files.pythonhosted.org/packages/25/1e/5672e16f34dbbcb2560cc7e6a2fbb26dfa8b270711e730101da4423d3973/regex-2026.4.4-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:ae5266a82596114e41fb5302140e9630204c1b5f325c770bec654b95dd54b0aa", size = 852078, upload-time = "2026-04-03T20:54:34.546Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/0d/c813f0af7c6cc7ed7b9558bac2e5120b60ad0fa48f813e4d4bd55446f214/regex-2026.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c882cd92ec68585e9c1cf36c447ec846c0d94edd706fe59e0c198e65822fd23b", size = 789181, upload-time = "2026-04-03T20:54:36.642Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/6d/a344608d1adbd2a95090ddd906cec09a11be0e6517e878d02a5123e0917f/regex-2026.4.4-cp313-cp313-win32.whl", hash = "sha256:05568c4fbf3cb4fa9e28e3af198c40d3237cf6041608a9022285fe567ec3ad62", size = 266690, upload-time = "2026-04-03T20:54:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/31/07/54049f89b46235ca6f45cd6c88668a7050e77d4a15555e47dd40fde75263/regex-2026.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:3384df51ed52db0bea967e21458ab0a414f67cdddfd94401688274e55147bb81", size = 277733, upload-time = "2026-04-03T20:54:40.11Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/21/61366a8e20f4d43fb597708cac7f0e2baadb491ecc9549b4980b2be27d16/regex-2026.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:acd38177bd2c8e69a411d6521760806042e244d0ef94e2dd03ecdaa8a3c99427", size = 270565, upload-time = "2026-04-03T20:54:41.883Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/1e/3a2b9672433bef02f5d39aa1143ca2c08f311c1d041c464a42be9ae648dc/regex-2026.4.4-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:f94a11a9d05afcfcfa640e096319720a19cc0c9f7768e1a61fceee6a3afc6c7c", size = 494126, upload-time = "2026-04-03T20:54:43.602Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/4b/c132a4f4fe18ad3340d89fcb56235132b69559136036b845be3c073142ed/regex-2026.4.4-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:36bcb9d6d1307ab629edc553775baada2aefa5c50ccc0215fbfd2afcfff43141", size = 293882, upload-time = "2026-04-03T20:54:45.41Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/5f/eaa38092ce7a023656280f2341dbbd4ad5f05d780a70abba7bb4f4bea54c/regex-2026.4.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:261c015b3e2ed0919157046d768774ecde57f03d8fa4ba78d29793447f70e717", size = 292334, upload-time = "2026-04-03T20:54:47.051Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f6/dd38146af1392dac33db7074ab331cec23cced3759167735c42c5460a243/regex-2026.4.4-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c228cf65b4a54583763645dcd73819b3b381ca8b4bb1b349dee1c135f4112c07", size = 811691, upload-time = "2026-04-03T20:54:49.074Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f0/dc54c2e69f5eeec50601054998ec3690d5344277e782bd717e49867c1d29/regex-2026.4.4-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:dd2630faeb6876fb0c287f664d93ddce4d50cd46c6e88e60378c05c9047e08ca", size = 871227, upload-time = "2026-04-03T20:54:51.035Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/af/cb16bd5dc61621e27df919a4449bbb7e5a1034c34d307e0a706e9cc0f3e3/regex-2026.4.4-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6a50ab11b7779b849472337191f3a043e27e17f71555f98d0092fa6d73364520", size = 917435, upload-time = "2026-04-03T20:54:52.994Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/71/8b260897f22996b666edd9402861668f45a2ca259f665ac029e6104a2d7d/regex-2026.4.4-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0734f63afe785138549fbe822a8cfeaccd1bae814c5057cc0ed5b9f2de4fc883", size = 816358, upload-time = "2026-04-03T20:54:54.884Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/60/775f7f72a510ef238254906c2f3d737fc80b16ca85f07d20e318d2eea894/regex-2026.4.4-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c4ee50606cb1967db7e523224e05f32089101945f859928e65657a2cbb3d278b", size = 785549, upload-time = "2026-04-03T20:54:57.01Z" },
+    { url = "https://files.pythonhosted.org/packages/58/42/34d289b3627c03cf381e44da534a0021664188fa49ba41513da0b4ec6776/regex-2026.4.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6c1818f37be3ca02dcb76d63f2c7aaba4b0dc171b579796c6fbe00148dfec6b1", size = 801364, upload-time = "2026-04-03T20:54:58.981Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/20/f6ecf319b382a8f1ab529e898b222c3f30600fcede7834733c26279e7465/regex-2026.4.4-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:f5bfc2741d150d0be3e4a0401a5c22b06e60acb9aa4daa46d9e79a6dcd0f135b", size = 866221, upload-time = "2026-04-03T20:55:00.88Z" },
+    { url = "https://files.pythonhosted.org/packages/92/6a/9f16d3609d549bd96d7a0b2aee1625d7512ba6a03efc01652149ef88e74d/regex-2026.4.4-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:504ffa8a03609a087cad81277a629b6ce884b51a24bd388a7980ad61748618ff", size = 772530, upload-time = "2026-04-03T20:55:03.213Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f6/aa9768bc96a4c361ac96419fbaf2dcdc33970bb813df3ba9b09d5d7b6d96/regex-2026.4.4-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:70aadc6ff12e4b444586e57fc30771f86253f9f0045b29016b9605b4be5f7dfb", size = 856989, upload-time = "2026-04-03T20:55:05.087Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/b4/c671db3556be2473ae3e4bb7a297c518d281452871501221251ea4ecba57/regex-2026.4.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f4f83781191007b6ef43b03debc35435f10cad9b96e16d147efe84a1d48bdde4", size = 803241, upload-time = "2026-04-03T20:55:07.162Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/5c/83e3b1d89fa4f6e5a1bc97b4abd4a9a97b3c1ac7854164f694f5f0ba98a0/regex-2026.4.4-cp313-cp313t-win32.whl", hash = "sha256:e014a797de43d1847df957c0a2a8e861d1c17547ee08467d1db2c370b7568baa", size = 269921, upload-time = "2026-04-03T20:55:09.62Z" },
+    { url = "https://files.pythonhosted.org/packages/28/07/077c387121f42cdb4d92b1301133c0d93b5709d096d1669ab847dda9fe2e/regex-2026.4.4-cp313-cp313t-win_amd64.whl", hash = "sha256:b15b88b0d52b179712632832c1d6e58e5774f93717849a41096880442da41ab0", size = 281240, upload-time = "2026-04-03T20:55:11.521Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/22/ead4a4abc7c59a4d882662aa292ca02c8b617f30b6e163bc1728879e9353/regex-2026.4.4-cp313-cp313t-win_arm64.whl", hash = "sha256:586b89cdadf7d67bf86ae3342a4dcd2b8d70a832d90c18a0ae955105caf34dbe", size = 272440, upload-time = "2026-04-03T20:55:13.365Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/f5/ed97c2dc47b5fbd4b73c0d7d75f9ebc8eca139f2bbef476bba35f28c0a77/regex-2026.4.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:2da82d643fa698e5e5210e54af90181603d5853cf469f5eedf9bfc8f59b4b8c7", size = 490343, upload-time = "2026-04-03T20:55:15.241Z" },
+    { url = "https://files.pythonhosted.org/packages/80/e9/de4828a7385ec166d673a5790ad06ac48cdaa98bc0960108dd4b9cc1aef7/regex-2026.4.4-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:54a1189ad9d9357760557c91103d5e421f0a2dabe68a5cdf9103d0dcf4e00752", size = 291909, upload-time = "2026-04-03T20:55:17.558Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/d6/5cfbfc97f3201a4d24b596a77957e092030dcc4205894bc035cedcfce62f/regex-2026.4.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:76d67d5afb1fe402d10a6403bae668d000441e2ab115191a804287d53b772951", size = 289692, upload-time = "2026-04-03T20:55:20.561Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ac/f2212d9fd56fe897e36d0110ba30ba2d247bd6410c5bd98499c7e5a1e1f2/regex-2026.4.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e7cd3e4ee8d80447a83bbc9ab0c8459781fa77087f856c3e740d7763be0df27f", size = 796979, upload-time = "2026-04-03T20:55:22.56Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e3/a016c12675fbac988a60c7e1c16e67823ff0bc016beb27bd7a001dbdabc6/regex-2026.4.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e19e18c568d2866d8b6a6dfad823db86193503f90823a8f66689315ba28fbe8", size = 866744, upload-time = "2026-04-03T20:55:24.646Z" },
+    { url = "https://files.pythonhosted.org/packages/af/a4/0b90ca4cf17adc3cb43de80ec71018c37c88ad64987e8d0d481a95ca60b5/regex-2026.4.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7698a6f38730fd1385d390d1ed07bb13dce39aa616aca6a6d89bea178464b9a4", size = 911613, upload-time = "2026-04-03T20:55:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3b/2b3dac0b82d41ab43aa87c6ecde63d71189d03fe8854b8ca455a315edac3/regex-2026.4.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:173a66f3651cdb761018078e2d9487f4cf971232c990035ec0eb1cdc6bf929a9", size = 800551, upload-time = "2026-04-03T20:55:29.532Z" },
+    { url = "https://files.pythonhosted.org/packages/25/fe/5365eb7aa0e753c4b5957815c321519ecab033c279c60e1b1ae2367fa810/regex-2026.4.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fa7922bbb2cc84fa062d37723f199d4c0cd200245ce269c05db82d904db66b83", size = 776911, upload-time = "2026-04-03T20:55:31.526Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b3/7fb0072156bba065e3b778a7bc7b0a6328212be5dd6a86fd207e0c4f2dab/regex-2026.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:59f67cd0a0acaf0e564c20bbd7f767286f23e91e2572c5703bf3e56ea7557edb", size = 785751, upload-time = "2026-04-03T20:55:33.797Z" },
+    { url = "https://files.pythonhosted.org/packages/02/1a/9f83677eb699273e56e858f7bd95acdbee376d42f59e8bfca2fd80d79df3/regex-2026.4.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:475e50f3f73f73614f7cba5524d6de49dee269df00272a1b85e3d19f6d498465", size = 860484, upload-time = "2026-04-03T20:55:35.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/7a/93937507b61cfcff8b4c5857f1b452852b09f741daa9acae15c971d8554e/regex-2026.4.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:a1c0c7d67b64d85ac2e1879923bad2f08a08f3004055f2f406ef73c850114bd4", size = 765939, upload-time = "2026-04-03T20:55:37.972Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ea/81a7f968a351c6552b1670ead861e2a385be730ee28402233020c67f9e0f/regex-2026.4.4-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:1371c2ccbb744d66ee63631cc9ca12aa233d5749972626b68fe1a649dd98e566", size = 851417, upload-time = "2026-04-03T20:55:39.92Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/7e/323c18ce4b5b8f44517a36342961a0306e931e499febbd876bb149d900f0/regex-2026.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:59968142787042db793348a3f5b918cf24ced1f23247328530e063f89c128a95", size = 789056, upload-time = "2026-04-03T20:55:42.303Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/af/e7510f9b11b1913b0cd44eddb784b2d650b2af6515bfce4cffcc5bfd1d38/regex-2026.4.4-cp314-cp314-win32.whl", hash = "sha256:59efe72d37fd5a91e373e5146f187f921f365f4abc1249a5ab446a60f30dd5f8", size = 272130, upload-time = "2026-04-03T20:55:44.995Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/51/57dae534c915e2d3a21490e88836fa2ae79dde3b66255ecc0c0a155d2c10/regex-2026.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:e0aab3ff447845049d676827d2ff714aab4f73f340e155b7de7458cf53baa5a4", size = 280992, upload-time = "2026-04-03T20:55:47.316Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/5e/abaf9f4c3792e34edb1434f06717fae2b07888d85cb5cec29f9204931bf8/regex-2026.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:a7a5bb6aa0cf62208bb4fa079b0c756734f8ad0e333b425732e8609bd51ee22f", size = 273563, upload-time = "2026-04-03T20:55:49.273Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/06/35da85f9f217b9538b99cbb170738993bcc3b23784322decb77619f11502/regex-2026.4.4-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:97850d0638391bdc7d35dc1c1039974dcb921eaafa8cc935ae4d7f272b1d60b3", size = 494191, upload-time = "2026-04-03T20:55:51.258Z" },
+    { url = "https://files.pythonhosted.org/packages/54/5b/1bc35f479eef8285c4baf88d8c002023efdeebb7b44a8735b36195486ae7/regex-2026.4.4-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:ee7337f88f2a580679f7bbfe69dc86c043954f9f9c541012f49abc554a962f2e", size = 293877, upload-time = "2026-04-03T20:55:53.214Z" },
+    { url = "https://files.pythonhosted.org/packages/39/5b/f53b9ad17480b3ddd14c90da04bfb55ac6894b129e5dea87bcaf7d00e336/regex-2026.4.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7429f4e6192c11d659900c0648ba8776243bf396ab95558b8c51a345afeddde6", size = 292410, upload-time = "2026-04-03T20:55:55.736Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/56/52377f59f60a7c51aa4161eecf0b6032c20b461805aca051250da435ffc9/regex-2026.4.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc4f10fbd5dd13dcf4265b4cc07d69ca70280742870c97ae10093e3d66000359", size = 811831, upload-time = "2026-04-03T20:55:57.802Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/63/8026310bf066f702a9c361f83a8c9658f3fe4edb349f9c1e5d5273b7c40c/regex-2026.4.4-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a152560af4f9742b96f3827090f866eeec5becd4765c8e0d3473d9d280e76a5a", size = 871199, upload-time = "2026-04-03T20:56:00.333Z" },
+    { url = "https://files.pythonhosted.org/packages/20/9f/a514bbb00a466dbb506d43f187a04047f7be1505f10a9a15615ead5080ee/regex-2026.4.4-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:54170b3e95339f415d54651f97df3bff7434a663912f9358237941bbf9143f55", size = 917649, upload-time = "2026-04-03T20:56:02.445Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/6b/8399f68dd41a2030218839b9b18360d79b86d22b9fab5ef477c7f23ca67c/regex-2026.4.4-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:07f190d65f5a72dcb9cf7106bfc3d21e7a49dd2879eda2207b683f32165e4d99", size = 816388, upload-time = "2026-04-03T20:56:04.595Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/9c/103963f47c24339a483b05edd568594c2be486188f688c0170fd504b2948/regex-2026.4.4-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9a2741ce5a29d3c84b0b94261ba630ab459a1b847a0d6beca7d62d188175c790", size = 785746, upload-time = "2026-04-03T20:56:07.13Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ee/7f6054c0dec0cee3463c304405e4ff42e27cff05bf36fcb34be549ab17bd/regex-2026.4.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:b26c30df3a28fd9793113dac7385a4deb7294a06c0f760dd2b008bd49a9139bc", size = 801483, upload-time = "2026-04-03T20:56:09.365Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c2/51d3d941cf6070dc00c3338ecf138615fc3cce0421c3df6abe97a08af61a/regex-2026.4.4-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:421439d1bee44b19f4583ccf42670ca464ffb90e9fdc38d37f39d1ddd1e44f1f", size = 866331, upload-time = "2026-04-03T20:56:12.039Z" },
+    { url = "https://files.pythonhosted.org/packages/16/e8/76d50dcc122ac33927d939f350eebcfe3dbcbda96913e03433fc36de5e63/regex-2026.4.4-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:b40379b53ecbc747fd9bdf4a0ea14eb8188ca1bd0f54f78893a39024b28f4863", size = 772673, upload-time = "2026-04-03T20:56:14.558Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/6e/5f6bf75e20ea6873d05ba4ec78378c375cbe08cdec571c83fbb01606e563/regex-2026.4.4-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:08c55c13d2eef54f73eeadc33146fb0baaa49e7335eb1aff6ae1324bf0ddbe4a", size = 857146, upload-time = "2026-04-03T20:56:16.663Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/33/3c76d9962949e487ebba353a18e89399f292287204ac8f2f4cfc3a51c233/regex-2026.4.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9776b85f510062f5a75ef112afe5f494ef1635607bf1cc220c1391e9ac2f5e81", size = 803463, upload-time = "2026-04-03T20:56:18.923Z" },
+    { url = "https://files.pythonhosted.org/packages/19/eb/ef32dcd2cb69b69bc0c3e55205bce94a7def48d495358946bc42186dcccc/regex-2026.4.4-cp314-cp314t-win32.whl", hash = "sha256:385edaebde5db5be103577afc8699fea73a0e36a734ba24870be7ffa61119d74", size = 275709, upload-time = "2026-04-03T20:56:20.996Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/86/c291bf740945acbf35ed7dbebf8e2eea2f3f78041f6bd7cdab80cb274dc0/regex-2026.4.4-cp314-cp314t-win_amd64.whl", hash = "sha256:5d354b18839328927832e2fa5f7c95b7a3ccc39e7a681529e1685898e6436d45", size = 285622, upload-time = "2026-04-03T20:56:23.641Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e7/ec846d560ae6a597115153c02ca6138a7877a1748b2072d9521c10a93e58/regex-2026.4.4-cp314-cp314t-win_arm64.whl", hash = "sha256:af0384cb01a33600c49505c27c6c57ab0b27bf84a74e28524c92ca897ebdac9d", size = 275773, upload-time = "2026-04-03T20:56:26.07Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2588,6 +2784,23 @@ wheels = [
 ]
 
 [[package]]
+name = "semantic-text-splitter"
+version = "0.29.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/e9/cc31904f918a0f9f20039a969e191a9b88ecfc7536d5ed822a72640d4022/semantic_text_splitter-0.29.0.tar.gz", hash = "sha256:80a57c689f3521730670a881eccf95b996cb6115ee5c916778a3996971899121", size = 283431, upload-time = "2025-12-30T22:31:58.534Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/53/ba753d570945b076b7a7e80bc49dc0bc43d60ac294b7b77e7769c52e77ac/semantic_text_splitter-0.29.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:a5197301c6ddf57ae421af0e723d97774516b8b93f6439d1ad16760c5290e0d5", size = 8261920, upload-time = "2025-12-30T22:31:42.696Z" },
+    { url = "https://files.pythonhosted.org/packages/76/b2/64b4396ddefcffb550461ea5b335b6e9e74356d744ad5aa93640ab4f9306/semantic_text_splitter-0.29.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:0cd62a7710c9049b9cd6484531379ba1d8c8594a9d63ffef38b65a084aa3c8ac", size = 8268950, upload-time = "2025-12-30T22:31:44.697Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/17/d3c8736590b9cd1c83f12e7fb67b63efd8fbf32da9689d1bfd8cee2e6f14/semantic_text_splitter-0.29.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:885a9c18e6f87e9280ac8894ed4760b26f718eb2d81656263278640e4abc35b1", size = 8485522, upload-time = "2025-12-30T22:31:46.582Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/8b/69772c4f884d99f62f7426bab3a8e75c3e0bcdcc2fd975e926057a813a47/semantic_text_splitter-0.29.0-cp310-abi3-manylinux_2_28_armv7l.whl", hash = "sha256:417db93494f97e83b8dab12c3e565df3357c4c75d6691a3314f4465a6eb57696", size = 8347931, upload-time = "2025-12-30T22:31:48.591Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/d6/acaed5cbe7182850fa7daea0fc9a27ce4c43d5ad0999aa3670013ce033f0/semantic_text_splitter-0.29.0-cp310-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:654bb33a9466b77177ea0ae2b382c3564977e49cc92c8a0fb4b320876bdedd77", size = 8817946, upload-time = "2025-12-30T22:31:50.028Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/90/a2482e3b1fa846b620e752aedc54629fd63034017542b400f1539277e522/semantic_text_splitter-0.29.0-cp310-abi3-manylinux_2_28_s390x.whl", hash = "sha256:1e011bb178801c0e8780e124edb0bd8e396e7846c60ab60aa5b126c57540556d", size = 8659506, upload-time = "2025-12-30T22:31:52.09Z" },
+    { url = "https://files.pythonhosted.org/packages/51/86/2947d6fa18bf8f89aa7096993ece71c927647846569a784a3441987d927b/semantic_text_splitter-0.29.0-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:8d4efcc5f42b9196b1aad165871ad212d7f102847d522f45e73dba712d61d7cb", size = 8492252, upload-time = "2025-12-30T22:31:53.724Z" },
+    { url = "https://files.pythonhosted.org/packages/64/61/f00fc614fa38d663d146df29342db6a057e3c086d2b7a84b468b5647b023/semantic_text_splitter-0.29.0-cp310-abi3-win32.whl", hash = "sha256:71adb6d2c9ea14ef56065688634a7fa98ea2f0f8768d6099cdb6fbb82d7745fd", size = 7784072, upload-time = "2025-12-30T22:31:55.753Z" },
+    { url = "https://files.pythonhosted.org/packages/75/3c/853c39e0adc769cf51dc87335fc929e1fe66036f3f6ece8c8556d5c1ea87/semantic_text_splitter-0.29.0-cp310-abi3-win_amd64.whl", hash = "sha256:ccbf00e2a54c790f117a4890c45f0045862a9c76bcbc23382e5eaf84fb4c8334", size = 8000626, upload-time = "2025-12-30T22:31:57.173Z" },
+]
+
+[[package]]
 name = "simple-websocket"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2606,6 +2819,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
 ]
 
 [[package]]
@@ -2727,6 +2949,53 @@ wheels = [
 ]
 
 [[package]]
+name = "tiktoken"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "regex" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ab/4d017d0f76ec3171d469d80fc03dfbb4e48a4bcaddaa831b31d526f05edc/tiktoken-0.12.0.tar.gz", hash = "sha256:b18ba7ee2b093863978fcb14f74b3707cdc8d4d4d3836853ce7ec60772139931", size = 37806, upload-time = "2025-10-06T20:22:45.419Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/85/be65d39d6b647c79800fd9d29241d081d4eeb06271f383bb87200d74cf76/tiktoken-0.12.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b97f74aca0d78a1ff21b8cd9e9925714c15a9236d6ceacf5c7327c117e6e21e8", size = 1050728, upload-time = "2025-10-06T20:21:52.756Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/42/6573e9129bc55c9bf7300b3a35bef2c6b9117018acca0dc760ac2d93dffe/tiktoken-0.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2b90f5ad190a4bb7c3eb30c5fa32e1e182ca1ca79f05e49b448438c3e225a49b", size = 994049, upload-time = "2025-10-06T20:21:53.782Z" },
+    { url = "https://files.pythonhosted.org/packages/66/c5/ed88504d2f4a5fd6856990b230b56d85a777feab84e6129af0822f5d0f70/tiktoken-0.12.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:65b26c7a780e2139e73acc193e5c63ac754021f160df919add909c1492c0fb37", size = 1129008, upload-time = "2025-10-06T20:21:54.832Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/90/3dae6cc5436137ebd38944d396b5849e167896fc2073da643a49f372dc4f/tiktoken-0.12.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:edde1ec917dfd21c1f2f8046b86348b0f54a2c0547f68149d8600859598769ad", size = 1152665, upload-time = "2025-10-06T20:21:56.129Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/fe/26df24ce53ffde419a42f5f53d755b995c9318908288c17ec3f3448313a3/tiktoken-0.12.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:35a2f8ddd3824608b3d650a000c1ef71f730d0c56486845705a8248da00f9fe5", size = 1194230, upload-time = "2025-10-06T20:21:57.546Z" },
+    { url = "https://files.pythonhosted.org/packages/20/cc/b064cae1a0e9fac84b0d2c46b89f4e57051a5f41324e385d10225a984c24/tiktoken-0.12.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:83d16643edb7fa2c99eff2ab7733508aae1eebb03d5dfc46f5565862810f24e3", size = 1254688, upload-time = "2025-10-06T20:21:58.619Z" },
+    { url = "https://files.pythonhosted.org/packages/81/10/b8523105c590c5b8349f2587e2fdfe51a69544bd5a76295fc20f2374f470/tiktoken-0.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffc5288f34a8bc02e1ea7047b8d041104791d2ddbf42d1e5fa07822cbffe16bd", size = 878694, upload-time = "2025-10-06T20:21:59.876Z" },
+    { url = "https://files.pythonhosted.org/packages/00/61/441588ee21e6b5cdf59d6870f86beb9789e532ee9718c251b391b70c68d6/tiktoken-0.12.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:775c2c55de2310cc1bc9a3ad8826761cbdc87770e586fd7b6da7d4589e13dab3", size = 1050802, upload-time = "2025-10-06T20:22:00.96Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/05/dcf94486d5c5c8d34496abe271ac76c5b785507c8eae71b3708f1ad9b45a/tiktoken-0.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a01b12f69052fbe4b080a2cfb867c4de12c704b56178edf1d1d7b273561db160", size = 993995, upload-time = "2025-10-06T20:22:02.788Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/70/5163fe5359b943f8db9946b62f19be2305de8c3d78a16f629d4165e2f40e/tiktoken-0.12.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:01d99484dc93b129cd0964f9d34eee953f2737301f18b3c7257bf368d7615baa", size = 1128948, upload-time = "2025-10-06T20:22:03.814Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/da/c028aa0babf77315e1cef357d4d768800c5f8a6de04d0eac0f377cb619fa/tiktoken-0.12.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:4a1a4fcd021f022bfc81904a911d3df0f6543b9e7627b51411da75ff2fe7a1be", size = 1151986, upload-time = "2025-10-06T20:22:05.173Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/5a/886b108b766aa53e295f7216b509be95eb7d60b166049ce2c58416b25f2a/tiktoken-0.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:981a81e39812d57031efdc9ec59fa32b2a5a5524d20d4776574c4b4bd2e9014a", size = 1194222, upload-time = "2025-10-06T20:22:06.265Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f8/4db272048397636ac7a078d22773dd2795b1becee7bc4922fe6207288d57/tiktoken-0.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9baf52f84a3f42eef3ff4e754a0db79a13a27921b457ca9832cf944c6be4f8f3", size = 1255097, upload-time = "2025-10-06T20:22:07.403Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/32/45d02e2e0ea2be3a9ed22afc47d93741247e75018aac967b713b2941f8ea/tiktoken-0.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:b8a0cd0c789a61f31bf44851defbd609e8dd1e2c8589c614cc1060940ef1f697", size = 879117, upload-time = "2025-10-06T20:22:08.418Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/76/994fc868f88e016e6d05b0da5ac24582a14c47893f4474c3e9744283f1d5/tiktoken-0.12.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:d5f89ea5680066b68bcb797ae85219c72916c922ef0fcdd3480c7d2315ffff16", size = 1050309, upload-time = "2025-10-06T20:22:10.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/b8/57ef1456504c43a849821920d582a738a461b76a047f352f18c0b26c6516/tiktoken-0.12.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b4e7ed1c6a7a8a60a3230965bdedba8cc58f68926b835e519341413370e0399a", size = 993712, upload-time = "2025-10-06T20:22:12.115Z" },
+    { url = "https://files.pythonhosted.org/packages/72/90/13da56f664286ffbae9dbcfadcc625439142675845baa62715e49b87b68b/tiktoken-0.12.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:fc530a28591a2d74bce821d10b418b26a094bf33839e69042a6e86ddb7a7fb27", size = 1128725, upload-time = "2025-10-06T20:22:13.541Z" },
+    { url = "https://files.pythonhosted.org/packages/05/df/4f80030d44682235bdaecd7346c90f67ae87ec8f3df4a3442cb53834f7e4/tiktoken-0.12.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:06a9f4f49884139013b138920a4c393aa6556b2f8f536345f11819389c703ebb", size = 1151875, upload-time = "2025-10-06T20:22:14.559Z" },
+    { url = "https://files.pythonhosted.org/packages/22/1f/ae535223a8c4ef4c0c1192e3f9b82da660be9eb66b9279e95c99288e9dab/tiktoken-0.12.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:04f0e6a985d95913cabc96a741c5ffec525a2c72e9df086ff17ebe35985c800e", size = 1194451, upload-time = "2025-10-06T20:22:15.545Z" },
+    { url = "https://files.pythonhosted.org/packages/78/a7/f8ead382fce0243cb625c4f266e66c27f65ae65ee9e77f59ea1653b6d730/tiktoken-0.12.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ee8f9ae00c41770b5f9b0bb1235474768884ae157de3beb5439ca0fd70f3e25", size = 1253794, upload-time = "2025-10-06T20:22:16.624Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e0/6cc82a562bc6365785a3ff0af27a2a092d57c47d7a81d9e2295d8c36f011/tiktoken-0.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:dc2dd125a62cb2b3d858484d6c614d136b5b848976794edfb63688d539b8b93f", size = 878777, upload-time = "2025-10-06T20:22:18.036Z" },
+    { url = "https://files.pythonhosted.org/packages/72/05/3abc1db5d2c9aadc4d2c76fa5640134e475e58d9fbb82b5c535dc0de9b01/tiktoken-0.12.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:a90388128df3b3abeb2bfd1895b0681412a8d7dc644142519e6f0a97c2111646", size = 1050188, upload-time = "2025-10-06T20:22:19.563Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7b/50c2f060412202d6c95f32b20755c7a6273543b125c0985d6fa9465105af/tiktoken-0.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:da900aa0ad52247d8794e307d6446bd3cdea8e192769b56276695d34d2c9aa88", size = 993978, upload-time = "2025-10-06T20:22:20.702Z" },
+    { url = "https://files.pythonhosted.org/packages/14/27/bf795595a2b897e271771cd31cb847d479073497344c637966bdf2853da1/tiktoken-0.12.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:285ba9d73ea0d6171e7f9407039a290ca77efcdb026be7769dccc01d2c8d7fff", size = 1129271, upload-time = "2025-10-06T20:22:22.06Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/de/9341a6d7a8f1b448573bbf3425fa57669ac58258a667eb48a25dfe916d70/tiktoken-0.12.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:d186a5c60c6a0213f04a7a802264083dea1bbde92a2d4c7069e1a56630aef830", size = 1151216, upload-time = "2025-10-06T20:22:23.085Z" },
+    { url = "https://files.pythonhosted.org/packages/75/0d/881866647b8d1be4d67cb24e50d0c26f9f807f994aa1510cb9ba2fe5f612/tiktoken-0.12.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:604831189bd05480f2b885ecd2d1986dc7686f609de48208ebbbddeea071fc0b", size = 1194860, upload-time = "2025-10-06T20:22:24.602Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/1e/b651ec3059474dab649b8d5b69f5c65cd8fcd8918568c1935bd4136c9392/tiktoken-0.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8f317e8530bb3a222547b85a58583238c8f74fd7a7408305f9f63246d1a0958b", size = 1254567, upload-time = "2025-10-06T20:22:25.671Z" },
+    { url = "https://files.pythonhosted.org/packages/80/57/ce64fd16ac390fafde001268c364d559447ba09b509181b2808622420eec/tiktoken-0.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:399c3dd672a6406719d84442299a490420b458c44d3ae65516302a99675888f3", size = 921067, upload-time = "2025-10-06T20:22:26.753Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/a4/72eed53e8976a099539cdd5eb36f241987212c29629d0a52c305173e0a68/tiktoken-0.12.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:c2c714c72bc00a38ca969dae79e8266ddec999c7ceccd603cc4f0d04ccd76365", size = 1050473, upload-time = "2025-10-06T20:22:27.775Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/d7/0110b8f54c008466b19672c615f2168896b83706a6611ba6e47313dbc6e9/tiktoken-0.12.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cbb9a3ba275165a2cb0f9a83f5d7025afe6b9d0ab01a22b50f0e74fee2ad253e", size = 993855, upload-time = "2025-10-06T20:22:28.799Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/77/4f268c41a3957c418b084dd576ea2fad2e95da0d8e1ab705372892c2ca22/tiktoken-0.12.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:dfdfaa5ffff8993a3af94d1125870b1d27aed7cb97aa7eb8c1cefdbc87dbee63", size = 1129022, upload-time = "2025-10-06T20:22:29.981Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2b/fc46c90fe5028bd094cd6ee25a7db321cb91d45dc87531e2bdbb26b4867a/tiktoken-0.12.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:584c3ad3d0c74f5269906eb8a659c8bfc6144a52895d9261cdaf90a0ae5f4de0", size = 1150736, upload-time = "2025-10-06T20:22:30.996Z" },
+    { url = "https://files.pythonhosted.org/packages/28/c0/3c7a39ff68022ddfd7d93f3337ad90389a342f761c4d71de99a3ccc57857/tiktoken-0.12.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:54c891b416a0e36b8e2045b12b33dd66fb34a4fe7965565f1b482da50da3e86a", size = 1194908, upload-time = "2025-10-06T20:22:32.073Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/0d/c1ad6f4016a3968c048545f5d9b8ffebf577774b2ede3e2e352553b685fe/tiktoken-0.12.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5edb8743b88d5be814b1a8a8854494719080c28faaa1ccbef02e87354fe71ef0", size = 1253706, upload-time = "2025-10-06T20:22:33.385Z" },
+    { url = "https://files.pythonhosted.org/packages/af/df/c7891ef9d2712ad774777271d39fdef63941ffba0a9d59b7ad1fd2765e57/tiktoken-0.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f61c0aea5565ac82e2ec50a05e02a6c44734e91b51c10510b084ea1b8e633a71", size = 920667, upload-time = "2025-10-06T20:22:34.444Z" },
+]
+
+[[package]]
 name = "tomli"
 version = "2.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2778,6 +3047,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Related Issue
- Closes #69

## Change Summary
- Add `BaseEmbeddingProtocol` with `embed_text`, `embed_batch`, and `dimension` property
- Implement `OpenAIEmbeddingClient` (token-based batching, tiktoken, 300K total token limit)
- Implement `BedrockEmbeddingClient` (aioboto3 invoke_model, 50K char validation)
- Add `providers.Selector` for multi-backend selection via `EMBEDDING_PROVIDER` env var
- Auto-derive embedding dimension from model (no configurable `EMBEDDING_DIMENSION`)
- Unify `S3VectorModelMeta.dimension` default with `settings.embedding_dimension`
- Add `chunk_text` and `chunk_text_by_tokens` utilities via `semantic-text-splitter`
- Add `EmbeddingInputTooLongException` for input limit enforcement
- Configuration: `EMBEDDING_*` fields with conditional validation (Broker pattern)
- ADR 035 (embedding abstraction) and ADR 036 (text chunking) documented

## Type of Change
- [x] feat: New feature
- [x] docs: Documentation

## Checklist
- [x] Architecture rules followed (no Domain -> Infrastructure imports)
- [x] Tests pass (134 passed, 2 skipped)
- [x] Linting passes (`ruff check src/`)
- [x] ADR recorded for architecture decisions

## How to Test

```bash
# Install dependencies (semantic-text-splitter added to core)
uv sync

# Run all unit tests
pytest tests/unit/_core/ -v

# Embedding tests only
pytest tests/unit/_core/infrastructure/embedding/ -v

# Text chunking tests only
pytest tests/unit/_core/common/test_text_utils.py -v

# Config validation tests
pytest tests/unit/_core/test_config.py::TestEmbeddingConfig -v

# Lint
pre-commit run --all-files
```

### Configuration

```bash
# OpenAI (default)
EMBEDDING_PROVIDER=openai
EMBEDDING_OPENAI_API_KEY=sk-...

# Bedrock
EMBEDDING_PROVIDER=bedrock
EMBEDDING_BEDROCK_ACCESS_KEY=...
EMBEDDING_BEDROCK_SECRET_KEY=...
EMBEDDING_BEDROCK_REGION=us-east-1

# Optional: override model (dimension auto-derived)
EMBEDDING_MODEL=text-embedding-3-large  # → 3072 dim
```