### PR TITLE
docs: optimize README and GitHub metadata for discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,43 +18,95 @@
 </p>
 
 <p align="center">
-  <b>AI Agent Backend Platform on FastAPI.</b><br>
-  MCP server + AI orchestration + async DDD — from CRUD to agent tools in one codebase.<br>
-  Build AI-powered backends that serve both users and agents.
+  <b>FastAPI DDD template, built for AI agent backends.</b><br>
+  Zero-boilerplate CRUD + auto discovery + vector search today. MCP server + AI orchestration coming soon.<br>
+  14+ AI development skills for Claude Code &amp; Codex CLI.
 </p>
 
 <p align="center">
-  <a href="#quick-start">Quick Start</a> · <a href="#architecture">Architecture</a> · <a href="#ai-native-development-aidd">AI-Native Development</a> · <a href="#comparison">Comparison</a> · <a href="docs/README.ko.md">한국어</a>
+  <a href="#quick-start">Quick Start</a> · <a href="#who-is-this-for">Who is this for?</a> · <a href="#architecture">Architecture</a> · <a href="#comparison">Comparison</a> · <a href="docs/README.ko.md">한국어</a>
 </p>
 
-<!-- TODO: Add demo GIF here
-![Demo](docs/assets/demo.gif)
--->
+<p align="center">
+  <a href="https://github.com/Mr-DooSun/fastapi-agent-blueprint/generate">
+    <img src="https://img.shields.io/badge/-Use%20this%20template-2ea44f?style=for-the-badge" alt="Use this template">
+  </a>
+</p>
 
 ---
 
-## Key Features
+## Who is this for?
 
-### AI Agent Platform
+- **FastAPI developers** who need a production-ready project structure beyond the tutorial stage — DDD layers, DI container, async throughout, architecture enforcement
+- **Backend teams** building systems that need multiple interfaces (REST API + background workers + admin UI) sharing the same domain logic
+- **AI agent builders** who need vector search and embedding infrastructure ready out of the box, with MCP server and PydanticAI orchestration coming soon
+- **AI-augmented developers** who use Claude Code or Codex CLI and want a codebase with 14+ built-in AI development skills that work in both tools
 
-- **MCP Server interface** `planned` — Expose domain services as AI agent tools via FastMCP
-- **AI agent orchestration** `planned` — PydanticAI integration for structured LLM workflows
-- **Vector infrastructure** `available` — AWS S3 Vectors + OpenAI/Bedrock embeddings + chunking utilities for semantic search foundations
+---
 
-### Production-Ready Architecture
+## What You Get
 
-- **4 interface types** — HTTP API (FastAPI) + Async Worker (Taskiq) + Admin UI (NiceGUI) + MCP Server (planned)
-- **Zero-boilerplate CRUD** — Inherit `BaseRepository[DTO]` + `BaseService[CreateRequest, UpdateRequest, DTO]` for core async CRUD and pagination helpers
-- **Auto domain discovery** — Add a domain folder, it auto-registers. No container or bootstrap changes needed
-- **Async-first** — Genuine async from DB (asyncpg) to HTTP (aiohttp) to task queue (Taskiq)
-
-### Developer Experience
-
-- **Shared AI rules + tool-specific harnesses** — `AGENTS.md` for common rules, plus Claude and Codex entrypoints
-- **Architecture enforcement** — Pre-commit hooks block `Domain -> Infrastructure` imports at commit time
+- **Zero-boilerplate CRUD** — Inherit `BaseRepository[DTO]` + `BaseService[Create, Update, DTO]`, get 7 async methods instantly
+- **Auto domain discovery** — Add a domain folder, it auto-registers. No container or bootstrap changes
+- **3 interface types** — HTTP API (FastAPI) + Async Worker (Taskiq) + Admin UI (NiceGUI), all sharing one domain layer
+- **Vector infrastructure** — S3 Vectors + OpenAI/Bedrock embeddings + semantic chunking utilities
 - **Type-safe generics** — `BaseRepository[ProductDTO]`, `BaseService[CreateProductRequest, UpdateProductRequest, ProductDTO]`, `SuccessResponse[ProductResponse]`
-- **DDD layered structure** — Each domain is fully independent with its own layers (Domain / Infrastructure / Interface / Application)
-- **Architecture Decision Records** — Major design choices documented with rationale
+- **Architecture enforcement** — Pre-commit hooks block `Domain → Infrastructure` imports at commit time
+- **DynamoDB support** — `BaseDynamoRepository` with cursor-based pagination alongside PostgreSQL
+- **14+ AI development skills** — Works in both Claude Code and Codex CLI: `new-domain`, `add-api`, `onboard`, `review-architecture`, and more ([details](#ai-native-development))
+- **Async-first** — From DB (asyncpg) to HTTP (aiohttp) to task queue (Taskiq)
+- **37 ADRs** — Every technical choice documented with rationale ([view index](docs/history/README.md))
+
+<details>
+<summary><b>Coming soon</b></summary>
+
+- **MCP Server interface** — Expose domain services as AI agent tools via FastMCP ([#18](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/18))
+- **PydanticAI integration** — Structured LLM orchestration with Pydantic-native outputs ([#15](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/15))
+- **pgvector** — Additional vector backend ([#11](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/11))
+
+</details>
+
+---
+
+## Quick Start
+
+```bash
+# 1. Clone
+git clone https://github.com/Mr-DooSun/fastapi-agent-blueprint.git
+cd fastapi-agent-blueprint
+
+# 2. Setup (requires uv)
+make setup
+
+# 3. Set up environment variables
+cp _env/local.env.example _env/local.env
+
+# 4. Start PostgreSQL + run migrations + start server
+make dev
+```
+
+Open http://localhost:8000/docs-swagger to explore the API.
+
+<details>
+<summary>Manual setup (without Make)</summary>
+
+```bash
+# 2. Create virtual environment + install dependencies
+uv venv --python 3.12
+source .venv/bin/activate
+uv sync --group dev
+
+# 3. Set up environment variables
+cp _env/local.env.example _env/local.env
+
+# 4. Start PostgreSQL (Docker)
+docker compose -f docker-compose.local.yml up -d postgres
+
+# 5. Run migrations + start server
+alembic upgrade head
+python run_server_local.py --env local
+```
+</details>
 
 ---
 
@@ -77,7 +129,7 @@ class DocumentService(
 async def analyze_document(document_id: int, service=Depends(...)):
     return await service.analyze(document_id)
 
-# 3. MCP Tool — for AI agents (planned)
+# 3. MCP Tool — for AI agents (coming soon)
 @mcp.tool()
 async def analyze_document(document_id: int) -> AnalysisResult:
     return await document_service.analyze(document_id)
@@ -165,172 +217,93 @@ Read:  Response <-- Service <-- Repository <-- DTO <-- Model
 
 ---
 
-## AI-Native Development (AIDD)
+## Interface Types
 
-This template works great on its own. For AI-native development, the repository uses a **shared rules + shared references + tool-specific harness** structure:
+Each domain can expose functionality through multiple interfaces:
 
-| File | Role |
-|------|------|
-| `AGENTS.md` | Canonical shared rules for all AI tools |
-| `docs/ai/shared/` | Shared workflow references and checklists used by Claude and Codex |
-| `CLAUDE.md` | Claude-specific hooks, plugins, slash skills, and workflow notes |
-| `.mcp.json` | Claude-only MCP server configuration |
-| `.codex/config.toml` | Codex CLI project settings, profiles, features, and MCP configuration |
-| `.codex/hooks.json` | Codex command-hook configuration |
-| `.agents/skills/` | Repo-local Codex workflow skills |
+| Interface | Technology | Status | Purpose |
+|-----------|-----------|--------|---------|
+| **HTTP API** | FastAPI | Stable | REST API endpoints |
+| **Async Worker** | Taskiq + SQS/RabbitMQ/InMemory | Stable | Background task processing |
+| **Admin UI** | NiceGUI | Stable | Auto-discovered admin CRUD dashboard |
+| **MCP Server** | FastMCP | Planned | AI agent tool interface |
 
-### Shared Rules First
+All interfaces share the same Domain and Infrastructure layers -- write your business logic once, expose it everywhere.
 
-All tools should follow `AGENTS.md` for:
-- project scale assumptions
-- absolute prohibitions
-- layer terminology and conversion patterns
-- DTO creation criteria
-- baseline run/test/lint/migration commands
-- documentation drift management principles
+---
 
-Use `docs/ai/shared/` for the deeper workflow references that are too detailed for root `AGENTS.md`, such as `project-dna.md`, planning checklists, review checklists, and test patterns. When running `/sync-guidelines` or `$sync-guidelines`, always close with `project-dna`, `AUTO-FIX`, `REVIEW`, and `Remaining` so manual review items are not silently skipped.
+## AI-Native Development
 
-### Claude Code
+This template includes built-in AI collaboration support for **Claude Code** and **OpenAI Codex CLI**. Both tools share the same architecture rules (`AGENTS.md`) and workflow references (`docs/ai/shared/`), with tool-specific harnesses layered on top.
 
-#### Zero Learning Curve
+| Layer | Claude Code | Codex CLI |
+|-------|------------|-----------|
+| **Shared rules** | `AGENTS.md` | `AGENTS.md` |
+| **Shared references** | `docs/ai/shared/` | `docs/ai/shared/` |
+| **Tool config** | `CLAUDE.md` + `.mcp.json` | `.codex/config.toml` + `.codex/hooks.json` |
+| **Skills** | 14 slash commands (`.claude/skills/`) | 15 workflow skills (`.agents/skills/`) |
+| **Hooks** | PostToolUse auto-format | 6 hooks (format, security, session-start, ...) |
 
-Complex architecture? Type `/onboard` -- it explains everything at your level.
+### Zero Learning Curve
 
-The `/onboard` skill adapts to your experience and learning style:
+Complex architecture? Type `/onboard` (Claude) or `$onboard` (Codex) -- it explains everything at your level.
+
+The onboard skill adapts to your experience and learning style:
 - **Beginner / Intermediate / Advanced** -- depth adjusts to your level
 - **Guided** -- structured Phase-by-Phase walkthrough
 - **Q&A** -- topic maps provided, explore by asking questions
 - **Explore** -- point at any code freely, uncovered essentials flagged at the end
 
-#### 14 Built-in Skills
+### Built-in Skills
 
-| Command | What it does |
-|---------|------------|
-| `/onboard` | Interactive onboarding -- adapts to your experience level and learning style |
-| `/new-domain {name}` | Scaffold an entire domain (21+ source files + tests) |
-| `/add-api {description}` | Add API endpoint to existing domain |
-| `/add-worker-task {domain} {task}` | Add async Taskiq background task |
-| `/add-admin-page {domain}` | Add a NiceGUI admin page to an existing domain |
-| `/add-cross-domain from:{a} to:{b}` | Wire cross-domain dependency via Protocol DIP |
-| `/plan-feature {description}` | Requirements interview -> architecture -> security -> task breakdown |
-| `/review-architecture {domain}` | Architecture compliance audit (20+ checks) |
-| `/security-review {domain}` | OWASP-based security audit |
-| `/test-domain {domain}` | Generate or run domain tests |
-| `/fix-bug {description}` | Structured bug fixing workflow |
-| `/review-pr {number}` | Architecture-aware PR review |
-| `/sync-guidelines` | Sync docs after design changes; report both AUTO-FIX and REVIEW targets before closing |
-| `/migrate-domain {command}` | Alembic migration management |
+All skills work in both Claude Code (`/` prefix) and Codex CLI (`$` prefix):
 
-#### Plugin Setup (Required)
+| Skill | What it does |
+|-------|------------|
+| `onboard` | Interactive onboarding -- adapts to your experience level and learning style |
+| `new-domain {name}` | Scaffold an entire domain (21+ source files + tests) |
+| `add-api {description}` | Add API endpoint to existing domain |
+| `add-worker-task {domain} {task}` | Add async Taskiq background task |
+| `add-admin-page {domain}` | Add a NiceGUI admin page to an existing domain |
+| `add-cross-domain from:{a} to:{b}` | Wire cross-domain dependency via Protocol DIP |
+| `plan-feature {description}` | Requirements interview -> architecture -> security -> task breakdown |
+| `review-architecture {domain}` | Architecture compliance audit (20+ checks) |
+| `security-review {domain}` | OWASP-based security audit |
+| `test-domain {domain}` | Generate or run domain tests |
+| `fix-bug {description}` | Structured bug fixing workflow |
+| `review-pr {number}` | Architecture-aware PR review |
+| `sync-guidelines` | Sync docs after design changes |
+| `migrate-domain {command}` | Alembic migration management |
 
-Install the pyright-lsp plugin for code intelligence (symbol navigation, references, diagnostics):
-
-```bash
-uv sync                              # installs pyright binary as dev dependency
-claude plugin install pyright-lsp    # installs Claude Code plugin
-```
-
-> `enabledPlugins` in `.claude/settings.json` will prompt installation automatically on first run.
-
-#### MCP Server Setup (`.mcp.json`)
-
-**context7** -- Up-to-date library documentation
-```json
-{
-  "mcpServers": {
-    "context7": {
-      "url": "https://mcp.context7.com/mcp"
-    }
-  }
-}
-```
-
-> `.mcp.json` is the Claude-side MCP entrypoint. The project works without MCP servers, but Claude skills expect this configuration.
-
-### Codex CLI
-
-Codex uses the committed project config in `.codex/config.toml`:
-
-```toml
-sandbox_mode = "workspace-write"
-approval_policy = "on-request"
-web_search = "disabled"
-
-[features]
-codex_hooks = true
-
-[profiles.research]
-web_search = "live"
-
-[mcp_servers.context7]
-url = "https://mcp.context7.com/mcp"
-```
-
-> Codex uses the remote Context7 MCP endpoint so documentation lookups are not blocked by the sandboxed network restrictions that apply to locally spawned stdio servers.
-
-Codex's repository workflow layer is split across:
-- `.codex/config.toml` for base config and profiles
-- `.codex/hooks.json` plus `.codex/hooks/` for command hooks
-- `.agents/skills/` for repo-local workflows such as `$onboard`, `$plan-feature`, `$review-pr`
-- `docs/ai/shared/` for shared references that both Claude and Codex consume
-
-Recommended verification flow:
-1. Trust the project in Codex.
-2. Run `codex mcp list` and `codex mcp get context7`.
-3. Run `codex debug prompt-input -c 'project_doc_max_bytes=400' "healthcheck" | rg "Shared Collaboration Rules|AGENTS\\.md"` and confirm `AGENTS.md` is included in the prompt input.
-4. Use `codex -p research` or `codex --search` only when live web search is actually required.
-5. Treat Codex memories as personal/session optimization only, not as team-shared governance.
-
-> `.codex/config.toml` is the Codex-side harness entrypoint. Web search is disabled by default; enable it explicitly only when you need live external information.
+> For plugin setup, MCP server configuration, and Codex CLI details, see the [AI Development Guide](docs/ai-development.md).
 
 ---
 
-## Quick Start
+## Comparison
 
-```bash
-# 1. Clone
-git clone https://github.com/Mr-DooSun/fastapi-agent-blueprint.git
-cd fastapi-agent-blueprint
-
-# 2. Setup (requires uv)
-make setup
-
-# 3. Set up environment variables
-cp _env/local.env.example _env/local.env
-
-# 4. Start PostgreSQL + run migrations + start server
-make dev
-```
-
-Open http://localhost:8000/docs-swagger to explore the API.
-
-<details>
-<summary>Manual setup (without Make)</summary>
-
-```bash
-# 2. Create virtual environment + install dependencies
-uv venv --python 3.12
-source .venv/bin/activate
-uv sync --group dev
-
-# 3. Set up environment variables
-cp _env/local.env.example _env/local.env
-
-# 4. Start PostgreSQL (Docker)
-docker compose -f docker-compose.local.yml up -d postgres
-
-# 5. Run migrations + start server
-alembic upgrade head
-python run_server_local.py --env local
-```
-</details>
+| Feature | FastAPI Agent Blueprint | [tiangolo/full-stack](https://github.com/fastapi/full-stack-fastapi-template) | [s3rius/template](https://github.com/s3rius/FastAPI-template) | [teamhide/boilerplate](https://github.com/teamhide/fastapi-boilerplate) |
+|---------|:-:|:-:|:-:|:-:|
+| Zero-boilerplate CRUD (7 methods) | **Yes** | No | No | No |
+| Auto domain discovery | **Yes** | No | No | No |
+| Architecture enforcement (pre-commit) | **Yes** | No | No | No |
+| AI workflow skills (Claude + Codex) | **14+** | 0 | 0 | 0 |
+| Vector infrastructure (S3 Vectors) | **Yes** | No | No | No |
+| Adaptive onboarding (`/onboard`) | **Yes** | No | No | No |
+| Multi-interface (API+Worker+Admin+MCP) | **3+1 planned** | 2 | 1 | 1 |
+| Architecture Decision Records | **37** | 0 | 0 | 0 |
+| Type-safe generics across layers | **Yes** | Partial | Partial | No |
+| DI with IoC Container | **Yes** | No | No | No |
+| MCP Server interface | **Planned** | No | No | No |
+| AI orchestration (PydanticAI) | **Planned** | No | No | No |
 
 ---
 
 ## Adding a New Domain
 
-Using `Product` domain as an example:
+> With Claude Code, just run `/new-domain product` to scaffold all of this automatically.
+
+<details>
+<summary>Manual steps (Product domain example)</summary>
 
 ### 1. Domain Layer
 
@@ -403,35 +376,25 @@ Discovery conditions:
 - `src/{name}/__init__.py` exists
 - `src/{name}/infrastructure/di/{name}_container.py` exists
 
-> With Claude Code, just run `/new-domain product` to scaffold all of this automatically.
-
----
-
-## 4 Interface Types
-
-Each domain can expose functionality through multiple interfaces:
-
-| Interface | Technology | Status | Purpose |
-|-----------|-----------|--------|---------|
-| **HTTP API** | FastAPI | Stable | REST API endpoints |
-| **Async Worker** | Taskiq + SQS/RabbitMQ/InMemory | Stable | Background task processing |
-| **Admin UI** | NiceGUI | Stable | Auto-discovered admin CRUD dashboard |
-| **MCP Server** | FastMCP | Planned | AI agent tool interface |
-
-All interfaces share the same Domain and Infrastructure layers -- write your business logic once, expose it everywhere.
+</details>
 
 ---
 
 ## Tech Stack
 
-### AI & Agent `planned`
+FastAPI + SQLAlchemy 2.0 + Pydantic 2.x + dependency-injector + Taskiq + NiceGUI + asyncpg + aioboto3
 
-| Technology | Purpose |
-|-----------|---------|
-| **FastMCP** | MCP server — expose domain services as tools for AI agents |
-| **PydanticAI** | Structured LLM orchestration with Pydantic-native outputs |
-| **AWS S3 Vectors** | Managed vector index backend for semantic search infrastructure |
-| **OpenAI / Bedrock Embeddings** | Pluggable embedding backends selected by configuration |
+<details>
+<summary>Full stack details</summary>
+
+### AI & Agent
+
+| Technology | Purpose | Status |
+|-----------|---------|--------|
+| **AWS S3 Vectors** | Managed vector index backend for semantic search infrastructure | Available |
+| **OpenAI / Bedrock Embeddings** | Pluggable embedding backends selected by configuration | Available |
+| **FastMCP** | MCP server — expose domain services as tools for AI agents | Planned |
+| **PydanticAI** | Structured LLM orchestration with Pydantic-native outputs | Planned |
 
 ### Core
 
@@ -462,9 +425,14 @@ All interfaces share the same Domain and Infrastructure layers -- write your bus
 | **UV** | Python package management ([why not Poetry?](docs/history/005-poetry-to-uv.md)) |
 | **NiceGUI** | Admin dashboard UI |
 
+</details>
+
 ---
 
 ## Project Structure
+
+<details>
+<summary>View full project tree</summary>
 
 ```
 src/
@@ -512,30 +480,16 @@ src/
 └── docs/history/                 # Architecture Decision Records
 ```
 
----
-
-## Comparison
-
-| Feature | FastAPI Agent Blueprint | [tiangolo/full-stack](https://github.com/fastapi/full-stack-fastapi-template) | [s3rius/template](https://github.com/s3rius/FastAPI-template) | [teamhide/boilerplate](https://github.com/teamhide/fastapi-boilerplate) |
-|---------|:-:|:-:|:-:|:-:|
-| MCP Server interface | **Planned** | No | No | No |
-| AI orchestration (PydanticAI) | **Planned** | No | No | No |
-| Vector infrastructure (S3 Vectors) | **Yes** | No | No | No |
-| Zero-boilerplate CRUD (7 methods) | **Yes** | No | No | No |
-| Auto domain discovery | **Yes** | No | No | No |
-| Architecture enforcement (pre-commit) | **Yes** | No | No | No |
-| AI workflow skills | **14** | 0 | 0 | 0 |
-| Adaptive onboarding (`/onboard`) | **Yes** | No | No | No |
-| Multi-interface (API+Worker+Admin+MCP) | **4 types** | 2 | 1 | 1 |
-| Architecture Decision Records | **32** | 0 | 0 | 0 |
-| Type-safe generics across layers | **Yes** | Partial | Partial | No |
-| DI with IoC Container | **Yes** | No | No | No |
+</details>
 
 ---
 
 ## Architecture Decisions
 
-Every technical choice in this project is documented as an ADR (Architecture Decision Record).
+Every technical choice in this project is documented as an ADR (Architecture Decision Record). [View all 37 ADRs →](docs/history/README.md)
+
+<details>
+<summary>Key decisions</summary>
 
 | # | Title |
 |---|-------|
@@ -546,7 +500,7 @@ Every technical choice in this project is documented as an ADR (Architecture Dec
 | [012](docs/history/012-ruff-migration.md) | Ruff adoption |
 | [013](docs/history/013-why-ioc-container.md) | Why IoC Container over inheritance |
 
-[View ADR index](docs/history/README.md)
+</details>
 
 ---
 
@@ -576,8 +530,8 @@ Every technical choice in this project is documented as an ADR (Architecture Dec
 - [x] Health check endpoint
 - [x] Auto domain discovery
 - [x] Architecture enforcement (pre-commit)
-- [x] 14 Claude Code skills
-- [x] Codex CLI workflow layer (`.codex/config.toml`, `.codex/hooks.json`, `.agents/skills/`)
+- [x] 14+ AI development skills for Claude Code and Codex CLI
+- [x] Codex CLI workflow layer (`.codex/config.toml`, `.codex/hooks.json`, `.agents/skills/`, 6 hooks)
 
 Star this repo to follow our progress!
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -14,46 +14,99 @@
   <a href="https://fastapi.tiangolo.com"><img src="https://img.shields.io/badge/FastAPI-0.115+-green.svg" alt="FastAPI"></a>
   <a href="../LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License"></a>
   <a href="https://github.com/astral-sh/ruff"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json" alt="Ruff"></a>
+  <a href="https://github.com/Mr-DooSun/fastapi-agent-blueprint/stargazers"><img src="https://img.shields.io/github/stars/Mr-DooSun/fastapi-agent-blueprint?style=social" alt="GitHub Stars"></a>
 </p>
 
 <p align="center">
-  <b>FastAPI 기반 AI 에이전트 백엔드 플랫폼.</b><br>
-  MCP 서버 + AI 오케스트레이션 + 비동기 DDD — CRUD부터 에이전트 도구까지 하나의 코드베이스로.<br>
-  사용자와 AI 에이전트 모두를 위한 백엔드를 구축하세요.
+  <b>FastAPI DDD 템플릿, AI 에이전트 백엔드를 위해 설계.</b><br>
+  보일러플레이트 제로 CRUD + 자동 도메인 발견 + 벡터 검색 인프라. MCP 서버 + AI 오케스트레이션 곧 출시.<br>
+  Claude Code &amp; Codex CLI용 14+ AI 개발 스킬 내장.
 </p>
 
 <p align="center">
-  <a href="#빠른-시작">빠른 시작</a> · <a href="#아키텍처">아키텍처</a> · <a href="#ai-네이티브-개발-aidd">AI 네이티브 개발</a> · <a href="#비교">비교</a> · <a href="../README.md">English</a>
+  <a href="#빠른-시작">빠른 시작</a> · <a href="#이-프로젝트는-누구를-위한-것인가요">누구를 위한 것?</a> · <a href="#아키텍처">아키텍처</a> · <a href="#비교">비교</a> · <a href="../README.md">English</a>
 </p>
 
-<!-- TODO: 데모 GIF 추가
-![Demo](assets/demo.gif)
--->
+<p align="center">
+  <a href="https://github.com/Mr-DooSun/fastapi-agent-blueprint/generate">
+    <img src="https://img.shields.io/badge/-Use%20this%20template-2ea44f?style=for-the-badge" alt="Use this template">
+  </a>
+</p>
 
 ---
 
-## 주요 기능
+## 이 프로젝트는 누구를 위한 것인가요?
 
-### AI 에이전트 플랫폼
+- **FastAPI 개발자** — 튜토리얼 수준을 넘어 프로덕션 프로젝트 구조가 필요한 분 (DDD 레이어, DI 컨테이너, 전면 async, 아키텍처 자동 강제)
+- **백엔드 팀** — REST API + 백그라운드 워커 + 어드민 UI가 동일한 도메인 로직을 공유해야 하는 시스템을 만드는 분
+- **AI 에이전트 빌더** — 벡터 검색과 임베딩 인프라가 즉시 사용 가능하고, MCP 서버와 PydanticAI 오케스트레이션이 곧 추가될 기반이 필요한 분
+- **AI 기반 개발자** — Claude Code나 Codex CLI를 사용하며 두 도구 모두에서 작동하는 14+개의 내장 AI 개발 스킬이 있는 코드베이스를 원하는 분
 
-- **MCP 서버 인터페이스** `planned` — FastMCP를 통해 도메인 서비스를 AI 에이전트 도구로 노출
-- **AI 에이전트 오케스트레이션** `planned` — 구조화된 LLM 워크플로우를 위한 PydanticAI 통합
-- **벡터 인프라** `available` — AWS S3 Vectors + OpenAI/Bedrock 임베딩 + chunking 유틸리티로 시맨틱 검색 기반 제공
+---
 
-### 프로덕션 레디 아키텍처
+## 제공 기능
 
-- **4가지 인터페이스** — HTTP API (FastAPI) + 비동기 Worker (Taskiq) + Admin UI (NiceGUI) + MCP Server (예정)
-- **보일러플레이트 제로 CRUD** — `BaseRepository[DTO]` + `BaseService[CreateRequest, UpdateRequest, DTO]` 상속으로 핵심 비동기 CRUD와 pagination helper 즉시 제공
+- **보일러플레이트 제로 CRUD** — `BaseRepository[DTO]` + `BaseService[Create, Update, DTO]` 상속으로 7개 비동기 메서드 즉시 제공
 - **도메인 자동 발견** — 도메인 폴더를 추가하면 자동 등록. Container나 bootstrap 수정 불필요
-- **비동기 우선** — DB(asyncpg)부터 HTTP(aiohttp), 태스크 큐(Taskiq)까지 진정한 async
-
-### 개발자 경험
-
-- **공통 규칙 + 도구별 하네스** — `AGENTS.md`, Claude 스킬, Codex CLI 설정으로 AI 협업 구조화
-- **아키텍처 자동 강제** — Pre-commit hook이 커밋 시점에 `Domain -> Infrastructure` import를 차단
+- **3가지 인터페이스** — HTTP API (FastAPI) + 비동기 Worker (Taskiq) + Admin UI (NiceGUI), 하나의 도메인 레이어 공유
+- **벡터 인프라** — S3 Vectors + OpenAI/Bedrock 임베딩 + 시맨틱 chunking 유틸리티
 - **타입 안전 제네릭** — `BaseRepository[ProductDTO]`, `BaseService[CreateProductRequest, UpdateProductRequest, ProductDTO]`, `SuccessResponse[ProductResponse]`
-- **DDD 레이어드 구조** — 각 도메인이 완전히 독립된 계층 보유 (Domain / Infrastructure / Interface / Application)
-- **Architecture Decision Records** — 주요 설계 결정을 근거와 함께 문서화
+- **아키텍처 자동 강제** — Pre-commit hook이 커밋 시점에 `Domain → Infrastructure` import 차단
+- **DynamoDB 지원** — 커서 기반 pagination의 `BaseDynamoRepository`, PostgreSQL과 병행 사용
+- **14+ AI 개발 스킬** — Claude Code와 Codex CLI 모두 지원: `new-domain`, `add-api`, `onboard`, `review-architecture` 등 ([상세](#ai-네이티브-개발))
+- **비동기 우선** — DB(asyncpg)부터 HTTP(aiohttp), 태스크 큐(Taskiq)까지
+- **37개 ADR** — 모든 기술 선택을 근거와 함께 문서화 ([인덱스 보기](../docs/history/README.md))
+
+<details>
+<summary><b>Coming soon</b></summary>
+
+- **MCP 서버 인터페이스** — FastMCP를 통해 도메인 서비스를 AI 에이전트 도구로 노출 ([#18](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/18))
+- **PydanticAI 통합** — Pydantic 네이티브 출력의 구조화된 LLM 오케스트레이션 ([#15](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/15))
+- **pgvector** — 추가 벡터 백엔드 ([#11](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/11))
+
+</details>
+
+---
+
+## 빠른 시작
+
+```bash
+# 1. Clone
+git clone https://github.com/Mr-DooSun/fastapi-agent-blueprint.git
+cd fastapi-agent-blueprint
+
+# 2. 셋업 (uv 필요)
+make setup
+
+# 3. 환경변수 설정
+cp _env/local.env.example _env/local.env
+
+# 4. PostgreSQL 실행 + 마이그레이션 + 서버 시작
+make dev
+```
+
+http://localhost:8000/docs-swagger 에서 API를 확인하세요.
+
+<details>
+<summary>수동 설정 (Make 미사용)</summary>
+
+```bash
+# 2. 가상환경 + 의존성 설치
+uv venv --python 3.12
+source .venv/bin/activate
+uv sync --group dev
+
+# 3. 환경변수 설정
+cp _env/local.env.example _env/local.env
+
+# 4. PostgreSQL 실행 (Docker)
+docker compose -f docker-compose.local.yml up -d postgres
+
+# 5. 마이그레이션 + 서버 실행
+alembic upgrade head
+python run_server_local.py --env local
+```
+</details>
 
 ---
 
@@ -76,7 +129,7 @@ class DocumentService(
 async def analyze_document(document_id: int, service=Depends(...)):
     return await service.analyze(document_id)
 
-# 3. MCP 도구 — AI 에이전트용 (예정)
+# 3. MCP 도구 — AI 에이전트용 (coming soon)
 @mcp.tool()
 async def analyze_document(document_id: int) -> AnalysisResult:
     return await document_service.analyze(document_id)
@@ -164,171 +217,93 @@ Read:  Response <-- Service <-- Repository <-- DTO <-- Model
 
 ---
 
-## AI 네이티브 개발 (AIDD)
+## 인터페이스 타입
 
-이 템플릿은 단독으로도 충분히 사용할 수 있습니다. 이제 AI 협업 구조는 **공통 규칙 + 공통 레퍼런스 + 도구별 하네스**로 정리되어 있습니다.
+각 도메인은 여러 인터페이스를 통해 기능을 노출할 수 있습니다:
 
-| 파일 | 역할 |
-|------|------|
-| `AGENTS.md` | 모든 AI 도구가 따라야 하는 공통 규칙의 canonical source |
-| `docs/ai/shared/` | Claude와 Codex가 함께 읽는 공통 workflow 레퍼런스와 체크리스트 |
-| `CLAUDE.md` | Claude 전용 hooks, plugins, slash skills, workflow 안내 |
-| `.mcp.json` | Claude 전용 MCP 설정 |
-| `.codex/config.toml` | Codex CLI 전용 프로젝트 설정, profile, feature, MCP 구성 |
-| `.codex/hooks.json` | Codex 명령 훅 설정 |
-| `.agents/skills/` | repo-local Codex workflow skill |
+| 인터페이스 | 기술 | 상태 | 용도 |
+|-----------|------|------|------|
+| **HTTP API** | FastAPI | Stable | REST API 엔드포인트 |
+| **비동기 Worker** | Taskiq + SQS/RabbitMQ/InMemory | Stable | 백그라운드 태스크 처리 |
+| **Admin UI** | NiceGUI | Stable | 자동 발견 기반 admin CRUD 대시보드 |
+| **MCP Server** | FastMCP | Planned | AI 에이전트 도구 인터페이스 |
 
-### 공통 규칙 우선
-
-모든 도구는 먼저 `AGENTS.md`를 기준으로 다음을 따른다:
-- 프로젝트 규모 전제
-- 절대 금지 규칙
-- 레이어 용어와 conversion pattern
-- DTO 생성 기준
-- 기본 run/test/lint/migration 명령
-- 문서와 규칙 drift 관리 원칙
-
-루트 `AGENTS.md`에 다 담기 어려운 workflow 세부사항은 `docs/ai/shared/`에 둡니다. 예: `project-dna.md`, planning/security/review checklist, test pattern. `/sync-guidelines` 또는 `$sync-guidelines`를 실행할 때는 수동 검토 항목이 빠지지 않도록 최종 결과에 `project-dna`, `AUTO-FIX`, `REVIEW`, `Remaining`를 모두 명시해야 합니다.
-
-### Claude Code
-
-#### 러닝 커브 제로
-
-복잡한 아키텍처? `/onboard`를 입력하세요 -- 당신의 수준에 맞춰 모든 것을 설명해줍니다.
-
-`/onboard` 스킬은 경험 수준에 따라 적응합니다:
-- **초급**: DDD 개념을 쉬운 비유로 설명
-- **중급**: 이 프로젝트 고유의 패턴에 집중
-- **고급**: 아키텍처 규칙과 컨벤션으로 바로 이동
-
-#### 14개 내장 스킬
-
-| 명령어 | 기능 |
-|--------|------|
-| `/onboard` | 대화형 온보딩 -- 경험 수준에 맞춰 적응 |
-| `/new-domain {name}` | 도메인 전체 스캐폴딩 (21개 이상 소스 파일 + 테스트) |
-| `/add-api {description}` | 기존 도메인에 API 엔드포인트 추가 |
-| `/add-worker-task {domain} {task}` | 비동기 Taskiq 백그라운드 태스크 추가 |
-| `/add-admin-page {domain}` | 기존 도메인에 NiceGUI admin 페이지 추가 |
-| `/add-cross-domain from:{a} to:{b}` | Protocol DIP를 통한 도메인 간 의존성 연결 |
-| `/plan-feature {description}` | 요구사항 인터뷰 -> 아키텍처 -> 보안 -> 태스크 분해 |
-| `/review-architecture {domain}` | 아키텍처 컴플라이언스 감사 (20개 이상 검사) |
-| `/security-review {domain}` | OWASP 기반 보안 감사 |
-| `/test-domain {domain}` | 도메인 테스트 생성 또는 실행 |
-| `/fix-bug {description}` | 구조화된 버그 수정 워크플로우 |
-| `/review-pr {number}` | 아키텍처 인식 PR 리뷰 |
-| `/sync-guidelines` | 설계 변경 후 문서 동기화, 종료 전에 AUTO-FIX와 REVIEW를 모두 보고 |
-| `/migrate-domain {command}` | Alembic 마이그레이션 관리 |
-
-#### 플러그인 설정 (필수)
-
-코드 인텔리전스(심볼 탐색, 참조 추적, 진단)를 위해 pyright-lsp 플러그인을 설치하세요:
-
-```bash
-uv sync                              # pyright 바이너리 설치 (dev 의존성)
-claude plugin install pyright-lsp    # Claude Code 플러그인 설치
-```
-
-> `.claude/settings.json`의 `enabledPlugins`가 첫 실행 시 자동으로 설치를 안내합니다.
-
-#### MCP 서버 설정 (`.mcp.json`)
-
-**context7** -- 라이브러리 최신 문서 조회
-```json
-{
-  "mcpServers": {
-    "context7": {
-      "url": "https://mcp.context7.com/mcp"
-    }
-  }
-}
-```
-
-> `.mcp.json`은 Claude 측 MCP 진입점입니다. MCP 서버 없이도 프로젝트 자체는 정상 동작하지만, Claude 스킬은 이 설정을 기대합니다.
-
-### Codex CLI
-
-Codex는 `.codex/config.toml`의 project-shared 설정을 사용합니다:
-
-```toml
-sandbox_mode = "workspace-write"
-approval_policy = "on-request"
-web_search = "disabled"
-
-[features]
-codex_hooks = true
-
-[profiles.research]
-web_search = "live"
-
-[mcp_servers.context7]
-url = "https://mcp.context7.com/mcp"
-```
-
-> Codex는 원격 Context7 MCP 엔드포인트를 사용합니다. 로컬 stdio 서버(npx) 방식은 샌드박스 네트워크 제한에 의해 차단되므로, HTTP 전송 방식을 사용합니다.
-
-Codex의 레포 workflow layer는 다음으로 나뉩니다:
-- `.codex/config.toml` — base config와 profile
-- `.codex/hooks.json` + `.codex/hooks/` — command hook
-- `.agents/skills/` — `$onboard`, `$plan-feature`, `$review-pr` 같은 repo-local workflow
-- `docs/ai/shared/` — Claude/Codex 공통 reference
-
-권장 검증 흐름:
-1. Codex에서 이 프로젝트를 trusted 상태로 만든다.
-2. `codex mcp list`, `codex mcp get context7`를 실행한다.
-3. `codex debug prompt-input -c 'project_doc_max_bytes=400' "healthcheck" | rg "Shared Collaboration Rules|AGENTS\\.md"`로 `AGENTS.md`가 실제 prompt input에 포함되는지 확인한다.
-4. 최신 외부 정보가 정말 필요할 때만 `codex -p research` 또는 `codex --search`를 사용한다.
-5. Codex memories는 개인/세션 최적화용으로만 보고, 팀 규칙 저장소로 쓰지 않는다.
-
-> `.codex/config.toml`은 Codex 측 하네스 진입점입니다. 웹 검색은 기본 비활성화되어 있으므로, 최신 외부 정보가 필요할 때만 명시적으로 활성화하세요.
+모든 인터페이스는 동일한 Domain/Infrastructure 계층을 공유합니다 -- 비즈니스 로직을 한 번 작성하고, 어디서든 노출하세요.
 
 ---
 
-## 빠른 시작
+## AI 네이티브 개발
 
-```bash
-# 1. Clone
-git clone https://github.com/Mr-DooSun/fastapi-agent-blueprint.git
-cd fastapi-agent-blueprint
+이 템플릿은 **Claude Code**와 **OpenAI Codex CLI**를 위한 AI 협업 지원이 내장되어 있습니다. 두 도구 모두 동일한 아키텍처 규칙(`AGENTS.md`)과 workflow 레퍼런스(`docs/ai/shared/`)를 공유하며, 도구별 하네스가 그 위에 레이어됩니다.
 
-# 2. 셋업 (uv 필요)
-make setup
+| 레이어 | Claude Code | Codex CLI |
+|--------|------------|-----------|
+| **공통 규칙** | `AGENTS.md` | `AGENTS.md` |
+| **공통 레퍼런스** | `docs/ai/shared/` | `docs/ai/shared/` |
+| **도구 설정** | `CLAUDE.md` + `.mcp.json` | `.codex/config.toml` + `.codex/hooks.json` |
+| **스킬** | 14개 slash 명령 (`.claude/skills/`) | 15개 workflow 스킬 (`.agents/skills/`) |
+| **훅** | PostToolUse 자동 포맷 | 6개 훅 (format, security, session-start, ...) |
 
-# 3. 환경변수 설정
-cp _env/local.env.example _env/local.env
+### 러닝 커브 제로
 
-# 4. PostgreSQL 실행 + 마이그레이션 + 서버 시작
-make dev
-```
+복잡한 아키텍처? `/onboard` (Claude) 또는 `$onboard` (Codex)를 입력하세요 -- 당신의 수준에 맞춰 모든 것을 설명해줍니다.
 
-http://localhost:8000/docs-swagger 에서 API를 확인하세요.
+onboard 스킬은 경험 수준에 따라 적응합니다:
+- **초급 / 중급 / 고급** -- 수준에 맞게 깊이 조절
+- **가이드** -- Phase별 구조화된 안내
+- **Q&A** -- 토픽 맵 제공, 질문으로 탐색
+- **탐험** -- 자유롭게 코드를 살펴보고, 놓친 핵심은 마지막에 정리
 
-<details>
-<summary>수동 설정 (Make 미사용)</summary>
+### 내장 스킬
 
-```bash
-# 2. 가상환경 + 의존성 설치
-uv venv --python 3.12
-source .venv/bin/activate
-uv sync --group dev
+모든 스킬은 Claude Code (`/` 접두사)와 Codex CLI (`$` 접두사) 모두에서 사용 가능합니다:
 
-# 3. 환경변수 설정
-cp _env/local.env.example _env/local.env
+| 스킬 | 기능 |
+|------|------|
+| `onboard` | 대화형 온보딩 -- 경험 수준에 맞춰 적응 |
+| `new-domain {name}` | 도메인 전체 스캐폴딩 (21개 이상 소스 파일 + 테스트) |
+| `add-api {description}` | 기존 도메인에 API 엔드포인트 추가 |
+| `add-worker-task {domain} {task}` | 비동기 Taskiq 백그라운드 태스크 추가 |
+| `add-admin-page {domain}` | 기존 도메인에 NiceGUI admin 페이지 추가 |
+| `add-cross-domain from:{a} to:{b}` | Protocol DIP를 통한 도메인 간 의존성 연결 |
+| `plan-feature {description}` | 요구사항 인터뷰 -> 아키텍처 -> 보안 -> 태스크 분해 |
+| `review-architecture {domain}` | 아키텍처 컴플라이언스 감사 (20개 이상 검사) |
+| `security-review {domain}` | OWASP 기반 보안 감사 |
+| `test-domain {domain}` | 도메인 테스트 생성 또는 실행 |
+| `fix-bug {description}` | 구조화된 버그 수정 워크플로우 |
+| `review-pr {number}` | 아키텍처 인식 PR 리뷰 |
+| `sync-guidelines` | 설계 변경 후 문서 동기화 |
+| `migrate-domain {command}` | Alembic 마이그레이션 관리 |
 
-# 4. PostgreSQL 실행 (Docker)
-docker compose -f docker-compose.local.yml up -d postgres
+> 플러그인 설정, MCP 서버 구성, Codex CLI 상세는 [AI 개발 가이드](ai-development.ko.md)를 참고하세요.
 
-# 5. 마이그레이션 + 서버 실행
-alembic upgrade head
-python run_server_local.py --env local
-```
-</details>
+---
+
+## 비교
+
+| 기능 | FastAPI Agent Blueprint | [tiangolo/full-stack](https://github.com/fastapi/full-stack-fastapi-template) | [s3rius/template](https://github.com/s3rius/FastAPI-template) | [teamhide/boilerplate](https://github.com/teamhide/fastapi-boilerplate) |
+|------|:-:|:-:|:-:|:-:|
+| 보일러플레이트 제로 CRUD (7개 메서드) | **Yes** | No | No | No |
+| 도메인 자동 발견 | **Yes** | No | No | No |
+| 아키텍처 자동 강제 (pre-commit) | **Yes** | No | No | No |
+| AI 개발 스킬 (Claude + Codex) | **14+** | 0 | 0 | 0 |
+| 벡터 인프라 (S3 Vectors) | **Yes** | No | No | No |
+| 적응형 온보딩 (`/onboard`) | **Yes** | No | No | No |
+| 멀티 인터페이스 (API+Worker+Admin+MCP) | **3+1 예정** | 2 | 1 | 1 |
+| Architecture Decision Records | **37** | 0 | 0 | 0 |
+| 전 계층 타입 안전 제네릭 | **Yes** | 부분 | 부분 | No |
+| IoC Container DI | **Yes** | No | No | No |
+| MCP 서버 인터페이스 | **Planned** | No | No | No |
+| AI 오케스트레이션 (PydanticAI) | **Planned** | No | No | No |
 
 ---
 
 ## 새 도메인 추가하기
 
-Product 도메인을 예로 들면:
+> Claude Code를 사용하면 `/new-domain product` 한 줄로 위 모든 파일을 자동 생성할 수 있습니다.
+
+<details>
+<summary>수동 추가 방법 (Product 도메인 예시)</summary>
 
 ### 1. Domain Layer
 
@@ -401,35 +376,25 @@ async def create_product(
 - `src/{name}/__init__.py` 존재
 - `src/{name}/infrastructure/di/{name}_container.py` 존재
 
-> Claude Code를 사용하면 `/new-domain product` 한 줄로 위 모든 파일을 자동 생성할 수 있습니다.
-
----
-
-## 4가지 인터페이스
-
-각 도메인은 여러 인터페이스를 통해 기능을 노출할 수 있습니다:
-
-| 인터페이스 | 기술 | 상태 | 용도 |
-|-----------|------|------|------|
-| **HTTP API** | FastAPI | Stable | REST API 엔드포인트 |
-| **비동기 Worker** | Taskiq + SQS/RabbitMQ/InMemory | Stable | 백그라운드 태스크 처리 |
-| **Admin UI** | NiceGUI | Stable | 자동 발견 기반 admin CRUD 대시보드 |
-| **MCP Server** | FastMCP | Planned | AI 에이전트 도구 인터페이스 |
-
-모든 인터페이스는 동일한 Domain/Infrastructure 계층을 공유합니다 -- 비즈니스 로직을 한 번 작성하고, 어디서든 노출하세요.
+</details>
 
 ---
 
 ## Tech Stack
 
-### AI & Agent `planned`
+FastAPI + SQLAlchemy 2.0 + Pydantic 2.x + dependency-injector + Taskiq + NiceGUI + asyncpg + aioboto3
 
-| 기술 | 용도 |
-|------|------|
-| **FastMCP** | MCP 서버 — 도메인 서비스를 AI 에이전트 도구로 노출 |
-| **PydanticAI** | Pydantic 네이티브 출력의 구조화된 LLM 오케스트레이션 |
-| **AWS S3 Vectors** | 시맨틱 검색 인프라를 위한 관리형 벡터 인덱스 백엔드 |
-| **OpenAI / Bedrock Embeddings** | 설정으로 선택하는 플러그형 임베딩 백엔드 |
+<details>
+<summary>상세 스택</summary>
+
+### AI & Agent
+
+| 기술 | 용도 | 상태 |
+|------|------|------|
+| **AWS S3 Vectors** | 시맨틱 검색 인프라를 위한 관리형 벡터 인덱스 백엔드 | Available |
+| **OpenAI / Bedrock Embeddings** | 설정으로 선택하는 플러그형 임베딩 백엔드 | Available |
+| **FastMCP** | MCP 서버 — 도메인 서비스를 AI 에이전트 도구로 노출 | Planned |
+| **PydanticAI** | Pydantic 네이티브 출력의 구조화된 LLM 오케스트레이션 | Planned |
 
 ### Core
 
@@ -460,9 +425,14 @@ async def create_product(
 | **UV** | Python 패키지 관리 ([왜 Poetry가 아닌가?](../docs/history/005-poetry-to-uv.md)) |
 | **NiceGUI** | Admin 대시보드 UI |
 
+</details>
+
 ---
 
 ## 프로젝트 구조
+
+<details>
+<summary>전체 프로젝트 트리 보기</summary>
 
 ```
 src/
@@ -510,30 +480,16 @@ src/
 └── docs/history/                 # Architecture Decision Records
 ```
 
----
-
-## 비교
-
-| 기능 | FastAPI Agent Blueprint | [tiangolo/full-stack](https://github.com/fastapi/full-stack-fastapi-template) | [s3rius/template](https://github.com/s3rius/FastAPI-template) | [teamhide/boilerplate](https://github.com/teamhide/fastapi-boilerplate) |
-|------|:-:|:-:|:-:|:-:|
-| MCP 서버 인터페이스 | **Planned** | No | No | No |
-| AI 오케스트레이션 (PydanticAI) | **Planned** | No | No | No |
-| 벡터 인프라 (S3 Vectors) | **Yes** | No | No | No |
-| 보일러플레이트 제로 CRUD (7개 메서드) | **Yes** | No | No | No |
-| 도메인 자동 발견 | **Yes** | No | No | No |
-| 아키텍처 자동 강제 (pre-commit) | **Yes** | No | No | No |
-| AI 개발 스킬 | **14** | 0 | 0 | 0 |
-| 적응형 온보딩 (`/onboard`) | **Yes** | No | No | No |
-| 멀티 인터페이스 (API+Worker+Admin+MCP) | **4종** | 2 | 1 | 1 |
-| Architecture Decision Records | **32** | 0 | 0 | 0 |
-| 전 계층 타입 안전 제네릭 | **Yes** | 부분 | 부분 | No |
-| IoC Container DI | **Yes** | No | No | No |
+</details>
 
 ---
 
 ## Architecture Decisions
 
-이 프로젝트의 모든 기술 선택은 ADR(Architecture Decision Record)로 기록되어 있습니다.
+이 프로젝트의 모든 기술 선택은 ADR(Architecture Decision Record)로 기록되어 있습니다. [37개 전체 ADR 보기 →](../docs/history/README.md)
+
+<details>
+<summary>주요 결정</summary>
 
 | # | 제목 |
 |---|------|
@@ -544,7 +500,7 @@ src/
 | [012](../docs/history/012-ruff-migration.md) | Ruff 도입 |
 | [013](../docs/history/013-why-ioc-container.md) | 상속 대신 IoC Container를 선택한 이유 |
 
-[ADR 인덱스 보기](../docs/history/README.md)
+</details>
 
 ---
 
@@ -574,8 +530,8 @@ src/
 - [x] 헬스 체크 엔드포인트
 - [x] 도메인 자동 발견
 - [x] 아키텍처 강제 (pre-commit)
-- [x] 14개 Claude Code 스킬
-- [x] Codex CLI workflow layer (`.codex/config.toml`, `.codex/hooks.json`, `.agents/skills/`)
+- [x] Claude Code + Codex CLI용 14+개 AI 개발 스킬
+- [x] Codex CLI workflow layer (`.codex/config.toml`, `.codex/hooks.json`, `.agents/skills/`, 6 hooks)
 
 스타를 눌러 진행 상황을 팔로우하세요!
 
@@ -590,3 +546,15 @@ src/
 ## License
 
 [MIT License](../LICENSE) -- 상업적 사용, 수정, 배포 자유.
+
+---
+
+## Star History
+
+<a href="https://star-history.com/#Mr-DooSun/fastapi-agent-blueprint&Date">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=Mr-DooSun/fastapi-agent-blueprint&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=Mr-DooSun/fastapi-agent-blueprint&type=Date" />
+   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=Mr-DooSun/fastapi-agent-blueprint&type=Date" width="600" />
+ </picture>
+</a>

--- a/docs/ai-development.ko.md
+++ b/docs/ai-development.ko.md
@@ -1,0 +1,93 @@
+# AI 네이티브 개발 가이드
+
+> 간략한 개요는 [README](README.ko.md#ai-네이티브-개발)를 참고하세요.
+
+## 구조
+
+이 레포지토리는 **공통 규칙 + 공통 레퍼런스 + 도구별 하네스** 구조를 사용합니다:
+
+| 파일 | 역할 |
+|------|------|
+| `AGENTS.md` | 모든 AI 도구가 따라야 하는 공통 규칙의 canonical source |
+| `docs/ai/shared/` | Claude와 Codex가 함께 읽는 공통 workflow 레퍼런스와 체크리스트 |
+| `CLAUDE.md` | Claude 전용 hooks, plugins, slash skills, workflow 안내 |
+| `.mcp.json` | Claude 전용 MCP 설정 |
+| `.codex/config.toml` | Codex CLI 전용 프로젝트 설정, profile, feature, MCP 구성 |
+| `.codex/hooks.json` | Codex 명령 훅 설정 |
+| `.agents/skills/` | repo-local Codex workflow skill |
+
+## 공통 규칙 우선
+
+모든 도구는 먼저 `AGENTS.md`를 기준으로 다음을 따른다:
+- 프로젝트 규모 전제
+- 절대 금지 규칙
+- 레이어 용어와 conversion pattern
+- DTO 생성 기준
+- 기본 run/test/lint/migration 명령
+- 문서와 규칙 drift 관리 원칙
+
+루트 `AGENTS.md`에 다 담기 어려운 workflow 세부사항은 `docs/ai/shared/`에 둡니다. 예: `project-dna.md`, planning/security/review checklist, test pattern. `/sync-guidelines` 또는 `$sync-guidelines`를 실행할 때는 수동 검토 항목이 빠지지 않도록 최종 결과에 `project-dna`, `AUTO-FIX`, `REVIEW`, `Remaining`를 모두 명시해야 합니다.
+
+## Claude Code
+
+### 플러그인 설정 (필수)
+
+코드 인텔리전스(심볼 탐색, 참조 추적, 진단)를 위해 pyright-lsp 플러그인을 설치하세요:
+
+```bash
+uv sync                              # pyright 바이너리 설치 (dev 의존성)
+claude plugin install pyright-lsp    # Claude Code 플러그인 설치
+```
+
+> `.claude/settings.json`의 `enabledPlugins`가 첫 실행 시 자동으로 설치를 안내합니다.
+
+### MCP 서버 설정 (`.mcp.json`)
+
+**context7** -- 라이브러리 최신 문서 조회
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "url": "https://mcp.context7.com/mcp"
+    }
+  }
+}
+```
+
+> `.mcp.json`은 Claude 측 MCP 진입점입니다. MCP 서버 없이도 프로젝트 자체는 정상 동작하지만, Claude 스킬은 이 설정을 기대합니다.
+
+## Codex CLI
+
+Codex는 `.codex/config.toml`의 project-shared 설정을 사용합니다:
+
+```toml
+sandbox_mode = "workspace-write"
+approval_policy = "on-request"
+web_search = "disabled"
+
+[features]
+codex_hooks = true
+
+[profiles.research]
+web_search = "live"
+
+[mcp_servers.context7]
+url = "https://mcp.context7.com/mcp"
+```
+
+> Codex는 원격 Context7 MCP 엔드포인트를 사용합니다. 로컬 stdio 서버(npx) 방식은 샌드박스 네트워크 제한에 의해 차단되므로, HTTP 전송 방식을 사용합니다.
+
+Codex의 레포 workflow layer는 다음으로 나뉩니다:
+- `.codex/config.toml` — base config와 profile
+- `.codex/hooks.json` + `.codex/hooks/` — command hook
+- `.agents/skills/` — `$onboard`, `$plan-feature`, `$review-pr` 같은 repo-local workflow
+- `docs/ai/shared/` — Claude/Codex 공통 reference
+
+권장 검증 흐름:
+1. Codex에서 이 프로젝트를 trusted 상태로 만든다.
+2. `codex mcp list`, `codex mcp get context7`를 실행한다.
+3. `codex debug prompt-input -c 'project_doc_max_bytes=400' "healthcheck" | rg "Shared Collaboration Rules|AGENTS\\.md"`로 `AGENTS.md`가 실제 prompt input에 포함되는지 확인한다.
+4. 최신 외부 정보가 정말 필요할 때만 `codex -p research` 또는 `codex --search`를 사용한다.
+5. Codex memories는 개인/세션 최적화용으로만 보고, 팀 규칙 저장소로 쓰지 않는다.
+
+> `.codex/config.toml`은 Codex 측 하네스 진입점입니다. 웹 검색은 기본 비활성화되어 있으므로, 최신 외부 정보가 필요할 때만 명시적으로 활성화하세요.

--- a/docs/ai-development.md
+++ b/docs/ai-development.md
@@ -1,0 +1,93 @@
+# AI-Native Development Guide
+
+> For a quick overview, see the [README](../README.md#ai-native-development).
+
+## Structure
+
+This repository uses a **shared rules + shared references + tool-specific harness** structure:
+
+| File | Role |
+|------|------|
+| `AGENTS.md` | Canonical shared rules for all AI tools |
+| `docs/ai/shared/` | Shared workflow references and checklists used by Claude and Codex |
+| `CLAUDE.md` | Claude-specific hooks, plugins, slash skills, and workflow notes |
+| `.mcp.json` | Claude-only MCP server configuration |
+| `.codex/config.toml` | Codex CLI project settings, profiles, features, and MCP configuration |
+| `.codex/hooks.json` | Codex command-hook configuration |
+| `.agents/skills/` | Repo-local Codex workflow skills |
+
+## Shared Rules First
+
+All tools should follow `AGENTS.md` for:
+- project scale assumptions
+- absolute prohibitions
+- layer terminology and conversion patterns
+- DTO creation criteria
+- baseline run/test/lint/migration commands
+- documentation drift management principles
+
+Use `docs/ai/shared/` for the deeper workflow references that are too detailed for root `AGENTS.md`, such as `project-dna.md`, planning checklists, review checklists, and test patterns. When running `/sync-guidelines` or `$sync-guidelines`, always close with `project-dna`, `AUTO-FIX`, `REVIEW`, and `Remaining` so manual review items are not silently skipped.
+
+## Claude Code
+
+### Plugin Setup (Required)
+
+Install the pyright-lsp plugin for code intelligence (symbol navigation, references, diagnostics):
+
+```bash
+uv sync                              # installs pyright binary as dev dependency
+claude plugin install pyright-lsp    # installs Claude Code plugin
+```
+
+> `enabledPlugins` in `.claude/settings.json` will prompt installation automatically on first run.
+
+### MCP Server Setup (`.mcp.json`)
+
+**context7** -- Up-to-date library documentation
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "url": "https://mcp.context7.com/mcp"
+    }
+  }
+}
+```
+
+> `.mcp.json` is the Claude-side MCP entrypoint. The project works without MCP servers, but Claude skills expect this configuration.
+
+## Codex CLI
+
+Codex uses the committed project config in `.codex/config.toml`:
+
+```toml
+sandbox_mode = "workspace-write"
+approval_policy = "on-request"
+web_search = "disabled"
+
+[features]
+codex_hooks = true
+
+[profiles.research]
+web_search = "live"
+
+[mcp_servers.context7]
+url = "https://mcp.context7.com/mcp"
+```
+
+> Codex uses the remote Context7 MCP endpoint so documentation lookups are not blocked by the sandboxed network restrictions that apply to locally spawned stdio servers.
+
+Codex's repository workflow layer is split across:
+- `.codex/config.toml` for base config and profiles
+- `.codex/hooks.json` plus `.codex/hooks/` for command hooks
+- `.agents/skills/` for repo-local workflows such as `$onboard`, `$plan-feature`, `$review-pr`
+- `docs/ai/shared/` for shared references that both Claude and Codex consume
+
+Recommended verification flow:
+1. Trust the project in Codex.
+2. Run `codex mcp list` and `codex mcp get context7`.
+3. Run `codex debug prompt-input -c 'project_doc_max_bytes=400' "healthcheck" | rg "Shared Collaboration Rules|AGENTS\\.md"` and confirm `AGENTS.md` is included in the prompt input.
+4. Use `codex -p research` or `codex --search` only when live web search is actually required.
+5. Treat Codex memories as personal/session optimization only, not as team-shared governance.
+
+> `.codex/config.toml` is the Codex-side harness entrypoint. Web search is disabled by default; enable it explicitly only when you need live external information.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,16 @@
 [project]
 name = "fastapi-agent-blueprint"
 version = "0.3.0"
-description = "AI Agent Backend Platform — MCP server, AI orchestration, and async DDD architecture on FastAPI"
+description = "FastAPI DDD template, built for AI agent backends — zero-boilerplate CRUD, auto domain discovery, async architecture"
 readme = "README.md"
 requires-python = ">=3.12.9"
+
+[project.urls]
+Homepage = "https://github.com/Mr-DooSun/fastapi-agent-blueprint"
+Repository = "https://github.com/Mr-DooSun/fastapi-agent-blueprint"
+Issues = "https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues"
+Changelog = "https://github.com/Mr-DooSun/fastapi-agent-blueprint/blob/main/CHANGELOG.md"
+
 dependencies = [
     "aioboto3>=15.4.0",
     "aiohttp>=3.13.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,6 @@ version = "0.3.0"
 description = "FastAPI DDD template, built for AI agent backends — zero-boilerplate CRUD, auto domain discovery, async architecture"
 readme = "README.md"
 requires-python = ">=3.12.9"
-
-[project.urls]
-Homepage = "https://github.com/Mr-DooSun/fastapi-agent-blueprint"
-Repository = "https://github.com/Mr-DooSun/fastapi-agent-blueprint"
-Issues = "https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues"
-Changelog = "https://github.com/Mr-DooSun/fastapi-agent-blueprint/blob/main/CHANGELOG.md"
-
 dependencies = [
     "aioboto3>=15.4.0",
     "aiohttp>=3.13.0",
@@ -40,6 +33,12 @@ dependencies = [
 sqs = ["taskiq-aws>=0.4.0"]
 rabbitmq = ["taskiq-aio-pika>=0.4.0"]
 openai = ["openai>=1.0.0", "tiktoken>=0.7.0"]
+
+[project.urls]
+Homepage = "https://github.com/Mr-DooSun/fastapi-agent-blueprint"
+Repository = "https://github.com/Mr-DooSun/fastapi-agent-blueprint"
+Issues = "https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues"
+Changelog = "https://github.com/Mr-DooSun/fastapi-agent-blueprint/blob/main/CHANGELOG.md"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Related Issue
- Closes #

## Change Summary
- Restructure README to lead with implemented features (What You Get) instead of planned ones (MCP, PydanticAI)
- Add "Who is this for?" section for instant visitor self-identification
- Add "Use this template" badge button (requires `is_template: true` set via gh CLI)
- Compress AIDD section from ~120 lines to ~50 lines; extract details to `docs/ai-development.md` / `docs/ai-development.ko.md`
- Equalize Claude Code and Codex CLI visibility (comparison table, skills syntax, hooks)
- Collapse verbose sections (Adding a New Domain, Tech Stack, Project Structure, ADRs) into `<details>`
- Reorder Comparison table: implemented features first, planned features last
- Fix ADR count 32 → 37, interface count "4 types" → "3+1 planned"
- Fix Tech Stack "AI & Agent `planned`" label → per-item Available/Planned status
- Sync all changes to Korean README (`docs/README.ko.md`), add Star History section
- Add `[project.urls]` to `pyproject.toml`, update description
- **GitHub Settings (already applied via gh CLI):** template=true, homepage removed, description updated, topics updated (removed `pydantic-ai`/`enterprise`/`ai-development`, added `pgvector`/`rag`/`vector-database`/`codex`)

## Type of Change
- [ ] feat: New feature
- [ ] fix: Bug fix
- [ ] refactor: Code restructuring
- [x] docs: Documentation
- [x] chore: Build/tooling
- [ ] test: Tests
- [ ] ci: CI/CD
- [ ] perf: Performance
- [ ] style: Code style

## Checklist
- [x] Architecture rules followed (no Domain -> Infrastructure imports)
- [x] Tests pass
- [x] Linting passes (`ruff check src/`)

## How to Test
- Open the repo page on GitHub and verify:
  - "Use this template" green button appears in the repo header
  - First viewport shows: logo → tagline → template button → "Who is this for?"
  - No "planned" in the first 50 lines of README
  - `<details>` sections collapse/expand properly
  - All internal links resolve
  - Korean README (`docs/README.ko.md`) mirrors English structure
  - Star History chart renders at the bottom of both READMEs