### PR TITLE
docs: add visual architecture and data-flow diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,13 +196,34 @@ class ProductService(BaseService[CreateProductRequest, UpdateProductRequest, Pro
 
 ## Architecture
 
-```
-Router -> Service(BaseService) -> Repository(BaseRepository) -> DB
-               ^ Simple CRUD: this is all you need
+Arrow direction = **"depends on"**. Domain sits at the center; Interface
+and Infrastructure point inward. UseCase is optional — the dotted bypass
+line is the common path for simple CRUD.
 
-Router -> UseCase -> Service -> Repository -> DB
-               ^ Add only when complex business logic is required
+```mermaid
+flowchart LR
+    subgraph domain["src/{domain}/  (4 DDD layers)"]
+        I["Interface<br/>routers · admin · worker · schemas"]
+        A["Application<br/>use cases — optional"]
+        D["Domain<br/>services · protocols · DTOs · value objects"]
+        Inf["Infrastructure<br/>repositories · models · DI container"]
+        I --> A
+        A --> D
+        Inf --> D
+        I -. direct when no UseCase .-> D
+    end
+
+    Core["src/_core/<br/>Base classes · CoreContainer · shared VOs"]
+    I --> Core
+    A --> Core
+    D --> Core
+    Inf --> Core
+
+    Other["Another domain"] -. via Protocol-based DIP .-> D
 ```
+
+> **Deep dive:** [`docs/ai/shared/architecture-diagrams.md`](docs/ai/shared/architecture-diagrams.md)
+> (canonical diagrams + full variant table for RDB / DynamoDB / S3 Vectors).
 
 ### Layer Responsibilities
 
@@ -215,14 +236,42 @@ Router -> UseCase -> Service -> Repository -> DB
 
 ### Data Flow
 
-```
-Write: Request --> Service --> Repository --> Model -> DB
-Read:  Response <-- Service <-- Repository <-- DTO <-- Model
+**Write** — `POST` / `PUT` / `DELETE`
+
+```mermaid
+flowchart LR
+    C[Client] -->|"HTTP + JSON"| R[Router]
+    R -->|"Request schema"| S[Service]
+    S -->|"entity"| Re["Repository<br/>BaseRepository[DTO]"]
+    Re -->|"Model(**dto.model_dump())"| M[ORM Model]
+    M -->|"SQLAlchemy"| DB[(Database)]
 ```
 
-- Request is passed directly to Service (no extra conversion needed)
-- Repository handles Model -> DTO conversion (`model_validate(model, from_attributes=True)`)
-- Router handles DTO -> Response conversion (`Response(**dto.model_dump(exclude={...}))`)
+**Read** — `GET`
+
+```mermaid
+flowchart LR
+    DB[(Database)] -->|"row"| M[ORM Model]
+    M -->|"DTO.model_validate(from_attributes=True)"| Re[Repository]
+    Re -->|"ReturnDTO"| S[Service]
+    S -->|"ReturnDTO"| R[Router]
+    R -->|"Response(exclude={sensitive})"| C[Client]
+```
+
+- Request passes directly to Service when fields match (no extra DTO)
+- Repository owns the single Model ↔ DTO conversion boundary
+- Router strips sensitive fields (`password`, etc.) at the Response edge
+
+### Storage Variants
+
+Same flow shape across all three storage backends — only the base classes
+and persistence types change.
+
+| Storage | Service base | Repo / Store base | Persistence | List return |
+|---|---|---|---|---|
+| RDB (default) | `BaseService[Create, Update, DTO]` | `BaseRepository[DTO]` | ORM `Model(Base)` | `(list[DTO], PaginationInfo)` |
+| DynamoDB | `BaseDynamoService[...]` | `BaseDynamoRepository[DTO]` | `DynamoModel` | `CursorPage[DTO]` |
+| S3 Vectors | domain-specific | `BaseS3VectorStore[DTO]` | `S3VectorModel` | `VectorSearchResult[DTO]` |
 
 ### Data Objects
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -196,13 +196,34 @@ class ProductService(BaseService[CreateProductRequest, UpdateProductRequest, Pro
 
 ## 아키텍처
 
-```
-Router -> Service(BaseService) -> Repository(BaseRepository) -> DB
-               ^ 단순 CRUD는 이것만으로 충분
+화살표 방향 = **"의존한다"**. Domain 이 중심에 있고 Interface / Infrastructure
+가 Domain 을 향해 의존합니다. UseCase 는 선택 사항 — 단순 CRUD 는 점선
+경로(직접 연결)를 사용합니다.
 
-Router -> UseCase -> Service -> Repository -> DB
-               ^ 복잡한 비즈니스 로직이 필요할 때만 추가
+```mermaid
+flowchart LR
+    subgraph domain["src/{domain}/  (4 DDD layers)"]
+        I["Interface<br/>routers · admin · worker · schemas"]
+        A["Application<br/>use cases — optional"]
+        D["Domain<br/>services · protocols · DTOs · value objects"]
+        Inf["Infrastructure<br/>repositories · models · DI container"]
+        I --> A
+        A --> D
+        Inf --> D
+        I -. direct when no UseCase .-> D
+    end
+
+    Core["src/_core/<br/>Base classes · CoreContainer · shared VOs"]
+    I --> Core
+    A --> Core
+    D --> Core
+    Inf --> Core
+
+    Other["다른 도메인"] -. Protocol 기반 DIP .-> D
 ```
+
+> **전체 다이어그램 + RDB / DynamoDB / S3 Vectors 변종 표:**
+> [`docs/ai/shared/architecture-diagrams.md`](ai/shared/architecture-diagrams.md)
 
 ### 계층별 책임
 
@@ -215,14 +236,42 @@ Router -> UseCase -> Service -> Repository -> DB
 
 ### 데이터 흐름
 
-```
-Write: Request --> Service --> Repository --> Model -> DB
-Read:  Response <-- Service <-- Repository <-- DTO <-- Model
+**Write** — `POST` / `PUT` / `DELETE`
+
+```mermaid
+flowchart LR
+    C[Client] -->|"HTTP + JSON"| R[Router]
+    R -->|"Request schema"| S[Service]
+    S -->|"entity"| Re["Repository<br/>BaseRepository[DTO]"]
+    Re -->|"Model(**dto.model_dump())"| M[ORM Model]
+    M -->|"SQLAlchemy"| DB[(Database)]
 ```
 
-- Request를 Service에 직접 전달 (별도 변환 불필요)
-- Repository가 Model -> DTO 변환 (`model_validate(model, from_attributes=True)`)
-- Router가 DTO -> Response 변환 (`Response(**dto.model_dump(exclude={...}))`)
+**Read** — `GET`
+
+```mermaid
+flowchart LR
+    DB[(Database)] -->|"row"| M[ORM Model]
+    M -->|"DTO.model_validate(from_attributes=True)"| Re[Repository]
+    Re -->|"ReturnDTO"| S[Service]
+    S -->|"ReturnDTO"| R[Router]
+    R -->|"Response(exclude={민감 필드})"| C[Client]
+```
+
+- 필드가 일치하면 Request 를 Service 에 그대로 전달 (별도 DTO 불필요)
+- Model ↔ DTO 변환은 **오직 Repository** 에서만 발생
+- 민감 필드(`password` 등)는 Router 가 Response 로 내보내기 직전에 제거
+
+### 저장소 변종
+
+세 저장소 모두 동일한 흐름 형태를 사용하며, Base 클래스와 영속 객체,
+리스트 반환 타입만 바뀝니다.
+
+| 저장소 | Service base | Repo / Store base | 영속 객체 | 리스트 반환 |
+|---|---|---|---|---|
+| RDB (기본) | `BaseService[Create, Update, DTO]` | `BaseRepository[DTO]` | ORM `Model(Base)` | `(list[DTO], PaginationInfo)` |
+| DynamoDB | `BaseDynamoService[...]` | `BaseDynamoRepository[DTO]` | `DynamoModel` | `CursorPage[DTO]` |
+| S3 Vectors | 도메인 고유 | `BaseS3VectorStore[DTO]` | `S3VectorModel` | `VectorSearchResult[DTO]` |
 
 ### 데이터 객체
 

--- a/docs/ai/shared/architecture-diagrams.md
+++ b/docs/ai/shared/architecture-diagrams.md
@@ -1,0 +1,107 @@
+# Visual Architecture Reference
+
+> Canonical Mermaid diagrams for layer dependencies and runtime data flow.
+> README / Korean README / `project-dna.md` / onboarding skill all reference
+> this file. Update the diagrams here when the architecture changes, then
+> confirm nothing downstream needs a matching edit.
+
+## 1. Layer Dependency
+
+Arrow direction = **"depends on"**: the tail imports from / is aware of the
+head. Domain sits at the center; Interface and Infrastructure both point
+inward.
+
+```mermaid
+flowchart LR
+    subgraph domain["src/{domain}/  (4 DDD layers)"]
+        I["Interface<br/>routers · admin · worker · schemas"]
+        A["Application<br/>use cases — optional"]
+        D["Domain<br/>services · protocols · DTOs · value objects"]
+        Inf["Infrastructure<br/>repositories · models · DI container"]
+        I --> A
+        A --> D
+        Inf --> D
+        I -. direct when no UseCase .-> D
+    end
+
+    Core["src/_core/<br/>Base classes · CoreContainer · shared VOs"]
+    I --> Core
+    A --> Core
+    D --> Core
+    Inf --> Core
+
+    Other["Another domain"] -. via Protocol-based DIP .-> D
+```
+
+- **UseCase is optional.** Simple CRUD routes Router → Service directly
+  (dotted bypass line). Add UseCase only when combining multiple services
+  or orchestrating transactions — ADR 011.
+- **`_core` holds framework primitives.** BaseService, BaseRepository,
+  BaseDynamoRepository, BaseS3VectorStore, CoreContainer, shared value
+  objects. Every layer may import from it.
+- **Cross-domain access goes through Protocol.** A domain declares its
+  public contract in `domain/protocols/` and other domains depend on the
+  protocol — never on the concrete repository.
+- **Forbidden edges:** `domain/ → infrastructure/`, `domain/ → interface/`.
+  Pre-commit hooks block the first; conventions block the second.
+
+## 2. Runtime Data Flow (RDB default)
+
+### Write — `POST` / `PUT` / `DELETE`
+
+```mermaid
+flowchart LR
+    C[Client] -->|"HTTP + JSON"| R[Router]
+    R -->|"Request schema"| S[Service]
+    S -->|"entity"| Re["Repository<br/>BaseRepository[DTO]"]
+    Re -->|"Model(**dto.model_dump())"| M[ORM Model]
+    M -->|"SQLAlchemy"| DB[(Database)]
+```
+
+### Read — `GET`
+
+```mermaid
+flowchart LR
+    DB[(Database)] -->|"row"| M[ORM Model]
+    M -->|"DTO.model_validate(from_attributes=True)"| Re[Repository]
+    Re -->|"ReturnDTO"| S[Service]
+    S -->|"ReturnDTO"| R[Router]
+    R -->|"Response(**dto.model_dump(<br/>exclude={sensitive}))"| C[Client]
+```
+
+- **Conversion boundaries** (numbered steps in `project-dna.md` §6):
+  Request → Service (direct pass when fields match),
+  Service → Repository (typed `entity`),
+  Repository ↔ Model (`model_dump()` out, `model_validate(from_attributes=True)` in),
+  Router → Response (`exclude` sensitive fields like `password`).
+- **Models never leave the Repository.** The `model_validate(...)` step is
+  the only place the ORM/DynamoDB/Vector model becomes a DTO.
+
+## 3. Storage Variants
+
+The flow shape (Client → Router → Service → Repository/Store → Model →
+storage) is identical across all three storage variants. Only the base
+classes, persistence object, and list/query value objects change — this
+is what the generics encode.
+
+| Storage | Service base | Repository / Store base | Persistence object | Query input | List return |
+|---|---|---|---|---|---|
+| **RDB** (default) | `BaseService[Create, Update, DTO]` | `BaseRepository[DTO]` | ORM `Model(Base)` | `QueryFilter` | `(list[DTO], PaginationInfo)` |
+| **DynamoDB** | `BaseDynamoService[Create, Update, DTO]` | `BaseDynamoRepository[DTO]` | `DynamoModel` | `DynamoKey` + `filter_expression` | `CursorPage[DTO]` |
+| **S3 Vectors** | domain-specific | `BaseS3VectorStore[DTO]` | `S3VectorModel` | `VectorQuery(vector, top_k, filters)` | `VectorSearchResult[DTO]` |
+
+- **RDB** uses offset pagination (`page`, `page_size`). Use `QueryFilter`
+  for sort/search combinations.
+- **DynamoDB** uses cursor pagination — DynamoDB does not support offset.
+  `CursorPage[DTO]` carries both items and the opaque next-page cursor.
+- **S3 Vectors** is a similarity-search API; the return carries distances
+  alongside items. Upsert accepts an `Entity`, not a typed Create DTO.
+
+## 4. Keep in Sync
+
+- Base class import paths: `project-dna.md` §2
+- Generic type signatures: `project-dna.md` §3
+- CRUD method signatures: `project-dna.md` §4
+- DI pattern (including `providers.Selector` for broker): `project-dna.md` §5
+- Conversion patterns (with explicit examples): `project-dna.md` §6
+- Detailed prohibitions (ADR 004, ADR 011): `AGENTS.md` Absolute Prohibitions

--- a/docs/ai/shared/project-dna.md
+++ b/docs/ai/shared/project-dna.md
@@ -15,6 +15,12 @@
 §9 Router Pattern | §10 Exception Pattern | §11 Admin Page Pattern
 §12 S3 Vector Store Pattern | §13 Embedding Pattern | §14 LLM Pattern
 
+> **Visual summary:** see [`architecture-diagrams.md`](architecture-diagrams.md)
+> for the layer dependency graph, Write/Read data flow (RDB), and the
+> RDB / DynamoDB / S3 Vectors variant table. The sections below are the
+> authoritative text reference; the diagrams exist to orient new readers
+> before they dig into §1–§14.
+
 ---
 
 ## §0. Project Scale and Design Philosophy

--- a/docs/ai/shared/skills/onboard.md
+++ b/docs/ai/shared/skills/onboard.md
@@ -166,10 +166,18 @@ Read the **AI Pair Programming (AIDD)** section of `README.md` and explain the f
 1. Read the **section 0 Project Scale** of `docs/ai/shared/project-dna.md`
    and explain the project's purpose and scale.
 
-2. Show the architecture core as a diagram (keep it concise since context is already known from Phase 1):
+2. Show the architecture core by referencing the canonical diagrams in
+   `docs/ai/shared/architecture-diagrams.md` — render the Layer Dependency
+   diagram and the Write/Read Data Flow diagrams inline (they are Mermaid,
+   so they render in GitHub / most Markdown viewers). Point out:
+   - Domain sits at the center; Interface and Infrastructure point inward
+   - UseCase is the dotted bypass — simple CRUD uses `Router → Service` directly
+   - Cross-domain access uses Protocol-based DIP, never direct imports
+
+   For harnesses/clients that cannot render Mermaid, fall back to:
    ```
-   Basic: Router -> Service(BaseService) -> Repository(BaseRepository)
-   Complex: Router -> UseCase -> Service -> Repository (when combining multiple Services)
+   Basic:   Router -> Service(BaseService) -> Repository(BaseRepository)
+   Complex: Router -> UseCase -> Service -> Repository   (when combining multiple Services)
    ```
 
 3. Read **section 1 Domain Directory Structure** of `docs/ai/shared/project-dna.md` and show the file composition of a single domain.


### PR DESCRIPTION
## Summary

Closes #81. Introduces canonical Mermaid diagrams so new readers and new teammates can orient themselves without wading through 41 ADRs or the `project-dna.md` pattern tables first.

- **One source of truth**: `docs/ai/shared/architecture-diagrams.md` holds the layer dependency graph, Write/Read data flow (RDB), and the RDB / DynamoDB / S3 Vectors variant table.
- **README surfaces them inline** (native GitHub Mermaid rendering) and links to the canonical file for the variant table.
- **Korean README** mirrors the same diagrams and link.
- **`project-dna.md`** gets a short pointer at the top of the section index — kept intentionally outside the `/sync-guidelines` auto-extract scope, so manual edits here survive the next regeneration.
- **`/onboard` skill** Phase 2 swaps its inline ASCII for a reference to the canonical diagrams, with a plain-text fallback for clients that cannot render Mermaid.

## Files

| File | Change |
|---|---|
| `docs/ai/shared/architecture-diagrams.md` | new — canonical Mermaid diagrams + variant table |
| `README.md` | Architecture section Mermaid + link to canonical |
| `docs/README.ko.md` | Korean mirror of the same |
| `docs/ai/shared/project-dna.md` | section-index pointer to the canonical file |
| `docs/ai/shared/skills/onboard.md` | Phase 2 points to canonical diagrams + ASCII fallback |

## Test plan

- [x] Every Mermaid block (3 files × 3 blocks) parses and renders through `@mermaid-js/mermaid-cli` 11.12.0 — the same engine GitHub uses for native Markdown Mermaid.
- [x] Pre-commit hooks pass on all changed files.
- [ ] Reviewer: open each Markdown file on GitHub and confirm all 9 Mermaid blocks render visually (layer dependency + 2 data flows × 3 files).
- [ ] Reviewer: confirm the canonical file in `docs/ai/shared/` is the right place (sibling of `project-dna.md` / `scaffolding-layers.md`) vs. `docs/` top level.

## Scope notes

- Intentionally **not** in this PR: full README restructure (#79) or consolidation of ADR reading order (#83). This PR only adds diagrams; prose organization stays as-is.
- No DynamoDB / S3 Vectors Mermaid flow diagrams — their data flow shape is identical to RDB, so they are documented as a compact variant table instead. If a reviewer wants separate diagrams per storage, happy to add.