### PR TITLE
docs: restructure README demo-first with tiered depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,17 @@
 </p>
 
 <p align="center">
-  <b>FastAPI DDD template, built for AI agent backends.</b><br>
-  Zero-boilerplate CRUD + auto discovery + vector search today. MCP server + AI orchestration coming soon.<br>
-  14+ AI development skills for Claude Code &amp; Codex CLI.
+  <b>Production-ready FastAPI blueprint for AI agent backends.</b><br>
+  DDD layers · zero-boilerplate CRUD · auto domain discovery · multi-interface (API · worker · admin · MCP-ready) ·<br>
+  vector / embedding / LLM infra · built-in AI dev skills for Claude Code &amp; Codex CLI.
 </p>
 
 <p align="center">
-  <a href="#quick-start">Quick Start</a> · <a href="#who-is-this-for">Who is this for?</a> · <a href="#architecture">Architecture</a> · <a href="#comparison">Comparison</a> · <a href="docs/README.ko.md">한국어</a>
+  <a href="#try-it-in-60-seconds">60s Quickstart</a>
+  · <a href="#architecture-at-a-glance">Architecture</a>
+  · <a href="#ai-native-development">AI Skills</a>
+  · <a href="#how-it-compares">Comparison</a>
+  · <a href="docs/README.ko.md">한국어</a>
 </p>
 
 <p align="center">
@@ -35,170 +39,75 @@
 
 ---
 
-## Who is this for?
+## Try it in 60 seconds
 
-- **FastAPI developers** who need a production-ready project structure beyond the tutorial stage — DDD layers, DI container, async throughout, architecture enforcement
-- **Backend teams** building systems that need multiple interfaces (REST API + background workers + admin UI) sharing the same domain logic
-- **AI agent builders** who need vector search and embedding infrastructure ready out of the box, with MCP server and PydanticAI orchestration coming soon
-- **AI-augmented developers** who use Claude Code or Codex CLI and want a codebase with 14+ built-in AI development skills that work in both tools
-
----
-
-## What You Get
-
-- **Zero-boilerplate CRUD** — Inherit `BaseRepository[DTO]` + `BaseService[Create, Update, DTO]`, get 7 async methods instantly
-- **Auto domain discovery** — Add a domain folder, it auto-registers. No container or bootstrap changes
-- **3 interface types** — HTTP API (FastAPI) + Async Worker (Taskiq) + Admin UI (NiceGUI), all sharing one domain layer
-- **Pluggable infrastructure** — PostgreSQL/MySQL/SQLite, DynamoDB, S3/MinIO, SQS/RabbitMQ, OpenAI/Bedrock — switch by env var
-- **Vector infrastructure** — S3 Vectors + OpenAI/Bedrock embeddings + semantic chunking utilities
-- **Type-safe generics** — `BaseRepository[ProductDTO]`, `BaseService[CreateProductRequest, UpdateProductRequest, ProductDTO]`, `SuccessResponse[ProductResponse]`
-- **Architecture enforcement** — Pre-commit hooks block `Domain → Infrastructure` imports at commit time
-- **DynamoDB support** — `BaseDynamoRepository` with cursor-based pagination alongside PostgreSQL
-- **14+ AI development skills** — Works in both Claude Code and Codex CLI: `new-domain`, `add-api`, `onboard`, `review-architecture`, and more ([details](#ai-native-development))
-- **Async-first** — From DB (asyncpg) to HTTP (aiohttp) to task queue (Taskiq)
-- **37 ADRs** — Every technical choice documented with rationale ([view index](docs/history/README.md))
-
-<details>
-<summary><b>Coming soon</b></summary>
-
-- **MCP Server interface** — Expose domain services as AI agent tools via FastMCP ([#18](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/18))
-- **PydanticAI integration** — Structured LLM orchestration with Pydantic-native outputs ([#15](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/15))
-- **pgvector** — Additional vector backend ([#11](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/11))
-
-</details>
-
----
-
-## Quick Start
-
-### 60-second evaluation (no Docker, no Postgres, no credentials)
+No Docker, no PostgreSQL, no cloud credentials — SQLite + in-memory broker.
 
 ```bash
 git clone https://github.com/Mr-DooSun/fastapi-agent-blueprint.git
 cd fastapi-agent-blueprint
-make setup        # one-time: create venv + install deps
-make quickstart   # boots FastAPI on SQLite + InMemory broker
+make setup        # one-time: venv + deps via uv
+make quickstart   # FastAPI on :8001, SQLite schema auto-created
 ```
 
-Open http://127.0.0.1:8001/docs-swagger. In another terminal, `make demo`
-runs a full CRUD walkthrough against the `user` domain.
+In a second terminal, `make demo` exercises the `user` domain with `curl`:
 
-Full details: [`docs/quickstart.md`](docs/quickstart.md).
+```text
+→ Health check
+{ "status": "ok" }
 
-### Real local development (PostgreSQL + migrations)
+→ Create a user
+{ "success": true, "data": { "id": 1, "username": "alice",
+                             "fullName": "Alice Liddell", ... } }
 
-```bash
-# 1. Clone
-git clone https://github.com/Mr-DooSun/fastapi-agent-blueprint.git
-cd fastapi-agent-blueprint
+→ List users (page=1, pageSize=10)
+{ "data": [ { "id": 1, "username": "alice", ... } ],
+  "pagination": { "currentPage": 1, "totalItems": 1,
+                  "hasNext": false, ... } }
 
-# 2. Setup (requires uv)
-make setup
-
-# 3. Set up environment variables
-cp _env/local.env.example _env/local.env
-
-# 4. Start PostgreSQL + run migrations + start server
-make dev
+→ Update the user    → Delete the user
+→ Done. Swagger UI: http://127.0.0.1:8001/docs-swagger
 ```
 
-Open http://localhost:8000/docs-swagger to explore the API.
-
-<details>
-<summary>Manual setup (without Make)</summary>
-
-```bash
-# 2. Create virtual environment + install dependencies
-uv venv --python 3.12
-source .venv/bin/activate
-uv sync --group dev
-
-# 3. Set up environment variables
-cp _env/local.env.example _env/local.env
-
-# 4. Start PostgreSQL (Docker)
-docker compose -f docker-compose.local.yml up -d postgres
-
-# 5. Run migrations + start server
-alembic upgrade head
-python run_server_local.py --env local
-```
-</details>
+- Swagger: <http://127.0.0.1:8001/docs-swagger>
+- Admin UI: <http://127.0.0.1:8001/admin> (`admin` / `admin`)
+- Full walkthrough: [`docs/quickstart.md`](docs/quickstart.md)
+- Real dev stack (PostgreSQL + migrations): [`docs/reference.md`](docs/reference.md#local-development-with-postgresql)
 
 ---
 
-## Why?
+## Why this blueprint
 
-### Your domain logic — accessible everywhere
-
-Write business logic once. Expose it as a REST API, background job, admin view, or AI agent tool.
-
-```python
-# 1. Define your service
-class DocumentService(
-    BaseService[CreateDocumentRequest, UpdateDocumentRequest, DocumentDTO]
-):
-    async def analyze(self, document_id: int) -> AnalysisDTO:
-        ...  # your business logic
-
-# 2. REST API — for your frontend
-@router.post("/documents/{document_id}/analyze")
-async def analyze_document(document_id: int, service=Depends(...)):
-    return await service.analyze(document_id)
-
-# 3. MCP Tool — for AI agents (coming soon)
-@mcp.tool()
-async def analyze_document(document_id: int) -> AnalysisResult:
-    return await document_service.analyze(document_id)
-
-# 4. Background job — for batch processing
-@broker.task()
-async def batch_analyze(project_id: int):
-    for doc in await service.get_by_project(project_id):
-        await service.analyze(doc.id)
-```
-
-### Zero-boilerplate CRUD
-
-```python
-# Before: Repeat the same CRUD for every domain
-@router.post("/user")
-async def create_user(user: UserCreate):
-    db = get_db()
-    new_user = User(**user.dict())
-    db.add(new_user)
-    db.commit()
-    return new_user
-
-@router.post("/product")  # Repeat again...
-async def create_product(product: ProductCreate):
-    db = get_db()
-    new_product = Product(**product.dict())
-    db.add(new_product)
-    db.commit()
-    return new_product
-```
-
-```python
-# After: One inheritance line, CRUD done
-class ProductRepository(BaseRepository[ProductDTO]):
-    def __init__(self, database: Database):
-        super().__init__(database=database, model=ProductModel, return_entity=ProductDTO)
-
-class ProductService(BaseService[CreateProductRequest, UpdateProductRequest, ProductDTO]):
-    def __init__(self, product_repository: ProductRepositoryProtocol):
-        super().__init__(repository=product_repository)
-
-# Core CRUD methods and pagination helpers are provided automatically
-```
+- **Write domain logic once, expose it everywhere.** HTTP (FastAPI) + worker (Taskiq) + admin (NiceGUI) share a single domain layer. MCP server is on the roadmap.
+- **Zero-boilerplate CRUD.** Inherit `BaseRepository[DTO]` and `BaseService[Create, Update, DTO]` to get 7 async methods — including paginated list with `QueryFilter` — for free.
+- **Auto domain discovery.** Drop a folder into `src/{name}/`, it auto-registers. No container edits, no bootstrap edits.
+- **Pluggable infra, env-switchable.** PostgreSQL / MySQL / SQLite · DynamoDB · S3 / MinIO · S3 Vectors · SQS / RabbitMQ / InMemory · OpenAI / Bedrock for both LLM and embeddings.
+- **Architecture enforced at commit time.** A pre-commit hook blocks `Domain → Infrastructure` imports so the DDD contract cannot rot.
+- **AI-native workflows.** 14 Claude Code skills + 15 Codex CLI skills sharing one `AGENTS.md` rules file — scaffold a domain, add a route, or audit architecture with a single command.
 
 ---
 
-## Architecture
+## How it compares
 
-Arrow direction = **"depends on"**. Domain sits at the center; Interface
-and Infrastructure point inward. UseCase is optional — the dotted bypass
-line is the common path for simple CRUD.
+| Feature | FastAPI Agent Blueprint | [tiangolo/full-stack](https://github.com/fastapi/full-stack-fastapi-template) | [s3rius/template](https://github.com/s3rius/FastAPI-template) | [teamhide/boilerplate](https://github.com/teamhide/fastapi-boilerplate) |
+|---|:-:|:-:|:-:|:-:|
+| Zero-boilerplate CRUD (7 methods) | **Yes** | No | No | No |
+| Auto domain discovery | **Yes** | No | No | No |
+| Architecture enforcement (pre-commit) | **Yes** | No | No | No |
+| AI workflow skills (Claude + Codex) | **14 + 15** | 0 | 0 | 0 |
+| Vector infrastructure (S3 Vectors) | **Yes** | No | No | No |
+| Multi-interface (API + Worker + Admin + MCP) | **3 + 1 planned** | 2 | 1 | 1 |
+| Architecture Decision Records | **40** | 0 | 0 | 0 |
+| Type-safe generics across layers | **Yes** | Partial | Partial | No |
+| IoC container DI | **Yes** | No | No | No |
+
+---
+
+## Architecture at a glance
+
+Every domain under `src/{domain}/` has four DDD layers. Arrows mean
+**"depends on"**. `Application` (use cases) is optional — the dotted
+line is the common path for simple CRUD (Router → Service directly).
 
 ```mermaid
 flowchart LR
@@ -222,21 +131,20 @@ flowchart LR
     Other["Another domain"] -. via Protocol-based DIP .-> D
 ```
 
-> **Deep dive:** [`docs/ai/shared/architecture-diagrams.md`](docs/ai/shared/architecture-diagrams.md)
-> (canonical diagrams + full variant table for RDB / DynamoDB / S3 Vectors).
+| Layer | Role | Base class |
+|---|---|---|
+| Interface | Router · Request/Response · Admin · Worker task | — |
+| Domain | Service · Protocol · DTO · Exceptions | `BaseService[CreateDTO, UpdateDTO, ReturnDTO]` |
+| Infrastructure | Repository · Model · DI container | `BaseRepository[ReturnDTO]` |
+| Application | UseCase — optional orchestrator | — |
 
-### Layer Responsibilities
+> Full set of diagrams (Layer · Write · Read) plus RDB / DynamoDB / S3
+> Vectors variants lives in
+> [`docs/ai/shared/architecture-diagrams.md`](docs/ai/shared/architecture-diagrams.md).
+> Non-Mermaid viewers:
+> [SVG exports](docs/assets/architecture/).
 
-| Layer | Role | Base Class |
-|-------|------|-----------|
-| **Interface** | Router, Request/Response, Admin, Worker Task, MCP Tool | - |
-| **Domain** | Service (business logic), Protocol, DTO, Exceptions | `BaseService[CreateDTO, UpdateDTO, ReturnDTO]` |
-| **Infrastructure** | Repository (DB access), Model, DI Container | `BaseRepository[ReturnDTO]` |
-| **Application** | UseCase (orchestration) -- **optional** | - |
-
-### Data Flow
-
-**Write** — `POST` / `PUT` / `DELETE`
+### Data flow — Write (`POST` / `PUT` / `DELETE`)
 
 ```mermaid
 flowchart LR
@@ -247,386 +155,106 @@ flowchart LR
     M -->|"SQLAlchemy"| DB[(Database)]
 ```
 
-**Read** — `GET`
+- **Request → Service** directly when fields match (no intermediate DTO — [ADR 004](docs/history/004-dto-entity-responsibility.md)).
+- **Model ↔ DTO** conversion happens *only* inside the Repository.
+- Read flow is the mirror image; the Router strips sensitive fields on the way out.
 
-```mermaid
-flowchart LR
-    DB[(Database)] -->|"row"| M[ORM Model]
-    M -->|"DTO.model_validate(from_attributes=True)"| Re[Repository]
-    Re -->|"ReturnDTO"| S[Service]
-    S -->|"ReturnDTO"| R[Router]
-    R -->|"Response(exclude={sensitive})"| C[Client]
+### Storage variants
+
+Same flow, different base classes:
+
+| Storage | Service base | Repository / Store base | List return |
+|---|---|---|---|
+| RDB (default) | `BaseService[Create, Update, DTO]` | `BaseRepository[DTO]` | `(list[DTO], PaginationInfo)` |
+| DynamoDB | `BaseDynamoService[…]` | `BaseDynamoRepository[DTO]` | `CursorPage[DTO]` |
+| S3 Vectors | domain-specific | `BaseS3VectorStore[DTO]` | `VectorSearchResult[DTO]` |
+
+---
+
+## Interfaces
+
+One business logic, multiple surfaces:
+
+| Interface | Tech | Status | Purpose |
+|---|---|---|---|
+| HTTP API | FastAPI | Stable | REST endpoints |
+| Async worker | Taskiq + SQS / RabbitMQ / InMemory | Stable | Background jobs |
+| Admin UI | NiceGUI | Stable | Auto-generated admin CRUD |
+| MCP server | FastMCP | Planned ([#18](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/18)) | AI agent tool interface |
+
+---
+
+## AI-native development
+
+Both **Claude Code** and **OpenAI Codex CLI** are first-class. They share one rules file ([`AGENTS.md`](AGENTS.md)) and one workflow reference layer ([`docs/ai/shared/`](docs/ai/shared/)); tool-specific harnesses layer on top.
+
+| | Claude Code | Codex CLI |
+|---|---|---|
+| Skills | 14 slash commands (`.claude/skills/`) | 15 workflow skills (`.agents/skills/`) |
+| Config | `CLAUDE.md` + `.mcp.json` | `.codex/config.toml` + `.codex/hooks.json` |
+| Hooks | PostToolUse auto-format | 6 hooks (format · security · session-start · …) |
+
+### Your first domain in 10 minutes
+
+```text
+/onboard            # adaptive walkthrough — beginner to advanced
+/new-domain product # scaffolds 15 source files + 25 __init__.py + 4 tests
+/add-api "add GET /product/top-selling to product"
+/review-architecture product
 ```
 
-- Request passes directly to Service when fields match (no extra DTO)
-- Repository owns the single Model ↔ DTO conversion boundary
-- Router strips sensitive fields (`password`, etc.) at the Response edge
+Swap `/` for `$` if you are on Codex CLI. Prefer no harness at all?
+The [manual scaffolding walkthrough](docs/reference.md#manual-domain-scaffolding)
+shows the exact three layers the skill produces.
 
-### Storage Variants
-
-Same flow shape across all three storage backends — only the base classes
-and persistence types change.
-
-| Storage | Service base | Repo / Store base | Persistence | List return |
-|---|---|---|---|---|
-| RDB (default) | `BaseService[Create, Update, DTO]` | `BaseRepository[DTO]` | ORM `Model(Base)` | `(list[DTO], PaginationInfo)` |
-| DynamoDB | `BaseDynamoService[...]` | `BaseDynamoRepository[DTO]` | `DynamoModel` | `CursorPage[DTO]` |
-| S3 Vectors | domain-specific | `BaseS3VectorStore[DTO]` | `S3VectorModel` | `VectorSearchResult[DTO]` |
-
-### Data Objects
-
-| Object | Role | Location |
-|--------|------|----------|
-| **Request/Response** | API contract | `interface/server/schemas/` |
-| **DTO** | Internal data transfer between layers | `domain/dtos/` |
-| **Model** | DB table mapping (never exposed outside Repository) | `infrastructure/database/models/` |
+Selected skills (all available in both tools): `onboard`, `new-domain`,
+`add-api`, `add-worker-task`, `add-admin-page`, `review-architecture`,
+`security-review`, `review-pr`, `plan-feature`, `fix-bug`.
+Full table and setup guide: [`docs/ai-development.md`](docs/ai-development.md).
 
 ---
 
-## Interface Types
+## Learn more
 
-Each domain can expose functionality through multiple interfaces:
-
-| Interface | Technology | Status | Purpose |
-|-----------|-----------|--------|---------|
-| **HTTP API** | FastAPI | Stable | REST API endpoints |
-| **Async Worker** | Taskiq + SQS/RabbitMQ/InMemory | Stable | Background task processing |
-| **Admin UI** | NiceGUI | Stable | Auto-discovered admin CRUD dashboard |
-| **MCP Server** | FastMCP | Planned | AI agent tool interface |
-
-All interfaces share the same Domain and Infrastructure layers -- write your business logic once, expose it everywhere.
-
----
-
-## AI-Native Development
-
-This template includes built-in AI collaboration support for **Claude Code** and **OpenAI Codex CLI**. Both tools share the same architecture rules (`AGENTS.md`) and workflow references (`docs/ai/shared/`), with tool-specific harnesses layered on top.
-
-| Layer | Claude Code | Codex CLI |
-|-------|------------|-----------|
-| **Shared rules** | `AGENTS.md` | `AGENTS.md` |
-| **Shared references** | `docs/ai/shared/` | `docs/ai/shared/` |
-| **Tool config** | `CLAUDE.md` + `.mcp.json` | `.codex/config.toml` + `.codex/hooks.json` |
-| **Skills** | 14 slash commands (`.claude/skills/`) | 15 workflow skills (`.agents/skills/`) |
-| **Hooks** | PostToolUse auto-format | 6 hooks (format, security, session-start, ...) |
-
-### Zero Learning Curve
-
-Complex architecture? Type `/onboard` (Claude) or `$onboard` (Codex) -- it explains everything at your level.
-
-The onboard skill adapts to your experience and learning style:
-- **Beginner / Intermediate / Advanced** -- depth adjusts to your level
-- **Guided** -- structured Phase-by-Phase walkthrough
-- **Q&A** -- topic maps provided, explore by asking questions
-- **Explore** -- point at any code freely, uncovered essentials flagged at the end
-
-### Built-in Skills
-
-All skills work in both Claude Code (`/` prefix) and Codex CLI (`$` prefix):
-
-| Skill | What it does |
-|-------|------------|
-| `onboard` | Interactive onboarding -- adapts to your experience level and learning style |
-| `new-domain {name}` | Scaffold an entire domain (21+ source files + tests) |
-| `add-api {description}` | Add API endpoint to existing domain |
-| `add-worker-task {domain} {task}` | Add async Taskiq background task |
-| `add-admin-page {domain}` | Add a NiceGUI admin page to an existing domain |
-| `add-cross-domain from:{a} to:{b}` | Wire cross-domain dependency via Protocol DIP |
-| `plan-feature {description}` | Requirements interview -> architecture -> security -> task breakdown |
-| `review-architecture {domain}` | Architecture compliance audit (20+ checks) |
-| `security-review {domain}` | OWASP-based security audit |
-| `test-domain {domain}` | Generate or run domain tests |
-| `fix-bug {description}` | Structured bug fixing workflow |
-| `review-pr {number}` | Architecture-aware PR review |
-| `sync-guidelines` | Sync docs after design changes |
-| `migrate-domain {command}` | Alembic migration management |
-
-> For plugin setup, MCP server configuration, and Codex CLI details, see the [AI Development Guide](docs/ai-development.md).
+| I want to… | Read |
+|---|---|
+| Spin it up and poke around | [`docs/quickstart.md`](docs/quickstart.md) |
+| Understand the architecture in depth | [`docs/ai/shared/architecture-diagrams.md`](docs/ai/shared/architecture-diagrams.md) · [`AGENTS.md`](AGENTS.md) |
+| Set up Claude Code or Codex CLI | [`docs/ai-development.md`](docs/ai-development.md) |
+| Add a domain by hand (no AI tools) | [`docs/reference.md#manual-domain-scaffolding`](docs/reference.md#manual-domain-scaffolding) |
+| See detailed env vars, tech stack, project tree | [`docs/reference.md`](docs/reference.md) |
+| Understand why a decision was made | [ADR index](docs/history/README.md) (40 records) |
+| Follow what's next | [Roadmap](docs/reference.md#roadmap) · [issue tracker](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues) |
 
 ---
 
-## Comparison
+## Coming soon
 
-| Feature | FastAPI Agent Blueprint | [tiangolo/full-stack](https://github.com/fastapi/full-stack-fastapi-template) | [s3rius/template](https://github.com/s3rius/FastAPI-template) | [teamhide/boilerplate](https://github.com/teamhide/fastapi-boilerplate) |
-|---------|:-:|:-:|:-:|:-:|
-| Zero-boilerplate CRUD (7 methods) | **Yes** | No | No | No |
-| Auto domain discovery | **Yes** | No | No | No |
-| Architecture enforcement (pre-commit) | **Yes** | No | No | No |
-| AI workflow skills (Claude + Codex) | **14+** | 0 | 0 | 0 |
-| Vector infrastructure (S3 Vectors) | **Yes** | No | No | No |
-| Adaptive onboarding (`/onboard`) | **Yes** | No | No | No |
-| Multi-interface (API+Worker+Admin+MCP) | **3+1 planned** | 2 | 1 | 1 |
-| Architecture Decision Records | **37** | 0 | 0 | 0 |
-| Type-safe generics across layers | **Yes** | Partial | Partial | No |
-| DI with IoC Container | **Yes** | No | No | No |
-| MCP Server interface | **Planned** | No | No | No |
-| AI orchestration (PydanticAI) | **Planned** | No | No | No |
-
----
-
-## Adding a New Domain
-
-> With Claude Code, just run `/new-domain product` to scaffold all of this automatically.
-
-<details>
-<summary>Manual steps (Product domain example)</summary>
-
-### 1. Domain Layer
-
-```python
-# src/product/domain/dtos/product_dto.py
-class ProductDTO(BaseModel):
-    id: int = Field(..., description="Product ID")
-    name: str = Field(..., description="Product name")
-    price: int = Field(..., description="Price")
-    created_at: datetime
-    updated_at: datetime
-
-# src/product/domain/protocols/product_repository_protocol.py
-class ProductRepositoryProtocol(BaseRepositoryProtocol[ProductDTO]):
-    pass
-
-# src/product/domain/services/product_service.py
-class ProductService(
-    BaseService[CreateProductRequest, UpdateProductRequest, ProductDTO]
-):
-    def __init__(self, product_repository: ProductRepositoryProtocol):
-        super().__init__(repository=product_repository)
-    # CRUD provided automatically. Just add custom logic.
-```
-
-### 2. Infrastructure Layer
-
-```python
-# src/product/infrastructure/database/models/product_model.py
-class ProductModel(Base):
-    __tablename__ = "product"
-    id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    name: Mapped[str] = mapped_column(String(255), nullable=False)
-    price: Mapped[int] = mapped_column(Integer, nullable=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
-    updated_at: Mapped[datetime] = mapped_column(DateTime, onupdate=func.now())
-
-# src/product/infrastructure/repositories/product_repository.py
-class ProductRepository(BaseRepository[ProductDTO]):
-    def __init__(self, database: Database):
-        super().__init__(database=database, model=ProductModel, return_entity=ProductDTO)
-
-# src/product/infrastructure/di/product_container.py
-class ProductContainer(containers.DeclarativeContainer):
-    core_container = providers.DependenciesContainer()
-    product_repository = providers.Singleton(ProductRepository, database=core_container.database)
-    product_service = providers.Factory(ProductService, product_repository=product_repository)
-```
-
-### 3. Interface Layer
-
-```python
-# src/product/interface/server/routers/product_router.py
-@router.post("/product", response_model=SuccessResponse[ProductResponse])
-@inject
-async def create_product(
-    item: CreateProductRequest,
-    product_service: ProductService = Depends(Provide[ProductContainer.product_service]),
-) -> SuccessResponse[ProductResponse]:
-    data = await product_service.create_data(entity=item)
-    return SuccessResponse(data=ProductResponse(**data.model_dump()))
-```
-
-### Auto Registration
-
-`discover_domains()` automatically detects new domains.
-**No changes needed** in `_apps/` containers or bootstrap files.
-
-Discovery conditions:
-- `src/{name}/__init__.py` exists
-- `src/{name}/infrastructure/di/{name}_container.py` exists
-
-</details>
-
----
-
-## Tech Stack
-
-FastAPI + SQLAlchemy 2.0 + Pydantic 2.x + dependency-injector + Taskiq + NiceGUI + asyncpg + aioboto3
-
-<details>
-<summary>Full stack details</summary>
-
-### AI & Agent
-
-| Technology | Purpose | Status |
-|-----------|---------|--------|
-| **AWS S3 Vectors** | Managed vector index backend for semantic search infrastructure | Available |
-| **OpenAI / Bedrock Embeddings** | Pluggable embedding backends selected by configuration | Available |
-| **FastMCP** | MCP server — expose domain services as tools for AI agents | Planned |
-| **PydanticAI** | Structured LLM orchestration with Pydantic-native outputs | Planned |
-
-### Core
-
-| Technology | Purpose |
-|-----------|---------|
-| **FastAPI** | Async web framework |
-| **Pydantic** 2.x | Data validation & settings |
-| **SQLAlchemy** 2.0 | Async ORM |
-| **dependency-injector** | IoC Container ([why?](docs/history/013-why-ioc-container.md)) |
-
-### Infrastructure
-
-| Technology | Purpose |
-|-----------|---------|
-| **PostgreSQL** + asyncpg | Primary RDBMS |
-| **Taskiq** + AWS SQS | Async task queue ([why not Celery?](docs/history/001-celery-to-taskiq.md)) |
-| **aiohttp** | Async HTTP client |
-| **aioboto3** | DynamoDB, S3/MinIO, S3 Vectors, and Bedrock clients |
-| **semantic-text-splitter** | Character/token chunking utilities for embedding preprocessing |
-| **Alembic** | DB migrations |
-
-### DevOps
-
-| Technology | Purpose |
-|-----------|---------|
-| **Ruff** | Linting + formatting ([replaces 6 tools](docs/history/012-ruff-migration.md)) |
-| **pre-commit** | Git hook automation + architecture enforcement |
-| **UV** | Python package management ([why not Poetry?](docs/history/005-poetry-to-uv.md)) |
-| **NiceGUI** | Admin dashboard UI |
-
-</details>
-
----
-
-## Project Structure
-
-<details>
-<summary>View full project tree</summary>
-
-```
-src/
-├── _apps/                        # App entry points
-│   ├── server/                  # FastAPI HTTP server
-│   ├── worker/                  # Taskiq async worker
-│   └── admin/                   # NiceGUI admin app
-│
-├── _core/                        # Shared infrastructure
-│   ├── common/                  # Pagination, security, text utils, UUID helpers
-│   ├── domain/
-│   │   ├── protocols/           # BaseRepositoryProtocol[ReturnDTO]
-│   │   └── services/            # BaseService[CreateDTO, UpdateDTO, ReturnDTO]
-│   ├── infrastructure/
-│   │   ├── database/            # Database, BaseRepository[ReturnDTO]
-│   │   ├── dynamodb/            # DynamoDBClient, BaseDynamoRepository
-│   │   ├── embedding/           # OpenAI/Bedrock embedding clients
-│   │   ├── http/                # HttpClient, BaseHttpGateway
-│   │   ├── s3vectors/           # S3VectorClient, BaseS3VectorStore
-│   │   ├── taskiq/              # Broker adapters, TaskiqManager
-│   │   ├── storage/             # S3/MinIO
-│   │   ├── di/                  # CoreContainer
-│   │   └── discovery.py         # Auto domain discovery
-│   ├── application/dtos/        # BaseRequest, BaseResponse, SuccessResponse
-│   ├── exceptions/              # Exception handlers, BaseCustomException
-│   └── config.py                # Settings (pydantic-settings)
-│
-├── user/                         # Example domain
-│   ├── domain/
-│   │   ├── dtos/                # UserDTO
-│   │   ├── protocols/           # UserRepositoryProtocol
-│   │   ├── services/            # UserService(BaseService[CreateUserRequest, UpdateUserRequest, UserDTO])
-│   │   ├── exceptions/          # UserNotFoundException
-│   ├── infrastructure/
-│   │   ├── database/models/     # UserModel
-│   │   ├── repositories/        # UserRepository(BaseRepository[UserDTO])
-│   │   └── di/                  # UserContainer
-│   └── interface/
-│       ├── server/              # routers/, schemas/, bootstrap/
-│       ├── worker/              # payloads/, tasks/, bootstrap/
-│       └── admin/               # configs/, pages/ (NiceGUI)
-│
-├── migrations/                   # Alembic
-├── _env/                         # Environment variables
-└── docs/history/                 # Architecture Decision Records
-```
-
-</details>
-
----
-
-## Architecture Decisions
-
-Every technical choice in this project is documented as an ADR (Architecture Decision Record). [View all 37 ADRs →](docs/history/README.md)
-
-<details>
-<summary>Key decisions</summary>
-
-| # | Title |
-|---|-------|
-| [004](docs/history/004-dto-entity-responsibility.md) | DTO/Entity responsibility redefined |
-| [006](docs/history/006-ddd-layered-architecture.md) | Domain-driven layered architecture |
-| [007](docs/history/007-di-container-and-app-separation.md) | DI container hierarchy and app separation |
-| [011](docs/history/011-3tier-hybrid-architecture.md) | 3-Tier hybrid architecture |
-| [012](docs/history/012-ruff-migration.md) | Ruff adoption |
-| [013](docs/history/013-why-ioc-container.md) | Why IoC Container over inheritance |
-
-</details>
-
----
-
-## Roadmap
-
-### Phase 1: AI Agent Foundation
-- [ ] FastMCP interface ([#18](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/18))
-- [ ] PydanticAI integration ([#15](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/15))
-- [ ] Additional vector backend: pgvector ([#11](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/11))
-- [ ] JWT authentication ([#4](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/4))
-
-### Phase 2: Production Readiness
-- [ ] Structured logging — structlog ([#9](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/9))
-- [ ] Error notifications ([#17](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/17))
-- [ ] CRUD data validation ([#10](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/10))
-
-### Phase 3: Ecosystem
-- [ ] Test coverage expansion ([#2](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/2))
-- [ ] Performance testing — Locust ([#3](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/3))
-- [ ] Serverless deployment ([#6](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/6))
-- [ ] WebSocket documentation ([#1](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/1))
-
-### Completed
-- [x] Storage abstraction — S3/MinIO switchable via env var ([#58](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/58))
-- [x] Embedding service — OpenAI/Bedrock switchable ([#69](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/69))
-- [x] S3 Vectors support ([#11](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/11))
-- [x] DynamoDB support ([#13](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/13))
-- [x] Broker abstraction — SQS/RabbitMQ/InMemory ([#8](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/8))
-- [x] Admin dashboard — NiceGUI ([#14](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/14))
-- [x] Per-environment config ([#7](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/7), [#16](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/16), [#53](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/53))
-- [x] Worker payload schemas ([#37](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/37))
-- [x] CHANGELOG ([#41](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/41))
-- [x] 14+ AI development skills for Claude Code and Codex CLI
-- [x] Codex CLI workflow layer
-- [x] Health check endpoint
-- [x] Auto domain discovery
-- [x] Architecture enforcement (pre-commit)
-
-Star this repo to follow our progress!
+- **MCP server interface** — expose domain services as agent tools via FastMCP ([#18](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/18))
+- **pgvector** — additional vector backend alongside S3 Vectors ([#11](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/11))
+- **JWT authentication** ([#4](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/4)) · **Structured logging** ([#9](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/9))
 
 ---
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, coding guidelines, and PR process.
-
----
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for dev setup, coding guidelines,
+and the PR workflow. Newcomers — check the
+[`good first issue`](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues?q=is%3Aopen+label%3A%22good+first+issue%22)
+label.
 
 ## License
 
-[MIT License](LICENSE) -- Free for commercial use, modification, and distribution.
+[MIT](LICENSE) — free for commercial use, modification, and distribution.
 
 ---
 
-## Star History
-
+<p align="center">
 <a href="https://star-history.com/#Mr-DooSun/fastapi-agent-blueprint&Date">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=Mr-DooSun/fastapi-agent-blueprint&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=Mr-DooSun/fastapi-agent-blueprint&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=Mr-DooSun/fastapi-agent-blueprint&type=Date" width="600" />
- </picture>
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=Mr-DooSun/fastapi-agent-blueprint&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=Mr-DooSun/fastapi-agent-blueprint&type=Date" />
+    <img alt="Star History" src="https://api.star-history.com/svg?repos=Mr-DooSun/fastapi-agent-blueprint&type=Date" width="600" />
+  </picture>
 </a>
+</p>

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -18,13 +18,17 @@
 </p>
 
 <p align="center">
-  <b>FastAPI DDD 템플릿, AI 에이전트 백엔드를 위해 설계.</b><br>
-  보일러플레이트 제로 CRUD + 자동 도메인 발견 + 벡터 검색 인프라. MCP 서버 + AI 오케스트레이션 곧 출시.<br>
-  Claude Code &amp; Codex CLI용 14+ AI 개발 스킬 내장.
+  <b>AI 에이전트 백엔드를 위한 프로덕션 지향 FastAPI 블루프린트.</b><br>
+  DDD 레이어 · 보일러플레이트 제로 CRUD · 도메인 자동 발견 · 멀티 인터페이스 (API · Worker · Admin · MCP 준비) ·<br>
+  벡터 / 임베딩 / LLM 인프라 · Claude Code &amp; Codex CLI용 AI 개발 스킬 내장.
 </p>
 
 <p align="center">
-  <a href="#빠른-시작">빠른 시작</a> · <a href="#이-프로젝트는-누구를-위한-것인가요">누구를 위한 것?</a> · <a href="#아키텍처">아키텍처</a> · <a href="#비교">비교</a> · <a href="../README.md">English</a>
+  <a href="#60초-만에-실행">60초 만에 실행</a>
+  · <a href="#한눈에-보는-아키텍처">아키텍처</a>
+  · <a href="#ai-네이티브-개발">AI 스킬</a>
+  · <a href="#비교">비교</a>
+  · <a href="../README.md">English</a>
 </p>
 
 <p align="center">
@@ -35,170 +39,75 @@
 
 ---
 
-## 이 프로젝트는 누구를 위한 것인가요?
+## 60초 만에 실행
 
-- **FastAPI 개발자** — 튜토리얼 수준을 넘어 프로덕션 프로젝트 구조가 필요한 분 (DDD 레이어, DI 컨테이너, 전면 async, 아키텍처 자동 강제)
-- **백엔드 팀** — REST API + 백그라운드 워커 + 어드민 UI가 동일한 도메인 로직을 공유해야 하는 시스템을 만드는 분
-- **AI 에이전트 빌더** — 벡터 검색과 임베딩 인프라가 즉시 사용 가능하고, MCP 서버와 PydanticAI 오케스트레이션이 곧 추가될 기반이 필요한 분
-- **AI 기반 개발자** — Claude Code나 Codex CLI를 사용하며 두 도구 모두에서 작동하는 14+개의 내장 AI 개발 스킬이 있는 코드베이스를 원하는 분
-
----
-
-## 제공 기능
-
-- **보일러플레이트 제로 CRUD** — `BaseRepository[DTO]` + `BaseService[Create, Update, DTO]` 상속으로 7개 비동기 메서드 즉시 제공
-- **도메인 자동 발견** — 도메인 폴더를 추가하면 자동 등록. Container나 bootstrap 수정 불필요
-- **3가지 인터페이스** — HTTP API (FastAPI) + 비동기 Worker (Taskiq) + Admin UI (NiceGUI), 하나의 도메인 레이어 공유
-- **교체 가능한 인프라** — PostgreSQL/MySQL/SQLite, DynamoDB, S3/MinIO, SQS/RabbitMQ, OpenAI/Bedrock — 환경변수로 전환
-- **벡터 인프라** — S3 Vectors + OpenAI/Bedrock 임베딩 + 시맨틱 chunking 유틸리티
-- **타입 안전 제네릭** — `BaseRepository[ProductDTO]`, `BaseService[CreateProductRequest, UpdateProductRequest, ProductDTO]`, `SuccessResponse[ProductResponse]`
-- **아키텍처 자동 강제** — Pre-commit hook이 커밋 시점에 `Domain → Infrastructure` import 차단
-- **DynamoDB 지원** — 커서 기반 pagination의 `BaseDynamoRepository`, PostgreSQL과 병행 사용
-- **14+ AI 개발 스킬** — Claude Code와 Codex CLI 모두 지원: `new-domain`, `add-api`, `onboard`, `review-architecture` 등 ([상세](#ai-네이티브-개발))
-- **비동기 우선** — DB(asyncpg)부터 HTTP(aiohttp), 태스크 큐(Taskiq)까지
-- **37개 ADR** — 모든 기술 선택을 근거와 함께 문서화 ([인덱스 보기](../docs/history/README.md))
-
-<details>
-<summary><b>Coming soon</b></summary>
-
-- **MCP 서버 인터페이스** — FastMCP를 통해 도메인 서비스를 AI 에이전트 도구로 노출 ([#18](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/18))
-- **PydanticAI 통합** — Pydantic 네이티브 출력의 구조화된 LLM 오케스트레이션 ([#15](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/15))
-- **pgvector** — 추가 벡터 백엔드 ([#11](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/11))
-
-</details>
-
----
-
-## 빠른 시작
-
-### 60초 평가용 (Docker·PostgreSQL·자격 증명 모두 불필요)
+Docker · PostgreSQL · 클라우드 자격 증명 모두 불필요 — SQLite + In-Memory 브로커.
 
 ```bash
 git clone https://github.com/Mr-DooSun/fastapi-agent-blueprint.git
 cd fastapi-agent-blueprint
-make setup        # 최초 1회: venv 생성 + 의존성 설치
-make quickstart   # SQLite + InMemory broker로 FastAPI 기동
+make setup        # 최초 1회: uv 로 venv + 의존성 설치
+make quickstart   # :8001 에 FastAPI 기동, SQLite 스키마 자동 생성
 ```
 
-http://127.0.0.1:8001/docs-swagger 을 열어보세요. 다른 터미널에서
-`make demo` 로 `user` 도메인 CRUD 전체 흐름을 curl로 돌려볼 수 있습니다.
+다른 터미널에서 `make demo` 로 `user` 도메인을 `curl` 로 왕복해봅니다:
 
-자세한 내용: [`docs/quickstart.md`](quickstart.md).
+```text
+→ Health check
+{ "status": "ok" }
 
-### 실제 로컬 개발 (PostgreSQL + 마이그레이션)
+→ Create a user
+{ "success": true, "data": { "id": 1, "username": "alice",
+                             "fullName": "Alice Liddell", ... } }
 
-```bash
-# 1. Clone
-git clone https://github.com/Mr-DooSun/fastapi-agent-blueprint.git
-cd fastapi-agent-blueprint
+→ List users (page=1, pageSize=10)
+{ "data": [ { "id": 1, "username": "alice", ... } ],
+  "pagination": { "currentPage": 1, "totalItems": 1,
+                  "hasNext": false, ... } }
 
-# 2. 셋업 (uv 필요)
-make setup
-
-# 3. 환경변수 설정
-cp _env/local.env.example _env/local.env
-
-# 4. PostgreSQL 실행 + 마이그레이션 + 서버 시작
-make dev
+→ Update the user    → Delete the user
+→ Done. Swagger UI: http://127.0.0.1:8001/docs-swagger
 ```
 
-http://localhost:8000/docs-swagger 에서 API를 확인하세요.
-
-<details>
-<summary>수동 설정 (Make 미사용)</summary>
-
-```bash
-# 2. 가상환경 + 의존성 설치
-uv venv --python 3.12
-source .venv/bin/activate
-uv sync --group dev
-
-# 3. 환경변수 설정
-cp _env/local.env.example _env/local.env
-
-# 4. PostgreSQL 실행 (Docker)
-docker compose -f docker-compose.local.yml up -d postgres
-
-# 5. 마이그레이션 + 서버 실행
-alembic upgrade head
-python run_server_local.py --env local
-```
-</details>
+- Swagger: <http://127.0.0.1:8001/docs-swagger>
+- Admin UI: <http://127.0.0.1:8001/admin> (`admin` / `admin`)
+- 전체 안내: [`docs/quickstart.md`](quickstart.md)
+- 실제 개발 환경 (PostgreSQL + 마이그레이션): [`docs/reference.md`](reference.md#local-development-with-postgresql)
 
 ---
 
-## Why?
+## 왜 이 블루프린트인가
 
-### 도메인 로직 — 어디서든 접근 가능
-
-비즈니스 로직을 한 번 작성하고, REST API, 백그라운드 작업, 어드민 뷰, AI 에이전트 도구로 노출하세요.
-
-```python
-# 1. 서비스 정의
-class DocumentService(
-    BaseService[CreateDocumentRequest, UpdateDocumentRequest, DocumentDTO]
-):
-    async def analyze(self, document_id: int) -> AnalysisDTO:
-        ...  # 비즈니스 로직
-
-# 2. REST API — 프론트엔드용
-@router.post("/documents/{document_id}/analyze")
-async def analyze_document(document_id: int, service=Depends(...)):
-    return await service.analyze(document_id)
-
-# 3. MCP 도구 — AI 에이전트용 (coming soon)
-@mcp.tool()
-async def analyze_document(document_id: int) -> AnalysisResult:
-    return await document_service.analyze(document_id)
-
-# 4. 백그라운드 작업 — 배치 처리용
-@broker.task()
-async def batch_analyze(project_id: int):
-    for doc in await service.get_by_project(project_id):
-        await service.analyze(doc.id)
-```
-
-### 보일러플레이트 제로 CRUD
-
-```python
-# Before: 도메인마다 동일한 CRUD 반복
-@router.post("/user")
-async def create_user(user: UserCreate):
-    db = get_db()
-    new_user = User(**user.dict())
-    db.add(new_user)
-    db.commit()
-    return new_user
-
-@router.post("/product")  # 또 반복...
-async def create_product(product: ProductCreate):
-    db = get_db()
-    new_product = Product(**product.dict())
-    db.add(new_product)
-    db.commit()
-    return new_product
-```
-
-```python
-# After: 베이스 클래스 상속 한 줄로 CRUD 완료
-class ProductRepository(BaseRepository[ProductDTO]):
-    def __init__(self, database: Database):
-        super().__init__(database=database, model=ProductModel, return_entity=ProductDTO)
-
-class ProductService(BaseService[CreateProductRequest, UpdateProductRequest, ProductDTO]):
-    def __init__(self, product_repository: ProductRepositoryProtocol):
-        super().__init__(repository=product_repository)
-
-# 핵심 CRUD 메서드와 pagination helper 자동 제공 — 커스텀 로직만 추가하면 됨
-```
+- **도메인 로직을 한 번만 쓰고, 어디서든 노출.** HTTP (FastAPI) + Worker (Taskiq) + Admin (NiceGUI) 가 하나의 Domain 레이어를 공유합니다. MCP 서버는 로드맵에 있음.
+- **보일러플레이트 제로 CRUD.** `BaseRepository[DTO]` 와 `BaseService[Create, Update, DTO]` 를 상속하면 `QueryFilter` 기반 페이징 목록을 포함한 7개 async 메서드를 즉시 확보.
+- **도메인 자동 발견.** `src/{name}/` 에 폴더 하나만 두면 자동 등록. Container 수정도, bootstrap 수정도 필요 없음.
+- **환경변수 한 줄로 교체 가능한 인프라.** PostgreSQL / MySQL / SQLite · DynamoDB · S3 / MinIO · S3 Vectors · SQS / RabbitMQ / InMemory · LLM/Embedding 모두 OpenAI / Bedrock.
+- **커밋 시점에 아키텍처 강제.** Pre-commit 훅이 `Domain → Infrastructure` import 를 차단하여 DDD 계약이 썩지 않도록 보장.
+- **AI 네이티브 워크플로우.** Claude Code 14개 + Codex CLI 15개 스킬이 동일한 `AGENTS.md` 규칙을 공유 — 한 줄로 도메인 스캐폴딩, 라우트 추가, 아키텍처 감사가 가능.
 
 ---
 
-## 아키텍처
+## 비교
 
-화살표 방향 = **"의존한다"**. Domain 이 중심에 있고 Interface / Infrastructure
-가 Domain 을 향해 의존합니다. UseCase 는 선택 사항 — 단순 CRUD 는 점선
-경로(직접 연결)를 사용합니다.
+| 기능 | FastAPI Agent Blueprint | [tiangolo/full-stack](https://github.com/fastapi/full-stack-fastapi-template) | [s3rius/template](https://github.com/s3rius/FastAPI-template) | [teamhide/boilerplate](https://github.com/teamhide/fastapi-boilerplate) |
+|---|:-:|:-:|:-:|:-:|
+| 보일러플레이트 제로 CRUD (7개 메서드) | **Yes** | No | No | No |
+| 도메인 자동 발견 | **Yes** | No | No | No |
+| 아키텍처 자동 강제 (pre-commit) | **Yes** | No | No | No |
+| AI 워크플로우 스킬 (Claude + Codex) | **14 + 15** | 0 | 0 | 0 |
+| 벡터 인프라 (S3 Vectors) | **Yes** | No | No | No |
+| 멀티 인터페이스 (API + Worker + Admin + MCP) | **3 + 1 예정** | 2 | 1 | 1 |
+| Architecture Decision Records | **40** | 0 | 0 | 0 |
+| 전 계층 타입 안전 제네릭 | **Yes** | 부분 | 부분 | No |
+| IoC Container DI | **Yes** | No | No | No |
+
+---
+
+## 한눈에 보는 아키텍처
+
+`src/{domain}/` 아래의 모든 도메인은 4개의 DDD 레이어를 가집니다. 화살표는
+**"의존한다"** 방향. `Application` (use case) 은 선택 사항이며, 단순 CRUD 는
+점선 경로 (Router → Service 직접 연결) 를 사용합니다.
 
 ```mermaid
 flowchart LR
@@ -222,21 +131,20 @@ flowchart LR
     Other["다른 도메인"] -. Protocol 기반 DIP .-> D
 ```
 
-> **전체 다이어그램 + RDB / DynamoDB / S3 Vectors 변종 표:**
-> [`docs/ai/shared/architecture-diagrams.md`](ai/shared/architecture-diagrams.md)
-
-### 계층별 책임
-
 | 계층 | 역할 | Base 클래스 |
-|------|------|------------|
-| **Interface** | Router, Request/Response, Admin, Worker Task, MCP Tool | - |
-| **Domain** | Service (비즈니스 로직), Protocol, DTO, Exception | `BaseService[CreateDTO, UpdateDTO, ReturnDTO]` |
-| **Infrastructure** | Repository (DB 접근), Model, DI Container | `BaseRepository[ReturnDTO]` |
-| **Application** | UseCase (복합 로직 조율) -- **선택적** | - |
+|---|---|---|
+| Interface | Router · Request/Response · Admin · Worker task | — |
+| Domain | Service · Protocol · DTO · Exceptions | `BaseService[CreateDTO, UpdateDTO, ReturnDTO]` |
+| Infrastructure | Repository · Model · DI container | `BaseRepository[ReturnDTO]` |
+| Application | UseCase — 선택적 오케스트레이터 | — |
 
-### 데이터 흐름
+> Layer · Write · Read 다이어그램 전체와 RDB / DynamoDB / S3 Vectors
+> 변종 표는
+> [`docs/ai/shared/architecture-diagrams.md`](ai/shared/architecture-diagrams.md)
+> 에 있습니다. Mermaid 가 렌더되지 않는 뷰어용 SVG export:
+> [`docs/assets/architecture/`](assets/architecture/).
 
-**Write** — `POST` / `PUT` / `DELETE`
+### 데이터 흐름 — Write (`POST` / `PUT` / `DELETE`)
 
 ```mermaid
 flowchart LR
@@ -247,386 +155,109 @@ flowchart LR
     M -->|"SQLAlchemy"| DB[(Database)]
 ```
 
-**Read** — `GET`
-
-```mermaid
-flowchart LR
-    DB[(Database)] -->|"row"| M[ORM Model]
-    M -->|"DTO.model_validate(from_attributes=True)"| Re[Repository]
-    Re -->|"ReturnDTO"| S[Service]
-    S -->|"ReturnDTO"| R[Router]
-    R -->|"Response(exclude={민감 필드})"| C[Client]
-```
-
-- 필드가 일치하면 Request 를 Service 에 그대로 전달 (별도 DTO 불필요)
-- Model ↔ DTO 변환은 **오직 Repository** 에서만 발생
-- 민감 필드(`password` 등)는 Router 가 Response 로 내보내기 직전에 제거
+- 필드가 일치하면 **Request 를 Service 로 그대로 전달** — 중간 DTO 불필요 ([ADR 004](history/004-dto-entity-responsibility.md))
+- **Model ↔ DTO 변환은 Repository 안에서만** 발생
+- Read 흐름은 대칭이며, 민감 필드는 Router 가 응답으로 내보내기 직전에 제거
 
 ### 저장소 변종
 
-세 저장소 모두 동일한 흐름 형태를 사용하며, Base 클래스와 영속 객체,
-리스트 반환 타입만 바뀝니다.
+흐름 형태는 동일하고 Base 클래스와 영속 객체만 바뀝니다.
 
-| 저장소 | Service base | Repo / Store base | 영속 객체 | 리스트 반환 |
-|---|---|---|---|---|
-| RDB (기본) | `BaseService[Create, Update, DTO]` | `BaseRepository[DTO]` | ORM `Model(Base)` | `(list[DTO], PaginationInfo)` |
-| DynamoDB | `BaseDynamoService[...]` | `BaseDynamoRepository[DTO]` | `DynamoModel` | `CursorPage[DTO]` |
-| S3 Vectors | 도메인 고유 | `BaseS3VectorStore[DTO]` | `S3VectorModel` | `VectorSearchResult[DTO]` |
-
-### 데이터 객체
-
-| 객체 | 역할 | 위치 |
-|------|------|------|
-| **Request/Response** | API 통신 규격 | `interface/server/schemas/` |
-| **DTO** | 내부 레이어 간 데이터 운반 | `domain/dtos/` |
-| **Model** | DB 테이블 매핑 (Repository 밖으로 노출 금지) | `infrastructure/database/models/` |
+| 저장소 | Service base | Repository / Store base | 리스트 반환 |
+|---|---|---|---|
+| RDB (기본) | `BaseService[Create, Update, DTO]` | `BaseRepository[DTO]` | `(list[DTO], PaginationInfo)` |
+| DynamoDB | `BaseDynamoService[…]` | `BaseDynamoRepository[DTO]` | `CursorPage[DTO]` |
+| S3 Vectors | 도메인별 구현 | `BaseS3VectorStore[DTO]` | `VectorSearchResult[DTO]` |
 
 ---
 
-## 인터페이스 타입
+## 인터페이스
 
-각 도메인은 여러 인터페이스를 통해 기능을 노출할 수 있습니다:
+하나의 비즈니스 로직을 여러 표면으로 노출:
 
 | 인터페이스 | 기술 | 상태 | 용도 |
-|-----------|------|------|------|
-| **HTTP API** | FastAPI | Stable | REST API 엔드포인트 |
-| **비동기 Worker** | Taskiq + SQS/RabbitMQ/InMemory | Stable | 백그라운드 태스크 처리 |
-| **Admin UI** | NiceGUI | Stable | 자동 발견 기반 admin CRUD 대시보드 |
-| **MCP Server** | FastMCP | Planned | AI 에이전트 도구 인터페이스 |
-
-모든 인터페이스는 동일한 Domain/Infrastructure 계층을 공유합니다 -- 비즈니스 로직을 한 번 작성하고, 어디서든 노출하세요.
+|---|---|---|---|
+| HTTP API | FastAPI | Stable | REST 엔드포인트 |
+| 비동기 Worker | Taskiq + SQS / RabbitMQ / InMemory | Stable | 백그라운드 작업 |
+| Admin UI | NiceGUI | Stable | 자동 생성 admin CRUD |
+| MCP server | FastMCP | Planned ([#18](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/18)) | AI 에이전트 도구 인터페이스 |
 
 ---
 
 ## AI 네이티브 개발
 
-이 템플릿은 **Claude Code**와 **OpenAI Codex CLI**를 위한 AI 협업 지원이 내장되어 있습니다. 두 도구 모두 동일한 아키텍처 규칙(`AGENTS.md`)과 workflow 레퍼런스(`docs/ai/shared/`)를 공유하며, 도구별 하네스가 그 위에 레이어됩니다.
+**Claude Code** 와 **OpenAI Codex CLI** 둘 다 일급 지원. 하나의 규칙
+파일 ([`AGENTS.md`](../AGENTS.md)) 과 하나의 workflow 레퍼런스 레이어
+([`docs/ai/shared/`](ai/shared/)) 를 공유하고, 도구별 하네스가 그 위에
+얹힙니다.
 
-| 레이어 | Claude Code | Codex CLI |
-|--------|------------|-----------|
-| **공통 규칙** | `AGENTS.md` | `AGENTS.md` |
-| **공통 레퍼런스** | `docs/ai/shared/` | `docs/ai/shared/` |
-| **도구 설정** | `CLAUDE.md` + `.mcp.json` | `.codex/config.toml` + `.codex/hooks.json` |
-| **스킬** | 14개 slash 명령 (`.claude/skills/`) | 15개 workflow 스킬 (`.agents/skills/`) |
-| **훅** | PostToolUse 자동 포맷 | 6개 훅 (format, security, session-start, ...) |
+| | Claude Code | Codex CLI |
+|---|---|---|
+| 스킬 | 14개 slash 커맨드 (`.claude/skills/`) | 15개 workflow 스킬 (`.agents/skills/`) |
+| 설정 | `CLAUDE.md` + `.mcp.json` | `.codex/config.toml` + `.codex/hooks.json` |
+| 훅 | PostToolUse 자동 포맷 | 6개 훅 (format · security · session-start · …) |
 
-### 러닝 커브 제로
+### 10분 안에 첫 도메인 만들기
 
-복잡한 아키텍처? `/onboard` (Claude) 또는 `$onboard` (Codex)를 입력하세요 -- 당신의 수준에 맞춰 모든 것을 설명해줍니다.
-
-onboard 스킬은 경험 수준에 따라 적응합니다:
-- **초급 / 중급 / 고급** -- 수준에 맞게 깊이 조절
-- **가이드** -- Phase별 구조화된 안내
-- **Q&A** -- 토픽 맵 제공, 질문으로 탐색
-- **탐험** -- 자유롭게 코드를 살펴보고, 놓친 핵심은 마지막에 정리
-
-### 내장 스킬
-
-모든 스킬은 Claude Code (`/` 접두사)와 Codex CLI (`$` 접두사) 모두에서 사용 가능합니다:
-
-| 스킬 | 기능 |
-|------|------|
-| `onboard` | 대화형 온보딩 -- 경험 수준에 맞춰 적응 |
-| `new-domain {name}` | 도메인 전체 스캐폴딩 (21개 이상 소스 파일 + 테스트) |
-| `add-api {description}` | 기존 도메인에 API 엔드포인트 추가 |
-| `add-worker-task {domain} {task}` | 비동기 Taskiq 백그라운드 태스크 추가 |
-| `add-admin-page {domain}` | 기존 도메인에 NiceGUI admin 페이지 추가 |
-| `add-cross-domain from:{a} to:{b}` | Protocol DIP를 통한 도메인 간 의존성 연결 |
-| `plan-feature {description}` | 요구사항 인터뷰 -> 아키텍처 -> 보안 -> 태스크 분해 |
-| `review-architecture {domain}` | 아키텍처 컴플라이언스 감사 (20개 이상 검사) |
-| `security-review {domain}` | OWASP 기반 보안 감사 |
-| `test-domain {domain}` | 도메인 테스트 생성 또는 실행 |
-| `fix-bug {description}` | 구조화된 버그 수정 워크플로우 |
-| `review-pr {number}` | 아키텍처 인식 PR 리뷰 |
-| `sync-guidelines` | 설계 변경 후 문서 동기화 |
-| `migrate-domain {command}` | Alembic 마이그레이션 관리 |
-
-> 플러그인 설정, MCP 서버 구성, Codex CLI 상세는 [AI 개발 가이드](ai-development.ko.md)를 참고하세요.
-
----
-
-## 비교
-
-| 기능 | FastAPI Agent Blueprint | [tiangolo/full-stack](https://github.com/fastapi/full-stack-fastapi-template) | [s3rius/template](https://github.com/s3rius/FastAPI-template) | [teamhide/boilerplate](https://github.com/teamhide/fastapi-boilerplate) |
-|------|:-:|:-:|:-:|:-:|
-| 보일러플레이트 제로 CRUD (7개 메서드) | **Yes** | No | No | No |
-| 도메인 자동 발견 | **Yes** | No | No | No |
-| 아키텍처 자동 강제 (pre-commit) | **Yes** | No | No | No |
-| AI 개발 스킬 (Claude + Codex) | **14+** | 0 | 0 | 0 |
-| 벡터 인프라 (S3 Vectors) | **Yes** | No | No | No |
-| 적응형 온보딩 (`/onboard`) | **Yes** | No | No | No |
-| 멀티 인터페이스 (API+Worker+Admin+MCP) | **3+1 예정** | 2 | 1 | 1 |
-| Architecture Decision Records | **37** | 0 | 0 | 0 |
-| 전 계층 타입 안전 제네릭 | **Yes** | 부분 | 부분 | No |
-| IoC Container DI | **Yes** | No | No | No |
-| MCP 서버 인터페이스 | **Planned** | No | No | No |
-| AI 오케스트레이션 (PydanticAI) | **Planned** | No | No | No |
-
----
-
-## 새 도메인 추가하기
-
-> Claude Code를 사용하면 `/new-domain product` 한 줄로 위 모든 파일을 자동 생성할 수 있습니다.
-
-<details>
-<summary>수동 추가 방법 (Product 도메인 예시)</summary>
-
-### 1. Domain Layer
-
-```python
-# src/product/domain/dtos/product_dto.py
-class ProductDTO(BaseModel):
-    id: int = Field(..., description="제품 ID")
-    name: str = Field(..., description="제품명")
-    price: int = Field(..., description="가격")
-    created_at: datetime
-    updated_at: datetime
-
-# src/product/domain/protocols/product_repository_protocol.py
-class ProductRepositoryProtocol(BaseRepositoryProtocol[ProductDTO]):
-    pass
-
-# src/product/domain/services/product_service.py
-class ProductService(
-    BaseService[CreateProductRequest, UpdateProductRequest, ProductDTO]
-):
-    def __init__(self, product_repository: ProductRepositoryProtocol):
-        super().__init__(repository=product_repository)
-    # CRUD 자동 제공. 커스텀 로직만 추가.
+```text
+/onboard            # 수준별 적응형 온보딩 (초급 ~ 고급)
+/new-domain product # 15개 소스 파일 + 25개 __init__.py + 4개 테스트 생성
+/add-api "add GET /product/top-selling to product"
+/review-architecture product
 ```
 
-### 2. Infrastructure Layer
+Codex CLI 를 쓴다면 `/` 대신 `$`. 하네스 없이 손으로 만들고 싶다면
+[수동 도메인 스캐폴딩](reference.md#manual-domain-scaffolding) 섹션이 스킬이
+생성하는 3개 레이어를 그대로 보여줍니다.
 
-```python
-# src/product/infrastructure/database/models/product_model.py
-class ProductModel(Base):
-    __tablename__ = "product"
-    id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    name: Mapped[str] = mapped_column(String(255), nullable=False)
-    price: Mapped[int] = mapped_column(Integer, nullable=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
-    updated_at: Mapped[datetime] = mapped_column(DateTime, onupdate=func.now())
-
-# src/product/infrastructure/repositories/product_repository.py
-class ProductRepository(BaseRepository[ProductDTO]):
-    def __init__(self, database: Database):
-        super().__init__(database=database, model=ProductModel, return_entity=ProductDTO)
-
-# src/product/infrastructure/di/product_container.py
-class ProductContainer(containers.DeclarativeContainer):
-    core_container = providers.DependenciesContainer()
-    product_repository = providers.Singleton(ProductRepository, database=core_container.database)
-    product_service = providers.Factory(ProductService, product_repository=product_repository)
-```
-
-### 3. Interface Layer
-
-```python
-# src/product/interface/server/routers/product_router.py
-@router.post("/product", response_model=SuccessResponse[ProductResponse])
-@inject
-async def create_product(
-    item: CreateProductRequest,
-    product_service: ProductService = Depends(Provide[ProductContainer.product_service]),
-) -> SuccessResponse[ProductResponse]:
-    data = await product_service.create_data(entity=item)
-    return SuccessResponse(data=ProductResponse(**data.model_dump()))
-```
-
-### 자동 등록
-
-`discover_domains()`가 새 도메인을 자동 탐지합니다.
-`_apps/` 내 container나 bootstrap을 **수정할 필요 없습니다**.
-
-자동 발견 조건:
-- `src/{name}/__init__.py` 존재
-- `src/{name}/infrastructure/di/{name}_container.py` 존재
-
-</details>
+두 도구에서 모두 동작하는 주요 스킬: `onboard`, `new-domain`, `add-api`,
+`add-worker-task`, `add-admin-page`, `review-architecture`,
+`security-review`, `review-pr`, `plan-feature`, `fix-bug`. 전체 표와
+설치 가이드: [`docs/ai-development.ko.md`](ai-development.ko.md).
 
 ---
 
-## Tech Stack
+## 더 읽을거리
 
-FastAPI + SQLAlchemy 2.0 + Pydantic 2.x + dependency-injector + Taskiq + NiceGUI + asyncpg + aioboto3
-
-<details>
-<summary>상세 스택</summary>
-
-### AI & Agent
-
-| 기술 | 용도 | 상태 |
-|------|------|------|
-| **AWS S3 Vectors** | 시맨틱 검색 인프라를 위한 관리형 벡터 인덱스 백엔드 | Available |
-| **OpenAI / Bedrock Embeddings** | 설정으로 선택하는 플러그형 임베딩 백엔드 | Available |
-| **FastMCP** | MCP 서버 — 도메인 서비스를 AI 에이전트 도구로 노출 | Planned |
-| **PydanticAI** | Pydantic 네이티브 출력의 구조화된 LLM 오케스트레이션 | Planned |
-
-### Core
-
-| 기술 | 용도 |
-|------|------|
-| **FastAPI** | 비동기 웹 프레임워크 |
-| **Pydantic** 2.x | 데이터 검증, Settings |
-| **SQLAlchemy** 2.0 | 비동기 ORM |
-| **dependency-injector** | IoC Container ([왜?](../docs/history/013-why-ioc-container.md)) |
-
-### Infrastructure
-
-| 기술 | 용도 |
-|------|------|
-| **PostgreSQL** + asyncpg | 메인 RDBMS |
-| **Taskiq** + AWS SQS | 비동기 태스크 큐 ([왜 Celery가 아닌가?](../docs/history/001-celery-to-taskiq.md)) |
-| **aiohttp** | 비동기 HTTP 클라이언트 |
-| **aioboto3** | DynamoDB, S3/MinIO, S3 Vectors, Bedrock 클라이언트 |
-| **semantic-text-splitter** | 임베딩 전처리를 위한 문자/토큰 chunking 유틸리티 |
-| **Alembic** | DB 마이그레이션 |
-
-### DevOps
-
-| 기술 | 용도 |
-|------|------|
-| **Ruff** | 린팅 + 포맷팅 ([6개 도구 통합](../docs/history/012-ruff-migration.md)) |
-| **pre-commit** | Git hook 자동화 + 아키텍처 강제 |
-| **UV** | Python 패키지 관리 ([왜 Poetry가 아닌가?](../docs/history/005-poetry-to-uv.md)) |
-| **NiceGUI** | Admin 대시보드 UI |
-
-</details>
+| 원하는 것 | 읽을 곳 |
+|---|---|
+| 일단 띄워보기 | [`docs/quickstart.md`](quickstart.md) |
+| 아키텍처를 깊이 이해 | [`docs/ai/shared/architecture-diagrams.md`](ai/shared/architecture-diagrams.md) · [`AGENTS.md`](../AGENTS.md) |
+| Claude Code / Codex CLI 설정 | [`docs/ai-development.ko.md`](ai-development.ko.md) |
+| 도메인을 수동으로 추가 (AI 도구 없이) | [`docs/reference.md#manual-domain-scaffolding`](reference.md#manual-domain-scaffolding) |
+| 상세 env 변수 · 기술 스택 · 프로젝트 트리 | [`docs/reference.md`](reference.md) |
+| 어떤 결정을 왜 했는지 | [ADR 인덱스](history/README.md) (40개 기록) |
+| 다음 계획 | [Roadmap](reference.md#roadmap) · [이슈 트래커](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues) |
 
 ---
 
-## 프로젝트 구조
+## Coming soon
 
-<details>
-<summary>전체 프로젝트 트리 보기</summary>
-
-```
-src/
-├── _apps/                        # App-level 진입점
-│   ├── server/                  # FastAPI HTTP 서버
-│   ├── worker/                  # Taskiq 비동기 워커
-│   └── admin/                   # NiceGUI admin 앱
-│
-├── _core/                        # 공통 인프라
-│   ├── common/                  # Pagination, security, text utils, UUID helper
-│   ├── domain/
-│   │   ├── protocols/           # BaseRepositoryProtocol[ReturnDTO]
-│   │   └── services/            # BaseService[CreateDTO, UpdateDTO, ReturnDTO]
-│   ├── infrastructure/
-│   │   ├── database/            # Database, BaseRepository[ReturnDTO]
-│   │   ├── dynamodb/            # DynamoDBClient, BaseDynamoRepository
-│   │   ├── embedding/           # OpenAI/Bedrock embedding client
-│   │   ├── http/                # HttpClient, BaseHttpGateway
-│   │   ├── s3vectors/           # S3VectorClient, BaseS3VectorStore
-│   │   ├── taskiq/              # Broker adapter, TaskiqManager
-│   │   ├── storage/             # S3/MinIO
-│   │   ├── di/                  # CoreContainer
-│   │   └── discovery.py         # 도메인 자동 발견
-│   ├── application/dtos/        # BaseRequest, BaseResponse, SuccessResponse
-│   ├── exceptions/              # Exception handlers, BaseCustomException
-│   └── config.py                # Settings (pydantic-settings)
-│
-├── user/                         # 예시 도메인
-│   ├── domain/
-│   │   ├── dtos/                # UserDTO
-│   │   ├── protocols/           # UserRepositoryProtocol
-│   │   ├── services/            # UserService(BaseService[CreateUserRequest, UpdateUserRequest, UserDTO])
-│   │   ├── exceptions/          # UserNotFoundException
-│   ├── infrastructure/
-│   │   ├── database/models/     # UserModel
-│   │   ├── repositories/        # UserRepository(BaseRepository[UserDTO])
-│   │   └── di/                  # UserContainer
-│   └── interface/
-│       ├── server/              # routers/, schemas/, bootstrap/
-│       ├── worker/              # payloads/, tasks/, bootstrap/
-│       └── admin/               # configs/, pages/ (NiceGUI)
-│
-├── migrations/                   # Alembic
-├── _env/                         # 환경변수
-└── docs/history/                 # Architecture Decision Records
-```
-
-</details>
-
----
-
-## Architecture Decisions
-
-이 프로젝트의 모든 기술 선택은 ADR(Architecture Decision Record)로 기록되어 있습니다. [37개 전체 ADR 보기 →](../docs/history/README.md)
-
-<details>
-<summary>주요 결정</summary>
-
-| # | 제목 |
-|---|------|
-| [004](../docs/history/004-dto-entity-responsibility.md) | DTO/Entity 책임 재정의 |
-| [006](../docs/history/006-ddd-layered-architecture.md) | 도메인별 레이어드 아키텍처 전환 |
-| [007](../docs/history/007-di-container-and-app-separation.md) | DI 컨테이너 계층화와 앱 분리 |
-| [011](../docs/history/011-3tier-hybrid-architecture.md) | 3-Tier 하이브리드 아키텍처 전환 |
-| [012](../docs/history/012-ruff-migration.md) | Ruff 도입 |
-| [013](../docs/history/013-why-ioc-container.md) | 상속 대신 IoC Container를 선택한 이유 |
-
-</details>
-
----
-
-## Roadmap
-
-### Phase 1: AI Agent Foundation
-- [ ] FastMCP 인터페이스 ([#18](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/18))
-- [ ] PydanticAI 통합 ([#15](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/15))
-- [ ] 추가 벡터 백엔드: pgvector ([#11](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/11))
-- [ ] JWT 인증 ([#4](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/4))
-
-### Phase 2: Production Readiness
-- [ ] 구조화된 로깅 — structlog ([#9](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/9))
-- [ ] 에러 알림 ([#17](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/17))
-- [ ] CRUD 데이터 검증 ([#10](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/10))
-
-### Phase 3: Ecosystem
-- [ ] 테스트 커버리지 확대 ([#2](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/2))
-- [ ] 성능 테스트 — Locust ([#3](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/3))
-- [ ] 서버리스 배포 ([#6](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/6))
-- [ ] WebSocket 문서 ([#1](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/1))
-
-### Completed
-- [x] Storage 추상화 — S3/MinIO 환경변수 전환 ([#58](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/58))
-- [x] Embedding 서비스 — OpenAI/Bedrock 전환 ([#69](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/69))
-- [x] S3 Vectors 지원 ([#11](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/11))
-- [x] DynamoDB 지원 ([#13](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/13))
-- [x] Broker 추상화 — SQS/RabbitMQ/InMemory ([#8](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/8))
-- [x] Admin 대시보드 — NiceGUI ([#14](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/14))
-- [x] 환경별 설정 분리 ([#7](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/7), [#16](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/16), [#53](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/53))
-- [x] 워커 페이로드 스키마 ([#37](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/37))
-- [x] CHANGELOG ([#41](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/41))
-- [x] Claude Code + Codex CLI용 14+개 AI 개발 스킬
-- [x] Codex CLI workflow layer
-- [x] 헬스 체크 엔드포인트
-- [x] 도메인 자동 발견
-- [x] 아키텍처 강제 (pre-commit)
-
-스타를 눌러 진행 상황을 팔로우하세요!
+- **MCP 서버 인터페이스** — FastMCP 로 도메인 서비스를 에이전트 도구로 노출 ([#18](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/18))
+- **pgvector** — S3 Vectors 와 병행할 추가 벡터 백엔드 ([#11](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/11))
+- **JWT 인증** ([#4](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/4)) · **구조화 로깅** ([#9](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/9))
 
 ---
 
 ## Contributing
 
-개발 환경 설정, 코딩 가이드라인, PR 프로세스는 [CONTRIBUTING.md](../CONTRIBUTING.md)를 참고하세요.
-
----
+개발 환경 설정, 코딩 가이드라인, PR 워크플로우는
+[`CONTRIBUTING.md`](../CONTRIBUTING.md) 를 참고하세요. 새로 오신 분은
+[`good first issue`](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues?q=is%3Aopen+label%3A%22good+first+issue%22)
+라벨을 먼저 확인해주세요.
 
 ## License
 
-[MIT License](../LICENSE) -- 상업적 사용, 수정, 배포 자유.
+[MIT](../LICENSE) — 상업적 사용, 수정, 재배포 자유.
 
 ---
 
-## Star History
-
+<p align="center">
 <a href="https://star-history.com/#Mr-DooSun/fastapi-agent-blueprint&Date">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=Mr-DooSun/fastapi-agent-blueprint&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=Mr-DooSun/fastapi-agent-blueprint&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=Mr-DooSun/fastapi-agent-blueprint&type=Date" width="600" />
- </picture>
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=Mr-DooSun/fastapi-agent-blueprint&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=Mr-DooSun/fastapi-agent-blueprint&type=Date" />
+    <img alt="Star History" src="https://api.star-history.com/svg?repos=Mr-DooSun/fastapi-agent-blueprint&type=Date" width="600" />
+  </picture>
 </a>
+</p>

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,293 @@
+# Reference
+
+Deep details that used to live in the README. Start with the
+[60-second quickstart](quickstart.md) or the
+[README](../README.md) for the high-level pitch; come here when you need
+environment specifics, the full tech stack, or a manual walkthrough.
+
+## Contents
+
+- [Local development with PostgreSQL](#local-development-with-postgresql)
+- [Manual setup (without Make)](#manual-setup-without-make)
+- [Tech stack](#tech-stack)
+- [Project structure](#project-structure)
+- [Manual domain scaffolding](#manual-domain-scaffolding)
+- [Roadmap](#roadmap)
+- [Selected ADRs](#selected-adrs)
+
+---
+
+## Local development with PostgreSQL
+
+The quickstart path uses SQLite + in-memory broker. For real development
+(migrations, PostgreSQL, Docker Compose):
+
+```bash
+# 1. Clone
+git clone https://github.com/Mr-DooSun/fastapi-agent-blueprint.git
+cd fastapi-agent-blueprint
+
+# 2. Setup (requires uv)
+make setup
+
+# 3. Environment variables
+cp _env/local.env.example _env/local.env
+
+# 4. PostgreSQL + migrations + server
+make dev
+```
+
+Open <http://localhost:8000/docs-swagger> to explore the API.
+
+## Manual setup (without Make)
+
+```bash
+# 1. Create venv + install deps
+uv venv --python 3.12
+source .venv/bin/activate
+uv sync --group dev
+
+# 2. Environment variables
+cp _env/local.env.example _env/local.env
+
+# 3. Start PostgreSQL (Docker)
+docker compose -f docker-compose.local.yml up -d postgres
+
+# 4. Migrations + server
+alembic upgrade head
+python run_server_local.py --env local
+```
+
+---
+
+## Tech stack
+
+FastAPI + SQLAlchemy 2.0 + Pydantic 2.x + dependency-injector + Taskiq +
+NiceGUI + asyncpg + aioboto3.
+
+### AI & Agent
+
+| Technology | Purpose | Status |
+|---|---|---|
+| **AWS S3 Vectors** | Managed vector index backend for semantic search | Available |
+| **OpenAI / Bedrock embeddings** | Pluggable embedding backends via config | Available |
+| **PydanticAI** | Structured LLM orchestration (Agent + typed outputs) | Available (classification domain) |
+| **FastMCP** | MCP server — expose domain services as AI-agent tools | Planned ([#18](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/18)) |
+
+### Core
+
+| Technology | Purpose |
+|---|---|
+| **FastAPI** | Async web framework |
+| **Pydantic** 2.x | Data validation & settings |
+| **SQLAlchemy** 2.0 | Async ORM |
+| **dependency-injector** | IoC container ([why?](history/013-why-ioc-container.md)) |
+
+### Infrastructure
+
+| Technology | Purpose |
+|---|---|
+| **PostgreSQL** + asyncpg | Primary RDBMS |
+| **Taskiq** + SQS / RabbitMQ / InMemory | Async task queue ([why not Celery?](history/001-celery-to-taskiq.md)) |
+| **aiohttp** | Async HTTP client |
+| **aioboto3** | DynamoDB, S3/MinIO, S3 Vectors, Bedrock clients |
+| **semantic-text-splitter** | Character/token chunking for embedding preprocessing |
+| **Alembic** | DB migrations |
+
+### DevOps
+
+| Technology | Purpose |
+|---|---|
+| **Ruff** | Linting + formatting ([replaces 6 tools](history/012-ruff-migration.md)) |
+| **pre-commit** | Git hook automation + architecture enforcement |
+| **UV** | Python package management ([why not Poetry?](history/005-poetry-to-uv.md)) |
+| **NiceGUI** | Admin dashboard UI |
+
+---
+
+## Project structure
+
+```
+src/
+├── _apps/                       # App entry points
+│   ├── server/                  # FastAPI HTTP server
+│   ├── worker/                  # Taskiq async worker
+│   └── admin/                   # NiceGUI admin app (mounted on server)
+│
+├── _core/                       # Shared infrastructure
+│   ├── common/                  # Pagination, security, text utils, UUID helpers
+│   ├── domain/
+│   │   ├── protocols/           # BaseRepositoryProtocol[ReturnDTO]
+│   │   └── services/            # BaseService[CreateDTO, UpdateDTO, ReturnDTO]
+│   ├── infrastructure/
+│   │   ├── database/            # Database, BaseRepository[ReturnDTO]
+│   │   ├── dynamodb/            # DynamoDBClient, BaseDynamoRepository
+│   │   ├── embedding/           # PydanticAI embedding adapter
+│   │   ├── http/                # HttpClient, BaseHttpGateway
+│   │   ├── s3vectors/           # S3VectorClient, BaseS3VectorStore
+│   │   ├── taskiq/              # Broker adapters, TaskiqManager
+│   │   ├── storage/             # S3 / MinIO
+│   │   ├── di/                  # CoreContainer
+│   │   └── discovery.py         # Auto domain discovery
+│   ├── application/dtos/        # BaseRequest, BaseResponse, SuccessResponse
+│   ├── exceptions/              # Handlers, BaseCustomException
+│   └── config.py                # Settings (pydantic-settings)
+│
+├── user/                        # Reference domain
+│   ├── domain/
+│   │   ├── dtos/                # UserDTO
+│   │   ├── protocols/           # UserRepositoryProtocol
+│   │   ├── services/            # UserService(BaseService[...])
+│   │   └── exceptions/          # UserNotFoundException
+│   ├── infrastructure/
+│   │   ├── database/models/     # UserModel
+│   │   ├── repositories/        # UserRepository(BaseRepository[UserDTO])
+│   │   └── di/                  # UserContainer
+│   └── interface/
+│       ├── server/              # routers/, schemas/, bootstrap/
+│       ├── worker/              # payloads/, tasks/, bootstrap/
+│       └── admin/               # configs/, pages/ (NiceGUI)
+│
+├── migrations/                  # Alembic
+└── _env/                        # Environment variables
+```
+
+---
+
+## Manual domain scaffolding
+
+> Prefer the automated path? `/new-domain product` (Claude Code) or
+> `$new-domain product` (Codex CLI) scaffolds the entire domain —
+> 15 content files + 25 `__init__.py` + 4 tests — in one command.
+
+Below is the same flow by hand, using a `Product` domain as an example.
+
+### 1. Domain layer
+
+```python
+# src/product/domain/dtos/product_dto.py
+class ProductDTO(BaseModel):
+    id: int = Field(..., description="Product ID")
+    name: str = Field(..., description="Product name")
+    price: int = Field(..., description="Price")
+    created_at: datetime
+    updated_at: datetime
+
+# src/product/domain/protocols/product_repository_protocol.py
+class ProductRepositoryProtocol(BaseRepositoryProtocol[ProductDTO]):
+    pass
+
+# src/product/domain/services/product_service.py
+class ProductService(
+    BaseService[CreateProductRequest, UpdateProductRequest, ProductDTO]
+):
+    def __init__(self, product_repository: ProductRepositoryProtocol):
+        super().__init__(repository=product_repository)
+    # CRUD is provided. Just add custom business logic.
+```
+
+### 2. Infrastructure layer
+
+```python
+# src/product/infrastructure/database/models/product_model.py
+class ProductModel(Base):
+    __tablename__ = "product"
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    price: Mapped[int] = mapped_column(Integer, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime, onupdate=func.now())
+
+# src/product/infrastructure/repositories/product_repository.py
+class ProductRepository(BaseRepository[ProductDTO]):
+    def __init__(self, database: Database):
+        super().__init__(database=database, model=ProductModel, return_entity=ProductDTO)
+
+# src/product/infrastructure/di/product_container.py
+class ProductContainer(containers.DeclarativeContainer):
+    core_container = providers.DependenciesContainer()
+    product_repository = providers.Singleton(ProductRepository, database=core_container.database)
+    product_service = providers.Factory(ProductService, product_repository=product_repository)
+```
+
+### 3. Interface layer
+
+```python
+# src/product/interface/server/routers/product_router.py
+@router.post("/product", response_model=SuccessResponse[ProductResponse])
+@inject
+async def create_product(
+    item: CreateProductRequest,
+    product_service: ProductService = Depends(Provide[ProductContainer.product_service]),
+) -> SuccessResponse[ProductResponse]:
+    data = await product_service.create_data(entity=item)
+    return SuccessResponse(data=ProductResponse(**data.model_dump()))
+```
+
+### Auto registration
+
+`discover_domains()` (see `src/_core/infrastructure/discovery.py`) detects
+the new domain automatically — **no edits** to `_apps/` containers or
+bootstrap files.
+
+Discovery conditions:
+
+- `src/{name}/__init__.py` exists
+- `src/{name}/infrastructure/di/{name}_container.py` exists
+
+---
+
+## Roadmap
+
+Short list; open issues are the source of truth. See the
+[issue tracker](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues)
+for the live view.
+
+### Phase 1 — AI agent foundation
+
+- [ ] FastMCP interface ([#18](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/18))
+- [ ] Additional vector backend: pgvector ([#11](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/11))
+- [ ] JWT authentication ([#4](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/4))
+- [x] PydanticAI Agent integration ([#15](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/15))
+
+### Phase 2 — Production readiness
+
+- [ ] Structured logging — structlog ([#9](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/9))
+- [ ] Error notifications ([#17](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/17))
+- [ ] CRUD data validation ([#10](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/10))
+
+### Phase 3 — Ecosystem
+
+- [ ] Test coverage expansion ([#2](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/2))
+- [ ] Performance testing — Locust ([#3](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/3))
+- [ ] Serverless deployment ([#6](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/6))
+- [ ] WebSocket documentation ([#1](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/1))
+
+### Completed (recent)
+
+- Zero-config quickstart ([#78](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/78))
+- Visual architecture diagrams + SVG exports ([#81](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/81), [#89](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/89))
+- PydanticAI embedder transition (ADR 039)
+- Storage abstraction — S3/MinIO ([#58](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/58))
+- Embedding service — OpenAI/Bedrock ([#69](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/69))
+- S3 Vectors support ([#11](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/11))
+- DynamoDB support ([#13](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/13))
+- Broker abstraction — SQS/RabbitMQ/InMemory ([#8](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/8))
+- Admin dashboard — NiceGUI ([#14](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/14))
+
+---
+
+## Selected ADRs
+
+Every technical choice in this project is captured as an ADR.
+[View all 40 ADRs →](history/README.md)
+
+| # | Title |
+|---|---|
+| [004](history/004-dto-entity-responsibility.md) | DTO/Entity responsibility redefined |
+| [006](history/006-ddd-layered-architecture.md) | Domain-driven layered architecture |
+| [007](history/007-di-container-and-app-separation.md) | DI container hierarchy and app separation |
+| [011](history/011-3tier-hybrid-architecture.md) | 3-tier hybrid architecture |
+| [012](history/012-ruff-migration.md) | Ruff adoption |
+| [013](history/013-why-ioc-container.md) | Why IoC container over inheritance |
+| [039](history/039-pydantic-ai-embedder-transition.md) | PydanticAI embedder transition |


### PR DESCRIPTION
Closes #79.

## Summary

- Rewrites [`README.md`](README.md) (633 → 260 lines) into the three tiers from #79: (1) hero + 60s quickstart with real `make demo` output + ✓/✗ comparison table, (2) one Mermaid layer diagram + one write-flow diagram + interfaces table + AI skills teaser, (3) a short "Learn more" link index.
- Mirrors the new structure in [`docs/README.ko.md`](docs/README.ko.md).
- Adds [`docs/reference.md`](docs/reference.md) as the new home for content moved out of the README: local PostgreSQL setup, manual venv path, full tech-stack tables, project tree, manual domain scaffolding walkthrough (Product example), roadmap, selected ADRs.
- Fixes stale numbers: ADR count corrected from `37`/`41` → `40` across references; PydanticAI moved from "Planned" to "Available (classification domain)" reflecting #15 being merged.

Leverages recent merges: the 60s quickstart from #78, the canonical Mermaid diagrams from #81, and the SVG exports from #89.

## What's still open, on purpose

- No gif / asciinema cast yet. The demo block uses the literal output of `make demo` captured from a real run so it stays accurate; an animated capture can be a follow-up issue.
- Korean reference doc (`docs/reference.ko.md`) not created — matches the existing pattern (`docs/quickstart.md` is English-only too). The Korean README still links to the English reference.
- `docs/ai-development.md` (skills table destination) was not touched; any cleanup there is a separate concern.

## Test plan

- [ ] Render `README.md` on GitHub and confirm:
  - both Mermaid blocks render
  - anchor nav (`60s Quickstart`, `Architecture`, `AI Skills`, `Comparison`) jumps correctly
  - the `docs/reference.md#manual-domain-scaffolding` and `docs/reference.md#local-development-with-postgresql` deep links jump to the right sections
- [ ] Render `docs/README.ko.md` on GitHub and confirm Korean anchors (`#60초-만에-실행`, `#한눈에-보는-아키텍처`, `#ai-네이티브-개발`, `#비교`) resolve
- [ ] `make quickstart` + `make demo` still produces the output shown in the README (smoke test: the example output was captured from a real run at the time of this PR)
- [ ] Skim `docs/reference.md` for any content that should stay in the README instead

## Out of scope

- End-to-end RAG example domain (#80)
- `fab init` CLI expansion (#82)
- "Your first domain in 10 minutes" full tutorial (#84) — README currently links to the manual walkthrough in `docs/reference.md` as a placeholder
- ADR consolidation (#83)