### PR TITLE
feat: add storage abstraction (S3/MinIO switchable support)

### DIFF
--- a/.claude/rules/architecture-conventions.md
+++ b/.claude/rules/architecture-conventions.md
@@ -1,6 +1,6 @@
 # Architecture Conventions
 
-> Last synced: 2026-04-14 via /sync-guidelines
+> Last synced: 2026-04-15 via /sync-guidelines
 > For Absolute Prohibitions, Conversion Patterns, Write DTO criteria, and common commands, refer to AGENTS.md.
 > This file only contains **structural context** that supplements AGENTS.md for Claude.
 
@@ -51,6 +51,13 @@ Key differences from RDB/DynamoDB:
 - providers.Selector in CoreContainer: SQS/RabbitMQ/InMemory by BROKER_TYPE env var
 - Task code: `from src._apps.worker.broker import broker` — no conditional logic
 - stg/prod require explicit BROKER_TYPE setting
+
+## Storage Selection
+- Parameter switching in CoreContainer: S3/MinIO by STORAGE_TYPE env var
+- Both use the same `ObjectStorageClient` class — only constructor parameters differ
+- S3: `region_name`, MinIO: `endpoint_url` + dummy `region_name="us-east-1"`
+- No `providers.Selector` needed (same class, different params — contrast with Broker/Embedding)
+- Settings computed properties (`storage_access_key`, etc.) resolve to S3/MinIO fields based on STORAGE_TYPE
 
 ## Embedding Selection
 - providers.Selector in CoreContainer: OpenAI/Bedrock by EMBEDDING_PROVIDER env var

--- a/.claude/rules/commands.md
+++ b/.claude/rules/commands.md
@@ -1,6 +1,6 @@
 # Suggested Commands
 
-> Last synced: 2026-04-14 via /sync-guidelines
+> Last synced: 2026-04-15 via /sync-guidelines
 > Purpose: Quick reference for Claude Code when executing shell commands.
 > Also referenced when running Skills.
 > Makefile targets (`make dev`, `make test`, etc.) are available as shortcuts — see `AGENTS.md` Common Commands.
@@ -75,6 +75,15 @@ BROKER_TYPE=inmemory python run_worker_local.py --env local
 
 # RabbitMQ
 BROKER_TYPE=rabbitmq RABBITMQ_URL=amqp://guest:guest@localhost:5672/ python run_worker_local.py --env local
+```
+
+## Storage
+```bash
+# MinIO (local development)
+STORAGE_TYPE=minio python run_server_local.py --env local
+
+# AWS S3
+STORAGE_TYPE=s3 python run_server_local.py --env local
 ```
 
 ## Admin Dashboard

--- a/.claude/rules/project-overview.md
+++ b/.claude/rules/project-overview.md
@@ -1,6 +1,6 @@
 # Project Overview
 
-> Last synced: 2026-04-14 via /sync-guidelines
+> Last synced: 2026-04-15 via /sync-guidelines
 > For tech stack, refer to project-dna.md §8; for layer structure, refer to §1.
 > This file only contains **project-level context** not covered in project-dna.md.
 
@@ -18,7 +18,7 @@ Interface → Application → Domain ← Infrastructure
 ## Infrastructure Options
 - RDB: PostgreSQL, MySQL, SQLite (DATABASE_ENGINE env var)
 - DynamoDB: Optional (DYNAMODB_* env vars, BaseDynamoRepository)
-- Object Storage: S3/MinIO (S3_*/MINIO_* env vars)
+- Object Storage: S3/MinIO (STORAGE_TYPE env var, parameter switching)
 - S3 Vectors: Optional (S3VECTORS_* env vars, BaseS3VectorStore)
 - Embedding: Optional (EMBEDDING_PROVIDER env var, OpenAI/Bedrock Selector)
 - Message Broker: SQS/RabbitMQ/InMemory (BROKER_TYPE env var)
@@ -26,6 +26,7 @@ Interface → Application → Domain ← Infrastructure
 ## Environment Config Validation
 - Settings (pydantic-settings) with model_validator
 - stg/prod: unsafe defaults blocked, broker required, partial config groups rejected
+- STORAGE_TYPE-driven validation: S3/MinIO config group required when set
 - Partial config group validation: S3, MinIO, DynamoDB, S3Vectors, SQS, OpenAI, Bedrock
 
 ## Key Value Objects

--- a/.claude/rules/project-status.md
+++ b/.claude/rules/project-status.md
@@ -1,11 +1,11 @@
 # Project Status
 
-> Last synced: 2026-04-14 via /sync-guidelines
+> Last synced: 2026-04-15 via /sync-guidelines
 
 ## Current Version Context
 - Latest release: v0.3.0 (2026-04-10)
 - Active domains: user (reference domain)
-- Infrastructure: RDB (PostgreSQL/MySQL/SQLite), DynamoDB, S3, S3 Vectors, Embedding, Broker (SQS/RabbitMQ/InMemory)
+- Infrastructure: RDB (PostgreSQL/MySQL/SQLite), DynamoDB, Storage (S3/MinIO), S3 Vectors, Embedding, Broker (SQS/RabbitMQ/InMemory)
 
 ## Recent Major Changes (since v0.3.0)
 | Feature | Issue | Impact |
@@ -23,6 +23,7 @@
 | Embedding Service Abstraction | #69 | Selector pattern (OpenAI/Bedrock), BaseEmbeddingProtocol, auto-dimension |
 | Text Chunking | #69 | semantic-text-splitter, chunk_text/chunk_text_by_tokens |
 | ADR 035/036 | #69 | Embedding abstraction + text chunking design decisions |
+| Storage Abstraction | #58 | STORAGE_TYPE env var, S3/MinIO parameter switching, Settings computed properties |
 
 ## Architecture Violation Status
 - Domain → Infrastructure import: CLEAN

--- a/docs/ai/shared/project-dna.md
+++ b/docs/ai/shared/project-dna.md
@@ -496,7 +496,7 @@ class {Name}Container(containers.DeclarativeContainer):
 | SQLAlchemy 2.0+ | Active | Mapped[T] + mapped_column() |
 | Pydantic 2.x | Active | model_validate, model_dump, ConfigDict |
 | dependency-injector | Active | DeclarativeContainer, @inject + Provide |
-| AWS S3 (aioboto3) | Active | ObjectStorage + ObjectStorageClient |
+| Object Storage (aioboto3) | Active | S3/MinIO switchable via STORAGE_TYPE, ObjectStorage + ObjectStorageClient |
 | AWS DynamoDB (aioboto3) | Active | BaseDynamoRepository + DynamoDBClient (optional infra) |
 | NiceGUI (BaseAdminPage) | Active | Admin dashboard (AG Grid, auto-discovery, Template Method rendering) |
 | alembic (migrations) | Active | DB migrations |

--- a/src/_core/config.py
+++ b/src/_core/config.py
@@ -8,6 +8,7 @@ KNOWN_ENVS = ("local", "dev", "stg", "prod")
 KNOWN_ENGINES = ("postgresql", "mysql", "sqlite")
 KNOWN_BROKER_TYPES = ("sqs", "rabbitmq", "inmemory")
 KNOWN_EMBEDDING_PROVIDERS = ("openai", "bedrock")
+KNOWN_STORAGE_TYPES = ("s3", "minio")
 STRICT_ENVS = frozenset({"stg", "prod"})
 
 _OPENAI_DIMENSIONS: dict[str, int] = {
@@ -97,6 +98,11 @@ class Settings(BaseSettings):
     minio_bucket_name: str | None = Field(
         default=None, validation_alias="MINIO_BUCKET_NAME"
     )
+
+    # ----------------------------------------------------------------
+    # Storage Type Selector (s3 / minio)
+    # ----------------------------------------------------------------
+    storage_type: str | None = Field(default=None, validation_alias="STORAGE_TYPE")
 
     # ----------------------------------------------------------------
     # DynamoDB (Optional)
@@ -255,6 +261,23 @@ class Settings(BaseSettings):
                 f"set but {', '.join(missing)} missing"
             )
 
+        storage = (self.storage_type or "").lower().strip()
+        if storage and storage not in KNOWN_STORAGE_TYPES:
+            errors.append(
+                f"[storage_type] Unknown storage type '{self.storage_type}'. "
+                f"Expected one of: {', '.join(KNOWN_STORAGE_TYPES)}"
+            )
+        if storage == "s3" and s3_set != set(s3_fields):
+            missing = sorted(set(s3_fields) - s3_set)
+            errors.append(
+                f"[Storage] STORAGE_TYPE=s3 requires: {', '.join(missing)} missing"
+            )
+        if storage == "minio" and minio_set != set(minio_fields):
+            missing = sorted(set(minio_fields) - minio_set)
+            errors.append(
+                f"[Storage] STORAGE_TYPE=minio requires: {', '.join(missing)} missing"
+            )
+
         dynamodb_fields = {
             "dynamodb_region": self.dynamodb_region,
             "dynamodb_access_key": self.dynamodb_access_key,
@@ -371,6 +394,49 @@ class Settings(BaseSettings):
     def minio_endpoint_url(self) -> str | None:
         if self.minio_host and self.minio_port:
             return f"{self.minio_host}:{self.minio_port}"
+        return None
+
+    @property
+    def storage_access_key(self) -> str | None:
+        st = (self.storage_type or "").lower()
+        if st == "s3":
+            return self.s3_access_key
+        if st == "minio":
+            return self.minio_access_key
+        return None
+
+    @property
+    def storage_secret_key(self) -> str | None:
+        st = (self.storage_type or "").lower()
+        if st == "s3":
+            return self.s3_secret_key
+        if st == "minio":
+            return self.minio_secret_key
+        return None
+
+    @property
+    def storage_region(self) -> str | None:
+        st = (self.storage_type or "").lower()
+        if st == "s3":
+            return self.s3_region
+        if st == "minio":
+            return "us-east-1"
+        return None
+
+    @property
+    def storage_endpoint_url(self) -> str | None:
+        st = (self.storage_type or "").lower()
+        if st == "minio":
+            return self.minio_endpoint_url
+        return None
+
+    @property
+    def storage_bucket_name(self) -> str | None:
+        st = (self.storage_type or "").lower()
+        if st == "s3":
+            return self.s3_bucket_name
+        if st == "minio":
+            return self.minio_bucket_name
         return None
 
     @property

--- a/src/_core/infrastructure/di/core_container.py
+++ b/src/_core/infrastructure/di/core_container.py
@@ -61,26 +61,18 @@ class CoreContainer(containers.DeclarativeContainer):
     # Storage
     #########################################################
 
-    # MinIO configuration (swap in when needed)
-    # minio_client = providers.Singleton(
-    #     ObjectStorageClient,
-    #     access_key=settings.minio_access_key,
-    #     secret_access_key=settings.minio_secret_key,
-    #     endpoint_url=settings.minio_endpoint_url,
-    # )
-
-    # AWS S3 configuration
-    s3_client = providers.Singleton(
+    storage_client = providers.Singleton(
         ObjectStorageClient,
-        access_key=settings.s3_access_key,
-        secret_access_key=settings.s3_secret_key,
-        region_name=settings.s3_region,
+        access_key=settings.storage_access_key,
+        secret_access_key=settings.storage_secret_key,
+        region_name=settings.storage_region,
+        endpoint_url=settings.storage_endpoint_url,
     )
 
-    s3_storage = providers.Factory(
+    storage = providers.Factory(
         ObjectStorage,
-        storage_client=s3_client,
-        bucket_name=settings.s3_bucket_name,
+        storage_client=storage_client,
+        bucket_name=settings.storage_bucket_name,
     )
 
     #########################################################

--- a/tests/unit/_core/test_config.py
+++ b/tests/unit/_core/test_config.py
@@ -216,6 +216,129 @@ class TestPartialConfigGroups:
             assert s.s3vectors_region is None
 
 
+class TestStorageTypeConfig:
+    def test_no_storage_type_accepted(self):
+        env = {"ENV": "local", **_REQUIRED_VARS}
+        with patch.dict(os.environ, env, clear=True):
+            s = _create_settings()
+            assert s.storage_type is None
+
+    def test_unknown_storage_type_rejected(self):
+        env = {"ENV": "local", "STORAGE_TYPE": "gcs", **_REQUIRED_VARS}
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(ValidationError, match="Unknown storage type"):
+                _create_settings()
+
+    def test_s3_without_config_rejected(self):
+        env = {"ENV": "local", "STORAGE_TYPE": "s3", **_REQUIRED_VARS}
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(
+                ValidationError, match=r"Storage.*STORAGE_TYPE=s3.*missing"
+            ):
+                _create_settings()
+
+    def test_s3_with_complete_config_accepted(self):
+        env = {
+            "ENV": "local",
+            "STORAGE_TYPE": "s3",
+            "S3_ACCESS_KEY": "s3-key",
+            "S3_SECRET_KEY": "s3-secret",
+            "S3_REGION": "ap-northeast-2",
+            "S3_BUCKET_NAME": "my-bucket",
+            **_REQUIRED_VARS,
+        }
+        with patch.dict(os.environ, env, clear=True):
+            s = _create_settings()
+            assert s.storage_type == "s3"
+            assert s.storage_access_key == "s3-key"
+            assert s.storage_secret_key == "s3-secret"
+            assert s.storage_bucket_name == "my-bucket"
+
+    def test_minio_without_config_rejected(self):
+        env = {"ENV": "local", "STORAGE_TYPE": "minio", **_REQUIRED_VARS}
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(
+                ValidationError, match=r"Storage.*STORAGE_TYPE=minio.*missing"
+            ):
+                _create_settings()
+
+    def test_minio_with_complete_config_accepted(self):
+        env = {
+            "ENV": "local",
+            "STORAGE_TYPE": "minio",
+            "MINIO_HOST": "localhost",
+            "MINIO_PORT": "9000",
+            "MINIO_ACCESS_KEY": "minio-key",
+            "MINIO_SECRET_KEY": "minio-secret",
+            "MINIO_BUCKET_NAME": "minio-bucket",
+            **_REQUIRED_VARS,
+        }
+        with patch.dict(os.environ, env, clear=True):
+            s = _create_settings()
+            assert s.storage_type == "minio"
+            assert s.storage_access_key == "minio-key"
+            assert s.storage_secret_key == "minio-secret"
+            assert s.storage_bucket_name == "minio-bucket"
+
+    def test_minio_endpoint_url_resolved(self):
+        env = {
+            "ENV": "local",
+            "STORAGE_TYPE": "minio",
+            "MINIO_HOST": "localhost",
+            "MINIO_PORT": "9000",
+            "MINIO_ACCESS_KEY": "key",
+            "MINIO_SECRET_KEY": "secret",
+            "MINIO_BUCKET_NAME": "bucket",
+            **_REQUIRED_VARS,
+        }
+        with patch.dict(os.environ, env, clear=True):
+            s = _create_settings()
+            assert s.storage_endpoint_url == "localhost:9000"
+
+    def test_s3_endpoint_url_is_none(self):
+        env = {
+            "ENV": "local",
+            "STORAGE_TYPE": "s3",
+            "S3_ACCESS_KEY": "key",
+            "S3_SECRET_KEY": "secret",
+            "S3_REGION": "us-east-1",
+            "S3_BUCKET_NAME": "bucket",
+            **_REQUIRED_VARS,
+        }
+        with patch.dict(os.environ, env, clear=True):
+            s = _create_settings()
+            assert s.storage_endpoint_url is None
+
+    def test_minio_region_is_us_east_1(self):
+        env = {
+            "ENV": "local",
+            "STORAGE_TYPE": "minio",
+            "MINIO_HOST": "localhost",
+            "MINIO_PORT": "9000",
+            "MINIO_ACCESS_KEY": "key",
+            "MINIO_SECRET_KEY": "secret",
+            "MINIO_BUCKET_NAME": "bucket",
+            **_REQUIRED_VARS,
+        }
+        with patch.dict(os.environ, env, clear=True):
+            s = _create_settings()
+            assert s.storage_region == "us-east-1"
+
+    def test_s3_region_resolved(self):
+        env = {
+            "ENV": "local",
+            "STORAGE_TYPE": "s3",
+            "S3_ACCESS_KEY": "key",
+            "S3_SECRET_KEY": "secret",
+            "S3_REGION": "ap-northeast-2",
+            "S3_BUCKET_NAME": "bucket",
+            **_REQUIRED_VARS,
+        }
+        with patch.dict(os.environ, env, clear=True):
+            s = _create_settings()
+            assert s.storage_region == "ap-northeast-2"
+
+
 class TestBrokerConfig:
     def test_local_no_broker_type_accepted(self):
         env = {"ENV": "local", **_REQUIRED_VARS}


### PR DESCRIPTION
## Related Issue
- Closes #58

## Change Summary
- Add `STORAGE_TYPE` env var (`s3` / `minio`) for config-driven storage backend selection
- Add Settings computed properties (`storage_access_key`, `storage_secret_key`, `storage_region`, `storage_endpoint_url`, `storage_bucket_name`) that resolve to the correct backend fields
- Add `STORAGE_TYPE` validation: unknown type rejection + config group completeness check
- Replace hardcoded `s3_client`/`s3_storage` + commented-out MinIO block with unified `storage_client`/`storage` providers in CoreContainer
- MinIO uses dummy `region_name="us-east-1"` per botocore/MinIO convention (botocore #2723, MinIO #3595)
- No `providers.Selector` needed — same `ObjectStorageClient` class, parameter switching only (ADR 029 decision framework)

## Type of Change
- [x] feat: New feature
- [x] docs: Documentation
- [x] test: Tests

## Checklist
- [x] Architecture rules followed (no Domain -> Infrastructure imports)
- [x] Tests pass (59 unit tests, 10 new)
- [x] Linting passes (`ruff check src/`)
- [x] `/sync-guidelines` completed (5 docs updated)

## How to Test

```bash
# Run all config tests (59 tests including 10 new storage tests)
pytest tests/unit/_core/test_config.py -v

# Storage-specific tests only
pytest tests/unit/_core/test_config.py::TestStorageTypeConfig -v

# Full unit test suite (regression check)
pytest tests/unit/ -v

# Lint
pre-commit run --all-files
```

### Configuration

```bash
# MinIO (local development)
STORAGE_TYPE=minio
MINIO_HOST=127.0.0.1
MINIO_PORT=9000
MINIO_ACCESS_KEY=minioadmin
MINIO_SECRET_KEY=minioadmin
MINIO_BUCKET_NAME=bucket

# AWS S3
STORAGE_TYPE=s3
S3_ACCESS_KEY=...
S3_SECRET_KEY=...
S3_REGION=ap-northeast-2
S3_BUCKET_NAME=my-bucket

# No storage (optional — omit STORAGE_TYPE)
# Storage components declared but not initialized
```