### PR TITLE
chore: harden test infra and sync guidelines for pydantic-ai-slim

### DIFF
--- a/.claude/rules/architecture-conventions.md
+++ b/.claude/rules/architecture-conventions.md
@@ -1,6 +1,6 @@
 # Architecture Conventions
 
-> Last synced: 2026-04-16 via /sync-guidelines
+> Last synced: 2026-04-20 via /sync-guidelines
 > For Absolute Prohibitions, Conversion Patterns, Write DTO criteria, and common commands, refer to AGENTS.md.
 > This file only contains **structural context** that supplements AGENTS.md for Claude.
 

--- a/.claude/rules/commands.md
+++ b/.claude/rules/commands.md
@@ -1,6 +1,6 @@
 # Suggested Commands
 
-> Last synced: 2026-04-16 via /sync-guidelines
+> Last synced: 2026-04-20 via /sync-guidelines
 > Purpose: Quick reference for Claude Code when executing shell commands.
 > Also referenced when running Skills.
 > Makefile targets (`make dev`, `make test`, etc.) are available as shortcuts — see `AGENTS.md` Common Commands.
@@ -18,12 +18,27 @@ python run_worker_local.py --env local
 
 ## Test
 ```bash
-pytest tests/ -v
+pytest tests/ -v                          # SQLite in-memory (default, no infra)
 pytest tests/unit/ -v
 pytest tests/integration/ -v
 pytest tests/e2e/ -v
-pytest tests/integration/ -v -k "dynamo"   # DynamoDB tests only
+pytest tests/integration/ -v -k "dynamo"  # DynamoDB tests only (requires docker dynamodb-local)
+
+# Run against real PostgreSQL (docker-compose.local.yml postgres service)
+make test-pg
+# or manually:
+TEST_DB_ENGINE=postgresql \
+  TEST_DB_USER=postgres TEST_DB_PASSWORD=postgres \
+  TEST_DB_HOST=localhost TEST_DB_PORT=5432 TEST_DB_NAME=postgres \
+  pytest tests/ -v
+
+# Run DynamoDB integration tests against docker dynamodb-local
+make test-dynamo
 ```
+
+- `tests/conftest.py::test_db` switches engine via `TEST_DB_ENGINE` (default `sqlite`)
+- `tests/conftest.py::_override_app_database` (autouse) swaps the running app's `CoreContainer.database` to `test_db`, so e2e tests do not need real PostgreSQL
+- `app.state.container` exposes the wired `DynamicContainer` for fixture overrides
 
 ## Lint / Format
 ```bash

--- a/.claude/rules/project-overview.md
+++ b/.claude/rules/project-overview.md
@@ -1,6 +1,6 @@
 # Project Overview
 
-> Last synced: 2026-04-16 via /sync-guidelines
+> Last synced: 2026-04-20 via /sync-guidelines
 > For tech stack, refer to project-dna.md §8; for layer structure, refer to §1.
 > This file only contains **project-level context** not covered in project-dna.md.
 

--- a/.claude/rules/project-status.md
+++ b/.claude/rules/project-status.md
@@ -1,6 +1,6 @@
 # Project Status
 
-> Last synced: 2026-04-16 via /sync-guidelines
+> Last synced: 2026-04-20 via /sync-guidelines
 
 ## Current Version Context
 - Latest release: v0.3.0 (2026-04-10)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,11 @@ jobs:
 
       - name: Run tests
         env:
-          ENV: test
+          ENV: local
+          ADMIN_ID: admin
+          ADMIN_PASSWORD: admin
+          ADMIN_STORAGE_SECRET: ci-test-secret
+          DATABASE_ENGINE: postgresql
           DATABASE_USER: postgres
           DATABASE_PASSWORD: postgres
           DATABASE_HOST: 127.0.0.1
@@ -76,7 +80,7 @@ jobs:
           AWS_SQS_ACCESS_KEY: test
           AWS_SQS_SECRET_KEY: test
           AWS_SQS_URL: http://localhost:4566
-        run: uv run pytest tests/ -v --tb=short --ignore=tests/e2e
+        run: uv run pytest tests/ -v --tb=short
 
   architecture:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,29 @@ dev:
 worker:
 	uv run python run_worker_local.py
 
-## Run all tests
+## Run all tests (SQLite in-memory by default)
 test:
 	uv run pytest tests/ -v
+
+## Run all tests against the local docker PostgreSQL (test_db -> postgresql)
+test-pg:
+	docker compose -f docker-compose.local.yml up -d postgres && \
+	sleep 2 && \
+	set -a && . _env/local.env && set +a && \
+	TEST_DB_ENGINE=postgresql \
+	TEST_DB_USER=postgres \
+	TEST_DB_PASSWORD=postgres \
+	TEST_DB_HOST=localhost \
+	TEST_DB_PORT=5432 \
+	TEST_DB_NAME=postgres \
+	uv run pytest tests/ -v
+
+## Run DynamoDB integration tests against local dynamodb-local
+test-dynamo:
+	docker compose -f docker-compose.local.yml up -d dynamodb-local && \
+	sleep 2 && \
+	set -a && . _env/local.env && set +a && \
+	uv run pytest tests/integration/_core/infrastructure/dynamodb/ -v
 
 ## Run tests with coverage
 test-cov:

--- a/docs/ai/shared/project-dna.md
+++ b/docs/ai/shared/project-dna.md
@@ -6,7 +6,7 @@
 > This file is auto-extracted/updated from `src/user/` (reference domain) and `src/_core/` (Base classes)
 > when `/sync-guidelines` is run. **Run `/sync-guidelines` instead of editing manually.**
 >
-> Last updated: 2026-04-16
+> Last updated: 2026-04-20
 
 ## Section Index
 §0 Project Scale and Design Philosophy |
@@ -425,10 +425,10 @@ embedding_client = providers.Singleton(
 
 | EMBEDDING_PROVIDER | Model Name Format | Dependency |
 |-------------------|------------------|------------|
-| `openai` | `openai:text-embedding-3-small` | `pydantic-ai`, `tiktoken` (optional extra) |
-| `bedrock` | `bedrock:amazon.titan-embed-text-v2:0` | `pydantic-ai`, `aioboto3` (main) |
-| `google` | `google:text-embedding-004` | `pydantic-ai` |
-| `ollama` | `ollama:nomic-embed-text` | `pydantic-ai` |
+| `openai` | `openai:text-embedding-3-small` | `pydantic-ai` extra (includes `tiktoken`) |
+| `bedrock` | `bedrock:amazon.titan-embed-text-v2:0` | `pydantic-ai` extra, `aioboto3` (main) |
+| `google` | `google:text-embedding-004` | `pydantic-ai-google` extra |
+| `ollama` | `ollama:nomic-embed-text` | `pydantic-ai` extra |
 
 - Single adapter implements `BaseEmbeddingProtocol` (embed_text, embed_batch, dimension)
 - `EmbeddingConfig`: frozen dataclass value object (domain layer) carrying provider+credentials
@@ -460,9 +460,9 @@ llm_model = providers.Singleton(
 
 | LLM_PROVIDER | Model Name Format | Dependency |
 |-------------|------------------|------------|
-| `openai` | `openai:gpt-4o` | `pydantic-ai` |
-| `anthropic` | `anthropic:claude-sonnet-4-20250514` | `pydantic-ai` |
-| `bedrock` | `bedrock:us.anthropic.claude-sonnet-4-20250514-v1:0` | `pydantic-ai`, `aioboto3` |
+| `openai` | `openai:gpt-4o` | `pydantic-ai` extra |
+| `anthropic` | `anthropic:claude-sonnet-4-20250514` | `pydantic-ai-anthropic` extra |
+| `bedrock` | `bedrock:us.anthropic.claude-sonnet-4-20250514-v1:0` | `pydantic-ai` extra, `aioboto3` (main) |
 
 - `LLMConfig`: frozen dataclass value object (domain layer) carrying provider+credentials
 - `build_llm_model()`: factory function returning Provider-specific Model or plain string
@@ -808,7 +808,9 @@ the adapter bridges to `BaseEmbeddingProtocol` and adds OpenAI batch splitting.
 | Bedrock | PydanticAI semaphore (default 5 concurrent) | `aws_*` → `BedrockProvider` |
 | Google / Ollama | Native batch or local | Auto-detect env vars |
 
-- Requires `pydantic-ai` extra: `uv sync --extra pydantic-ai`
+- Requires `pydantic-ai` extra: `uv sync --extra pydantic-ai` (installs `pydantic-ai-slim` + `tiktoken`)
+- Provider-specific extras: `pydantic-ai-anthropic` (Anthropic LLM), `pydantic-ai-google` (Google embedding)
+- Bedrock providers reuse the main `aioboto3` dependency — no extra needed
 - OpenAI batch splitting requires `tiktoken` (included in pydantic-ai extra)
 - Raises domain exceptions: `EmbeddingRateLimitException`, `EmbeddingAuthenticationException`, `EmbeddingInputTooLongException`, `EmbeddingModelNotFoundException`
 - `EmbeddingConfig`: frozen dataclass (domain-layer VO) carrying model_name + dimension + credentials

--- a/docs/ai/shared/security-checklist.md
+++ b/docs/ai/shared/security-checklist.md
@@ -261,7 +261,7 @@ Check Embedding client and configuration files:
 
 ### API Key Management
 - [ ] [When applicable][CRITICAL] Embedding API keys (OpenAI/Bedrock) managed via environment variables (not hardcoded)
-  - Detection condition: Check **project-dna.md section 8** "Embedding (OpenAI/Bedrock)" status -> [SKIP] if "not implemented"
+  - Detection condition: Check **project-dna.md section 8** "Embedding (PydanticAI)" status -> [SKIP] if "not implemented"
   - Grep: `embedding_openai_api_key|embedding_bedrock_access_key|embedding_bedrock_secret_key` loaded from `Settings`
   - Verify no API key hardcoded in client constructors
 
@@ -290,3 +290,55 @@ Check Embedding client and configuration files:
   - Grep: Settings `_validate_environment_safety` in `config.py` -> verify provider-specific validation
   - OpenAI: requires `embedding_openai_api_key` when `EMBEDDING_PROVIDER=openai`
   - Bedrock: requires all 3 fields (`access_key`, `secret_key`, `region`) when `EMBEDDING_PROVIDER=bedrock`
+
+## 12. LLM API Security
+
+Check LLM model factory, configuration, and Agent-using services:
+
+### API Key / Credential Management
+- [ ] [When applicable][CRITICAL] LLM API keys / AWS credentials managed via environment variables (not hardcoded)
+  - Detection condition: Check **project-dna.md section 8** "LLM (PydanticAI Agent)" status -> [SKIP] if "not implemented"
+  - Grep: `llm_api_key|llm_bedrock_access_key|llm_bedrock_secret_key` loaded from `Settings`
+  - Verify `LLMConfig` is constructed only via DI (`core_container.llm_config`), not instantiated with literal credentials
+  - Verify `build_llm_model()` does not log or echo the credential fields
+
+### Provider / Model Validation
+- [ ] [When applicable][HIGH] LLM provider + model_name configuration validated at startup
+  - Detection condition: Same as above
+  - Grep: Settings `_validate_environment_safety` in `config.py` -> verify `llm_provider` ∈ {openai, anthropic, bedrock}
+  - OpenAI/Anthropic: requires `llm_api_key` when `LLM_PROVIDER` is set
+  - Bedrock: requires all 3 fields (`access_key`, `secret_key`, `region`) when `LLM_PROVIDER=bedrock`
+  - `model_name` follows `{provider}:{model}` prefix format (matches `build_llm_model()` switch)
+
+### Prompt Injection / Input Validation
+- [ ] [When applicable][HIGH] User-supplied text passed to `Agent.run(...)` is treated as untrusted input
+  - Detection condition: Same as above
+  - System prompts are defined as code constants — never concatenated with user input
+  - User input is passed only as the `Agent.run()` argument (data position), not interpolated into the system prompt
+  - When the user input affects tool calls / function calling, validate the action before execution
+
+### Output / Structured Response Handling
+- [ ] [When applicable][MEDIUM] Agent structured output is validated by Pydantic before being returned to clients
+  - Detection condition: Same as above
+  - Grep: `Agent[..., {DTO}]` declarations -> verify `output_type` is a Pydantic model (not `str`/`Any`)
+  - Sensitive fields excluded from API Response via `model_dump(exclude={...})` (same rule as DTO -> Response)
+
+### Context Length / Cost Guardrails
+- [ ] [When applicable][MEDIUM] LLM context length and request size guarded
+  - Detection condition: Same as above
+  - Grep: `LLMContextLengthExceededException` raised when input exceeds model context window
+  - Long-running or batched LLM calls run via Worker (not in request handler) to avoid request-thread blocking
+  - Per-request token / cost limits considered for endpoints exposed to external users
+
+### Rate Limit Handling
+- [ ] [When applicable][HIGH] LLM API rate limit errors caught and wrapped into domain exceptions
+  - Detection condition: Same as above
+  - Grep: provider rate-limit errors mapped to `LLMRateLimitException`
+  - Verify retry / backoff strategy does not amplify the rate limit (no tight retry loop)
+
+### Error Information Exposure
+- [ ] [When applicable][HIGH] LLM error responses do not expose raw provider error details in production
+  - Detection condition: Same as above
+  - Grep: `LLMException` (and subclasses) wrap provider errors -> verify raw `error_message` is not surfaced in user-facing responses
+  - Known exceptions (`LLMAuthenticationException`, `LLMRateLimitException`, `LLMModelNotFoundException`, `LLMContextLengthExceededException`) use sanitized messages
+  - Stack traces / model identifiers / credentials never leaked to API responses or logs in stg/prod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,8 @@ dev = [
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "session"
+asyncio_default_test_loop_scope = "session"
 testpaths = ["tests"]
 
 # === Ruff Configuration ===

--- a/src/_apps/server/bootstrap.py
+++ b/src/_apps/server/bootstrap.py
@@ -41,6 +41,7 @@ def bootstrap_app(app: FastAPI) -> None:
 
     # Bootstrap DI container (auto-discovery)
     server_container = create_server_container()
+    app.state.container = server_container
 
     # Wire core container for health check DI
     # (core is not a domain — no separate bootstrap file needed)

--- a/src/classification/interface/server/schemas/classification_schema.py
+++ b/src/classification/interface/server/schemas/classification_schema.py
@@ -1,6 +1,5 @@
 from pydantic import Field
 
-from src._core.application.dtos.base_config import ApiConfig
 from src._core.application.dtos.base_request import BaseRequest
 from src._core.application.dtos.base_response import BaseResponse
 
@@ -13,8 +12,6 @@ class ClassifyRequest(BaseRequest):
         default=None, description="Allowed categories (optional)"
     )
 
-    model_config = ApiConfig
-
 
 class ClassificationResponse(BaseResponse):
     """Response schema for classification result."""
@@ -22,5 +19,3 @@ class ClassificationResponse(BaseResponse):
     category: str
     confidence: float
     reasoning: str
-
-    model_config = ApiConfig

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 import pytest_asyncio
 
@@ -5,10 +7,28 @@ from src._core.infrastructure.database.config import DatabaseConfig
 from src._core.infrastructure.database.database import Base, Database
 
 
-@pytest_asyncio.fixture(scope="session")
-async def test_db():
+def _build_test_database() -> Database:
+    """Construct the test Database based on ``TEST_DB_ENGINE``.
+
+    Default: SQLite in-memory — no external infra, fast, CI-friendly.
+    ``TEST_DB_ENGINE=postgresql``: connect to the local docker PostgreSQL
+    (see ``docker-compose.local.yml``). Use ``make test-pg`` for this path.
+    """
+    engine = os.environ.get("TEST_DB_ENGINE", "sqlite").lower()
     config = DatabaseConfig(echo=False)
-    db = Database(
+
+    if engine == "postgresql":
+        return Database(
+            database_engine="postgresql",
+            database_user=os.environ.get("TEST_DB_USER", "postgres"),
+            database_password=os.environ.get("TEST_DB_PASSWORD", "postgres"),
+            database_host=os.environ.get("TEST_DB_HOST", "localhost"),
+            database_port=int(os.environ.get("TEST_DB_PORT", "5432")),
+            database_name=os.environ.get("TEST_DB_NAME", "postgres"),
+            config=config,
+        )
+
+    return Database(
         database_engine="sqlite",
         database_user="",
         database_password="",
@@ -17,10 +37,35 @@ async def test_db():
         database_name=":memory:",
         config=config,
     )
+
+
+@pytest_asyncio.fixture(scope="session")
+async def test_db():
+    db = _build_test_database()
     async with db.async_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
         await conn.run_sync(Base.metadata.create_all)
     yield db
+    async with db.async_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
     await db.dispose()
+
+
+@pytest_asyncio.fixture(autouse=True, scope="session")
+async def _override_app_database(test_db):
+    """Swap the app's PostgreSQL Database for the active ``test_db``.
+
+    The FastAPI app boots a real PostgreSQL Singleton at import time
+    (`src._apps.server.app.app`). E2E tests must run without external infra,
+    so we override the running container instance attached to ``app.state``.
+    """
+    from src._apps.server.app import app
+
+    container = app.state.container
+    core = container.core_container()
+    core.database.override(test_db)
+    yield
+    core.database.reset_override()
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,23 +51,6 @@ async def test_db():
     await db.dispose()
 
 
-@pytest_asyncio.fixture(autouse=True, scope="session")
-async def _override_app_database(test_db):
-    """Swap the app's PostgreSQL Database for the active ``test_db``.
-
-    The FastAPI app boots a real PostgreSQL Singleton at import time
-    (`src._apps.server.app.app`). E2E tests must run without external infra,
-    so we override the running container instance attached to ``app.state``.
-    """
-    from src._apps.server.app import app
-
-    container = app.state.container
-    core = container.core_container()
-    core.database.override(test_db)
-    yield
-    core.database.reset_override()
-
-
 @pytest.fixture(scope="session")
 def anyio_backend():
     return "asyncio"

--- a/tests/e2e/classification/test_classification_router.py
+++ b/tests/e2e/classification/test_classification_router.py
@@ -1,0 +1,44 @@
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from src._apps.server.app import app
+
+
+@pytest.mark.asyncio
+async def test_classify_rejects_empty_text():
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://localhost"
+    ) as client:
+        response = await client.post(
+            "/v1/classify",
+            json={"text": "", "categories": ["a", "b"]},
+        )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_classify_rejects_missing_text():
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://localhost"
+    ) as client:
+        response = await client.post(
+            "/v1/classify",
+            json={"categories": ["a", "b"]},
+        )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_classify_route_registered_in_openapi():
+    """Confirm route is wired without invoking the live LLM provider.
+
+    Service-level happy-path is covered by the unit test with a mocked Agent.
+    """
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://localhost"
+    ) as client:
+        response = await client.get("/openapi.json")
+    assert response.status_code == 200
+    paths = response.json().get("paths", {})
+    assert "/v1/classify" in paths
+    assert "post" in paths["/v1/classify"]

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,22 @@
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture(autouse=True, scope="session")
+async def _override_app_database(test_db):
+    """Swap the app's Database with ``test_db`` for the entire e2e session.
+
+    The FastAPI app boots a real Database Singleton at import time
+    (`src._apps.server.app.app`). E2E tests must run without external infra,
+    so we override the wired container instance exposed via ``app.state``.
+
+    Scoped to ``tests/e2e`` because unit/integration tests do not (and should
+    not) import the app — forcing an app import on them makes the unit suite
+    unnecessarily depend on Settings env vars.
+    """
+    from src._apps.server.app import app
+
+    container = app.state.container
+    core = container.core_container()
+    core.database.override(test_db)
+    yield
+    core.database.reset_override()

--- a/tests/e2e/user/test_user_router.py
+++ b/tests/e2e/user/test_user_router.py
@@ -7,10 +7,10 @@ from src._apps.server.app import app
 @pytest.mark.asyncio
 async def test_create_user():
     async with AsyncClient(
-        transport=ASGITransport(app=app), base_url="http://test"
+        transport=ASGITransport(app=app), base_url="http://localhost"
     ) as client:
         response = await client.post(
-            "/api/user",
+            "/v1/user",
             json={
                 "username": "e2euser",
                 "fullName": "E2E User",
@@ -28,9 +28,9 @@ async def test_create_user():
 @pytest.mark.asyncio
 async def test_get_users():
     async with AsyncClient(
-        transport=ASGITransport(app=app), base_url="http://test"
+        transport=ASGITransport(app=app), base_url="http://localhost"
     ) as client:
-        response = await client.get("/api/users")
+        response = await client.get("/v1/users")
     assert response.status_code == 200
     data = response.json()
     assert data["success"] is True

--- a/tests/factories/classification_factory.py
+++ b/tests/factories/classification_factory.py
@@ -1,0 +1,26 @@
+from src.classification.domain.dtos.classification_dto import ClassificationDTO
+from src.classification.interface.server.schemas.classification_schema import (
+    ClassifyRequest,
+)
+
+
+def make_classification_dto(
+    category: str = "positive",
+    confidence: float = 0.95,
+    reasoning: str = "The text expresses positive sentiment.",
+) -> ClassificationDTO:
+    return ClassificationDTO(
+        category=category,
+        confidence=confidence,
+        reasoning=reasoning,
+    )
+
+
+def make_classify_request(
+    text: str = "This is great!",
+    categories: list[str] | None = None,
+) -> ClassifyRequest:
+    return ClassifyRequest(
+        text=text,
+        categories=categories,
+    )


### PR DESCRIPTION
## Related Issue
- Fixes #
- Closes #

## Change Summary
- **docs sync**: refresh project-dna §13/§14 dependency tables for `pydantic-ai-slim` (anthropic/google extras; bedrock reuses `aioboto3`); add §12 LLM API Security to security-checklist; align §11 detection label with project-dna §8; bump `.claude/rules` Last synced.
- **classification fix**: drop invalid `model_config = ApiConfig` (ApiConfig is a BaseModel subclass, model_config expects a ConfigDict — also redundant since BaseRequest/BaseResponse already inherit ApiConfig); add `tests/factories/classification_factory.py` and `tests/e2e/classification/` (schema validation + OpenAPI route smoke; live LLM happy path stays in unit test with mocked Agent).
- **test infra hardening**: expose wired DynamicContainer via `app.state.container`; add autouse session fixture that overrides `CoreContainer.database` with `test_db` so e2e runs offline; make `test_db` engine-switchable via `TEST_DB_ENGINE` (default `sqlite`); pin `asyncio_default_{fixture,test}_loop_scope=session` to avoid asyncpg loop-binding errors; fix existing user e2e tests (`/api/*` → `/v1/*`, `http://test` → `http://localhost`).
- **make targets**: `make test-pg` (docker postgres + full pytest against PostgreSQL) and `make test-dynamo` (docker dynamodb-local + DynamoDB integration tests).

## Type of Change
- [ ] feat: New feature
- [ ] fix: Bug fix
- [ ] refactor: Code restructuring
- [x] docs: Documentation
- [x] chore: Build/tooling
- [x] test: Tests
- [ ] ci: CI/CD
- [ ] perf: Performance
- [ ] style: Code style

## Checklist
- [x] Architecture rules followed (no Domain -> Infrastructure imports)
- [x] Tests pass
- [x] Linting passes (`ruff check src/`)

## How to Test
- `make test` — SQLite default; expect **180 passed, 3 skipped** (DynamoDB integration auto-skips when dynamodb-local is not running).
- `make test-pg` — boots docker postgres, runs full suite against PostgreSQL; expect 180 passed (DynamoDB still requires `make test-dynamo`).
- `make test-dynamo` — boots docker dynamodb-local; expect **10 passed**.
- `pytest tests/e2e/ -v` — should pass without any docker container running (DI override uses SQLite in-memory).
- Verify the security checklist update: `docs/ai/shared/security-checklist.md` §12 LLM API Security exists; §11 detection condition references "Embedding (PydanticAI)".