### PR TITLE
feat(apps): add zero-config quickstart path

### DIFF
--- a/.claude/rules/commands.md
+++ b/.claude/rules/commands.md
@@ -7,7 +7,11 @@
 
 ## Run
 ```bash
-# FastAPI server (dev)
+# Zero-config quickstart (SQLite + InMemory broker, no external infra)
+make quickstart
+make demo            # in a second terminal — runs curl CRUD walkthrough
+
+# FastAPI server (dev — requires PostgreSQL via docker-compose.local.yml)
 uvicorn src._apps.server.app:app --reload --host 127.0.0.1 --port 8001
 # or
 python run_server_local.py --env local

--- a/.claude/rules/project-status.md
+++ b/.claude/rules/project-status.md
@@ -27,6 +27,7 @@
 | PydanticAI Agent Integration | #15 | Agent structured output, classification prototype, LLMConfig + build_llm_model |
 | PydanticAI Embedder Transition | ADR 039 | PydanticAIEmbeddingAdapter replaces per-provider clients, EmbeddingConfig VO |
 | Bedrock Credential Support | #15 | LLMConfig with per-service AWS credential injection, model_factory |
+| Zero-config Quickstart | #78 | `make quickstart` + `make demo`, ENV=quickstart with SQLite + InMemory broker + auto create_all, Settings defaults for zero-infra boot |
 
 ## Architecture Violation Status
 - Domain → Infrastructure import: CLEAN

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,9 @@ When fields match, Request is passed directly to Service — creating a separate
 ### Run
 
 ```bash
-make dev
+make quickstart   # zero-config evaluation (SQLite + InMemory broker)
+make demo         # curl walkthrough against running quickstart
+make dev          # real local dev (PostgreSQL via docker-compose)
 make worker
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,11 @@ Thank you for your interest in contributing! This guide will help you get starte
 
 ## Development Setup
 
+> First time evaluating the project? Run `make quickstart` instead — it
+> boots the server on SQLite with no external infrastructure. See
+> [`docs/quickstart.md`](docs/quickstart.md). The setup below is for
+> actual contribution work against PostgreSQL + migrations.
+
 ```bash
 # Clone the repository
 git clone https://github.com/Mr-DooSun/fastapi-agent-blueprint.git

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup dev test lint format check clean
+.PHONY: help setup quickstart demo dev test lint format check clean
 
 ## Show available commands
 help:
@@ -11,6 +11,22 @@ help:
 ## Setup development environment
 setup:
 	uv venv && uv sync --group dev && uv run pre-commit install && uv run pre-commit install --hook-type commit-msg
+
+## Zero-config quickstart: SQLite + InMemory broker, no external infra
+quickstart:
+	@if [ ! -f _env/quickstart.env ]; then \
+		echo "→ Creating _env/quickstart.env from template"; \
+		cp _env/quickstart.env.example _env/quickstart.env; \
+	fi
+	@echo "→ Starting FastAPI server on http://127.0.0.1:8001"
+	@echo "  Docs:       http://127.0.0.1:8001/docs-swagger"
+	@echo "  Admin:      http://127.0.0.1:8001/admin (admin / admin)"
+	@echo "  Run demo:   make demo  (in another terminal)"
+	@uv run python run_server_local.py --env quickstart
+
+## Hit the running quickstart server with sample user requests
+demo:
+	@bash scripts/demo.sh
 
 ## Start local development (postgres + server)
 dev:

--- a/README.md
+++ b/README.md
@@ -71,6 +71,22 @@
 
 ## Quick Start
 
+### 60-second evaluation (no Docker, no Postgres, no credentials)
+
+```bash
+git clone https://github.com/Mr-DooSun/fastapi-agent-blueprint.git
+cd fastapi-agent-blueprint
+make setup        # one-time: create venv + install deps
+make quickstart   # boots FastAPI on SQLite + InMemory broker
+```
+
+Open http://127.0.0.1:8001/docs-swagger. In another terminal, `make demo`
+runs a full CRUD walkthrough against the `user` domain.
+
+Full details: [`docs/quickstart.md`](docs/quickstart.md).
+
+### Real local development (PostgreSQL + migrations)
+
 ```bash
 # 1. Clone
 git clone https://github.com/Mr-DooSun/fastapi-agent-blueprint.git

--- a/_env/quickstart.env.example
+++ b/_env/quickstart.env.example
@@ -1,0 +1,48 @@
+# ================================================================
+# Zero-config quickstart — run with `make quickstart`
+#
+# This env file is loaded automatically when you run `make quickstart`.
+# The goal: spin up the blueprint in under 60 seconds with no external
+# infrastructure (no Docker, no Postgres, no cloud credentials).
+#
+# Everything here uses safe local defaults:
+#   - SQLite file-backed database (./quickstart.db)
+#   - InMemory Taskiq broker (no queue needed)
+#   - No storage / DynamoDB / S3 Vectors / Embedding / LLM
+#   - Admin dashboard locked to admin/admin — CHANGE BEFORE ANY DEPLOYMENT
+#
+# For real local development, copy `_env/local.env.example` to
+# `_env/local.env` and run `make dev` instead.
+# ================================================================
+
+ENV=quickstart
+
+# ----------------------------------------------------------------
+# Admin Dashboard — http://127.0.0.1:8001/admin
+# ----------------------------------------------------------------
+ADMIN_ID=admin
+ADMIN_PASSWORD=admin
+ADMIN_STORAGE_SECRET=quickstart-dev-only-do-not-deploy
+
+# ----------------------------------------------------------------
+# Database — SQLite file (no server required)
+# ----------------------------------------------------------------
+DATABASE_ENGINE=sqlite
+DATABASE_NAME=./quickstart.db
+
+# sqlite ignores the fields below, but Settings still reads them
+DATABASE_USER=unused
+DATABASE_PASSWORD=unused
+DATABASE_HOST=unused
+DATABASE_PORT=0
+
+# ----------------------------------------------------------------
+# Message Broker — InMemory (no broker process required)
+# ----------------------------------------------------------------
+BROKER_TYPE=inmemory
+
+# ----------------------------------------------------------------
+# Network
+# ----------------------------------------------------------------
+ALLOWED_HOSTS=["localhost","127.0.0.1"]
+ALLOW_ORIGINS=["*"]

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -71,6 +71,22 @@
 
 ## 빠른 시작
 
+### 60초 평가용 (Docker·PostgreSQL·자격 증명 모두 불필요)
+
+```bash
+git clone https://github.com/Mr-DooSun/fastapi-agent-blueprint.git
+cd fastapi-agent-blueprint
+make setup        # 최초 1회: venv 생성 + 의존성 설치
+make quickstart   # SQLite + InMemory broker로 FastAPI 기동
+```
+
+http://127.0.0.1:8001/docs-swagger 을 열어보세요. 다른 터미널에서
+`make demo` 로 `user` 도메인 CRUD 전체 흐름을 curl로 돌려볼 수 있습니다.
+
+자세한 내용: [`docs/quickstart.md`](quickstart.md).
+
+### 실제 로컬 개발 (PostgreSQL + 마이그레이션)
+
 ```bash
 # 1. Clone
 git clone https://github.com/Mr-DooSun/fastapi-agent-blueprint.git

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,79 @@
+# Quickstart — run the blueprint in 60 seconds
+
+Zero external infrastructure. No Docker. No Postgres. No cloud credentials.
+Just Python + `uv` + one command.
+
+## Prerequisites
+
+- Python `>=3.12.9`
+- [`uv`](https://docs.astral.sh/uv/) (package manager)
+
+## Run it
+
+```bash
+make setup         # first time only — create venv + install deps
+make quickstart    # boots FastAPI on SQLite + InMemory broker
+```
+
+The server comes up on `http://127.0.0.1:8001`:
+
+| Endpoint | URL |
+|----------|-----|
+| Swagger docs | http://127.0.0.1:8001/docs-swagger |
+| ReDoc        | http://127.0.0.1:8001/docs-redoc |
+| Admin UI     | http://127.0.0.1:8001/admin (admin / admin) |
+| Health       | http://127.0.0.1:8001/health |
+
+## Exercise the API
+
+In a second terminal:
+
+```bash
+make demo
+```
+
+This hits the `user` domain via `curl`: health check → create → get → list →
+update → delete. Raw script is at [`scripts/demo.sh`](../scripts/demo.sh).
+
+## What does `quickstart` actually configure?
+
+`make quickstart` loads [`_env/quickstart.env`](../_env/quickstart.env.example)
+(auto-copied from the committed template on first run).
+
+| Setting | Value |
+|---------|-------|
+| `ENV` | `quickstart` |
+| `DATABASE_ENGINE` | `sqlite` → `./quickstart.db` |
+| `BROKER_TYPE` | `inmemory` (no queue server needed) |
+| `STORAGE_TYPE` | _(unset — object storage disabled)_ |
+| `LLM_PROVIDER` / `EMBEDDING_PROVIDER` | _(unset — AI features disabled)_ |
+| `ADMIN_ID` / `ADMIN_PASSWORD` | `admin` / `admin` |
+
+On startup the server auto-creates the SQLite schema from `Base.metadata`
+(see [`src/_apps/server/bootstrap.py`](../src/_apps/server/bootstrap.py)) —
+no migrations required.
+
+**This path is for evaluation only.** `ADMIN_PASSWORD=admin` and the shared
+`ADMIN_STORAGE_SECRET` will not pass the `stg`/`prod` safety check in
+[`src/_core/config.py`](../src/_core/config.py).
+
+## Next steps
+
+- **Real local development** — copy `_env/local.env.example` to
+  `_env/local.env`, edit values, then run `make dev` (spins up PostgreSQL
+  via Docker Compose).
+- **Add a domain** — see [AGENTS.md](../AGENTS.md) and
+  [docs/ai-development.md](ai-development.md), or invoke the
+  `/new-domain` skill if you use Claude Code / Codex.
+- **Enable AI features** — set `LLM_PROVIDER` / `EMBEDDING_PROVIDER` (and
+  the matching credentials) in your env file. The `classification` domain
+  demonstrates the PydanticAI Agent integration.
+
+## Troubleshooting
+
+- **Port 8001 already in use** — kill the previous server:
+  `pkill -f run_server_local.py`
+- **Fresh schema** — delete the SQLite file: `rm -f ./quickstart.db`, then
+  re-run `make quickstart`
+- **Regenerate the env file** — delete `_env/quickstart.env` and run
+  `make quickstart` again

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -16,7 +16,7 @@ config = context.config
 
 # Resolve environment: ENV variable > alembic.ini > default "local"
 env = os.getenv("ENV") or config.get_main_option("env") or "local"
-valid_envs = {"local", "dev", "stg", "prod"}
+valid_envs = {"quickstart", "local", "dev", "stg", "prod"}
 if env not in valid_envs:
     raise RuntimeError(
         f"Invalid ENV '{env}'. Expected one of: {', '.join(sorted(valid_envs))}. "

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# --------------------------------------------------------------
+# Quickstart demo — exercise the user domain via curl.
+# Expects a quickstart server running on http://127.0.0.1:8001
+# (start it with `make quickstart` in another terminal).
+# --------------------------------------------------------------
+
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://127.0.0.1:8001}"
+
+note() { printf "\n\033[1;36m→ %s\033[0m\n" "$*"; }
+run()  { printf "\033[0;90m$ %s\033[0m\n" "$*"; eval "$*"; }
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "curl is required but not installed." >&2
+  exit 1
+fi
+
+# Pretty-print JSON if python3 is available, otherwise pass through.
+pretty() {
+  if command -v python3 >/dev/null 2>&1; then
+    python3 -m json.tool 2>/dev/null || cat
+  else
+    cat
+  fi
+}
+
+note "Health check"
+run "curl -sS '${BASE_URL}/health' | pretty"
+
+note "Create a user"
+CREATE_BODY='{"username":"alice","full_name":"Alice Liddell","email":"alice@example.com","password":"secret123"}'
+CREATE_RESPONSE="$(curl -sS -X POST "${BASE_URL}/v1/user" \
+  -H 'Content-Type: application/json' \
+  -d "${CREATE_BODY}")"
+echo "${CREATE_RESPONSE}" | pretty
+
+USER_ID="$(echo "${CREATE_RESPONSE}" | python3 -c "import json,sys;print(json.load(sys.stdin)['data']['id'])" 2>/dev/null || echo "")"
+
+if [ -z "${USER_ID}" ]; then
+  echo "Could not parse created user id from response — aborting." >&2
+  exit 1
+fi
+
+note "Get the user by id (id=${USER_ID})"
+run "curl -sS '${BASE_URL}/v1/user/${USER_ID}' | pretty"
+
+note "List users (page=1, pageSize=10)"
+run "curl -sS '${BASE_URL}/v1/users?page=1&pageSize=10' | pretty"
+
+note "Update the user"
+UPDATE_BODY='{"full_name":"Alice (updated)"}'
+run "curl -sS -X PUT '${BASE_URL}/v1/user/${USER_ID}' -H 'Content-Type: application/json' -d '${UPDATE_BODY}' | pretty"
+
+note "Delete the user"
+run "curl -sS -X DELETE '${BASE_URL}/v1/user/${USER_ID}' | pretty"
+
+note "Done. Swagger UI: ${BASE_URL}/docs-swagger"

--- a/src/_apps/server/bootstrap.py
+++ b/src/_apps/server/bootstrap.py
@@ -17,6 +17,7 @@ from src._core.exceptions.exception_handlers import (
     http_exception_handler,
     validation_exception_handler,
 )
+from src._core.infrastructure.database.database import Base, Database
 from src._core.infrastructure.discovery import discover_domains
 
 
@@ -42,6 +43,12 @@ def bootstrap_app(app: FastAPI) -> None:
     # Bootstrap DI container (auto-discovery)
     server_container = create_server_container()
     app.state.container = server_container
+
+    # Quickstart convenience: auto-create tables from model metadata so that
+    # `make quickstart` works with an empty SQLite file and no migrations.
+    # Real environments (local/dev/stg/prod) must use Alembic.
+    if settings.env.lower() == "quickstart":
+        _auto_create_tables(server_container.core_container.database())
 
     # Wire core container for health check DI
     # (core is not a domain — no separate bootstrap file needed)
@@ -74,3 +81,16 @@ def _bootstrap_domains(app: FastAPI, server_container) -> None:
             database=server_container.core_container.database(),
             **{f"{name}_container": domain_container},
         )
+
+
+def _auto_create_tables(database: Database) -> None:
+    """Create tables from SQLAlchemy metadata — quickstart only.
+
+    Invoked at bootstrap time when ``ENV=quickstart`` so a fresh SQLite file
+    immediately has the schema needed for the `user` domain (and any other
+    domain whose models are registered on ``Base.metadata``).
+
+    Real deployments use Alembic migrations; calling ``create_all`` against
+    a non-sqlite engine would mask migration drift.
+    """
+    Base.metadata.create_all(database.engine)

--- a/src/_core/config.py
+++ b/src/_core/config.py
@@ -4,7 +4,7 @@ from typing import Self
 from pydantic import AliasChoices, Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-KNOWN_ENVS = ("local", "dev", "stg", "prod")
+KNOWN_ENVS = ("quickstart", "local", "dev", "stg", "prod")
 KNOWN_ENGINES = ("postgresql", "mysql", "sqlite")
 KNOWN_BROKER_TYPES = ("sqs", "rabbitmq", "inmemory")
 KNOWN_EMBEDDING_PROVIDERS = (
@@ -59,7 +59,7 @@ class Settings(BaseSettings):
     # General
     # ----------------------------------------------------------------
     # Environment (e.g. local, dev, stg, prod)
-    env: str = Field("local", validation_alias=AliasChoices("ENV", "env"))
+    env: str = Field(default="local", validation_alias=AliasChoices("ENV", "env"))
 
     # Taskiq task name prefix (e.g. "my-project.user.test")
     task_name_prefix: str = Field(
@@ -68,20 +68,36 @@ class Settings(BaseSettings):
 
     # ----------------------------------------------------------------
     # Admin Dashboard
+    #
+    # Defaults here are intentionally unsafe ("admin"/"admin") so that
+    # `make quickstart` runs with no configuration. They are blocked in
+    # stg/prod by the `_UNSAFE_DEFAULTS` check below; callers in real
+    # deployments must override them via env vars.
     # ----------------------------------------------------------------
-    admin_id: str = Field(validation_alias="ADMIN_ID")
-    admin_password: str = Field(validation_alias="ADMIN_PASSWORD")
-    admin_storage_secret: str = Field(validation_alias="ADMIN_STORAGE_SECRET")
+    admin_id: str = Field(default="admin", validation_alias="ADMIN_ID")
+    admin_password: str = Field(default="admin", validation_alias="ADMIN_PASSWORD")
+    admin_storage_secret: str = Field(
+        default="change-me-in-production", validation_alias="ADMIN_STORAGE_SECRET"
+    )
 
     # ----------------------------------------------------------------
     # Database
+    #
+    # Defaults target the zero-config SQLite path used by `make quickstart`.
+    # For non-sqlite engines, the user/password/host/port/name fields must
+    # all be supplied via env vars. stg/prod additionally reject the
+    # unsafe-password and unsafe-host defaults via `_UNSAFE_DEFAULTS`.
     # ----------------------------------------------------------------
-    database_engine: str = Field(validation_alias="DATABASE_ENGINE")
-    database_user: str = Field(validation_alias="DATABASE_USER")
-    database_password: str = Field(validation_alias="DATABASE_PASSWORD")
-    database_host: str = Field(validation_alias="DATABASE_HOST")
-    database_port: int = Field(validation_alias="DATABASE_PORT")
-    database_name: str = Field(validation_alias="DATABASE_NAME")
+    database_engine: str = Field(default="sqlite", validation_alias="DATABASE_ENGINE")
+    database_user: str = Field(default="postgres", validation_alias="DATABASE_USER")
+    database_password: str = Field(
+        default="postgres", validation_alias="DATABASE_PASSWORD"
+    )
+    database_host: str = Field(default="localhost", validation_alias="DATABASE_HOST")
+    database_port: int = Field(default=5432, validation_alias="DATABASE_PORT")
+    database_name: str = Field(
+        default="./quickstart.db", validation_alias="DATABASE_NAME"
+    )
     database_pool_size: int | None = Field(
         default=None, validation_alias="DATABASE_POOL_SIZE"
     )
@@ -437,7 +453,7 @@ class Settings(BaseSettings):
 
     @property
     def is_dev(self) -> bool:
-        return self.env.lower() in {"dev", "local"}
+        return self.env.lower() in {"quickstart", "dev", "local"}
 
     @property
     def docs_url(self) -> str | None:


### PR DESCRIPTION
## Summary

Closes #78. Introduces `make quickstart` so a first-time visitor can boot the blueprint in under 60 seconds with no external infrastructure (no Docker, no Postgres, no cloud credentials).

- **SQLite + InMemory broker**, `admin_*` / `database_*` Settings fields get safe local defaults (stg/prod still reject them via `_UNSAFE_DEFAULTS`)
- **Auto-create tables** from `Base.metadata` on startup when `ENV=quickstart`, so an empty SQLite file works without running Alembic
- **`make demo`** (`scripts/demo.sh`) runs a curl walkthrough against the `user` domain: health → create → get → list → update → delete
- New `docs/quickstart.md`; README / CONTRIBUTING / AGENTS / `.claude/rules/*` / ko README all point to it without regressing the existing `make dev` path

## Changes

| File | Change |
|---|---|
| `src/_core/config.py` | `quickstart` added to `KNOWN_ENVS` + `is_dev`; zero-config defaults for admin / database fields |
| `migrations/env.py` | `quickstart` added to alembic `valid_envs` |
| `src/_apps/server/bootstrap.py` | `_auto_create_tables()` invoked when `ENV=quickstart` |
| `Makefile` | `quickstart` / `demo` targets |
| `_env/quickstart.env.example` | new — checked-in template, auto-copied on first run |
| `scripts/demo.sh` | new — curl walkthrough of the user domain |
| `docs/quickstart.md` | new — user-facing doc |
| `README.md`, `docs/README.ko.md`, `CONTRIBUTING.md`, `AGENTS.md`, `.claude/rules/{project-status,commands}.md` | surface the quickstart path |

## Test plan

- [x] `pytest tests/` → 190 passed, 3 skipped (no regression; strict-env / `_UNSAFE_DEFAULTS` checks still enforce stg/prod)
- [x] Fresh state (no `_env/quickstart.env`, no `quickstart.db`) → `make quickstart` → server boots on http://127.0.0.1:8001
- [x] `make demo` hits every CRUD endpoint successfully (health → create → get → list → update → delete)
- [x] `pre-commit run --files …` passes on all changed files
- [ ] Reviewer: confirm the new `_env/quickstart.env.example` does not leak any credentials and that the gitignored `_env/quickstart.env` follows the existing `_env/*.env` rule

## Scope notes

- README restructure (demo-first layout, diagrams) is intentionally **not** in this PR — tracked separately in #79 and #81.
- `docs/notes/` remains untracked per the working tree at branch creation time.