### PR TITLE
docs: add 'Your first domain in 10 minutes' tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,8 +204,9 @@ Both **Claude Code** and **OpenAI Codex CLI** are first-class. They share one ru
 ```
 
 Swap `/` for `$` if you are on Codex CLI. Prefer no harness at all?
-The [manual scaffolding walkthrough](docs/reference.md#manual-domain-scaffolding)
-shows the exact three layers the skill produces.
+The [**"Your first domain in 10 minutes" tutorial**](docs/tutorial/first-domain.md)
+walks both paths side-by-side — one harness command vs. 9 Python files —
+and ends with a passing `pytest` run plus `curl` against the real server.
 
 Selected skills (all available in both tools): `onboard`, `new-domain`,
 `add-api`, `add-worker-task`, `add-admin-page`, `review-architecture`,
@@ -219,9 +220,10 @@ Full table and setup guide: [`docs/ai-development.md`](docs/ai-development.md).
 | I want to… | Read |
 |---|---|
 | Spin it up and poke around | [`docs/quickstart.md`](docs/quickstart.md) |
+| Build a real domain, end-to-end | [`docs/tutorial/first-domain.md`](docs/tutorial/first-domain.md) |
 | Understand the architecture in depth | [`docs/ai/shared/architecture-diagrams.md`](docs/ai/shared/architecture-diagrams.md) · [`AGENTS.md`](AGENTS.md) |
 | Set up Claude Code or Codex CLI | [`docs/ai-development.md`](docs/ai-development.md) |
-| Add a domain by hand (no AI tools) | [`docs/reference.md#manual-domain-scaffolding`](docs/reference.md#manual-domain-scaffolding) |
+| Add a domain by hand (no AI tools) | [`docs/tutorial/first-domain.md`](docs/tutorial/first-domain.md) (Path B) |
 | See detailed env vars, tech stack, project tree | [`docs/reference.md`](docs/reference.md) |
 | Understand why a decision was made | [ADR index](docs/history/README.md) (40 records) |
 | Follow what's next | [Roadmap](docs/reference.md#roadmap) · [issue tracker](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues) |

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -207,8 +207,9 @@ flowchart LR
 ```
 
 Codex CLI 를 쓴다면 `/` 대신 `$`. 하네스 없이 손으로 만들고 싶다면
-[수동 도메인 스캐폴딩](reference.md#manual-domain-scaffolding) 섹션이 스킬이
-생성하는 3개 레이어를 그대로 보여줍니다.
+[**"10분 안에 첫 도메인" 튜토리얼**](tutorial/first-domain.md) 이 두 경로를
+나란히 보여줍니다 — 스킬 한 줄 vs. Python 파일 9개 — 마지막엔 `pytest`
+통과 + 실제 서버에 `curl` 까지 완주.
 
 두 도구에서 모두 동작하는 주요 스킬: `onboard`, `new-domain`, `add-api`,
 `add-worker-task`, `add-admin-page`, `review-architecture`,
@@ -222,9 +223,10 @@ Codex CLI 를 쓴다면 `/` 대신 `$`. 하네스 없이 손으로 만들고 싶
 | 원하는 것 | 읽을 곳 |
 |---|---|
 | 일단 띄워보기 | [`docs/quickstart.md`](quickstart.md) |
+| 도메인 하나 end-to-end 로 만들기 | [`docs/tutorial/first-domain.md`](tutorial/first-domain.md) |
 | 아키텍처를 깊이 이해 | [`docs/ai/shared/architecture-diagrams.md`](ai/shared/architecture-diagrams.md) · [`AGENTS.md`](../AGENTS.md) |
 | Claude Code / Codex CLI 설정 | [`docs/ai-development.ko.md`](ai-development.ko.md) |
-| 도메인을 수동으로 추가 (AI 도구 없이) | [`docs/reference.md#manual-domain-scaffolding`](reference.md#manual-domain-scaffolding) |
+| 도메인을 수동으로 추가 (AI 도구 없이) | [`docs/tutorial/first-domain.md`](tutorial/first-domain.md) (Path B) |
 | 상세 env 변수 · 기술 스택 · 프로젝트 트리 | [`docs/reference.md`](reference.md) |
 | 어떤 결정을 왜 했는지 | [ADR 인덱스](history/README.md) (40개 기록) |
 | 다음 계획 | [Roadmap](reference.md#roadmap) · [이슈 트래커](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues) |

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -156,6 +156,11 @@ src/
 
 ## Manual domain scaffolding
 
+> Looking for a guided walk-through that ends with a passing test and a
+> `curl`? Use the [**"Your first domain in 10 minutes" tutorial**](tutorial/first-domain.md)
+> instead — this section is a compact reference card of the same three
+> layers, without the step-by-step verification.
+>
 > Prefer the automated path? `/new-domain product` (Claude Code) or
 > `$new-domain product` (Codex CLI) scaffolds the entire domain —
 > 15 content files + 25 `__init__.py` + 4 tests — in one command.

--- a/docs/tutorial/first-domain.md
+++ b/docs/tutorial/first-domain.md
@@ -1,0 +1,562 @@
+# Your first domain in 10 minutes
+
+Build a working `order` domain (CRUD endpoints + a unit test) from scratch.
+By the end you will have a REST API you can `curl`, backed by SQLite,
+with the same DDD layering the rest of the blueprint uses.
+
+Two parallel paths are given side-by-side. They produce the same
+result — **the AI skills are a convenience, not a requirement**:
+
+| Path | Who it's for | What you run |
+|---|---|---|
+| **A. Harness-assisted** | You use Claude Code or Codex CLI | 3 slash / dollar commands |
+| **B. Manual** | No AI tooling, or you want to see the scaffolding explicitly | 9 Python files + 1 test |
+
+Whichever path you pick, the verification in [step 4](#step-4--verify-it-works) is identical.
+
+## Prerequisites
+
+- Python `>=3.12.9` and [`uv`](https://docs.astral.sh/uv/) installed
+- A clone of this repo with `make setup` already run (see [quickstart](../quickstart.md))
+- Expected time: **10 minutes**. No Docker, no PostgreSQL, no cloud credentials.
+
+If you have not run the quickstart yet:
+
+```bash
+git clone https://github.com/Mr-DooSun/fastapi-agent-blueprint.git
+cd fastapi-agent-blueprint
+make setup        # venv + deps via uv
+```
+
+---
+
+## Step 1 — Start the blueprint in one terminal
+
+```bash
+make quickstart   # SQLite + InMemory broker, FastAPI on :8001
+```
+
+Leave that running. Every command below runs in a *second* terminal
+from the repo root.
+
+---
+
+## Step 2 — Scaffold the `order` domain
+
+### Path A — Harness-assisted
+
+```text
+/new-domain order        # Claude Code  (use $new-domain order in Codex CLI)
+```
+
+That one command generates 15 source files + 25 `__init__.py` files +
+4 test skeletons under `src/order/` and `tests/*/order/`. Skip to
+[Step 3](#step-3--describe-an-order) to fill in the schema.
+
+### Path B — Manual
+
+Create the directory skeleton:
+
+```bash
+mkdir -p src/order/domain/{dtos,protocols,services,exceptions}
+mkdir -p src/order/infrastructure/{database/models,repositories,di}
+mkdir -p src/order/interface/server/{schemas,routers,bootstrap}
+mkdir -p tests/unit/order
+```
+
+Drop an empty `__init__.py` into **every** directory you just created,
+plus `src/order/__init__.py` itself. (These are what `discover_domains()`
+uses to find the domain at startup — see
+[`src/_core/infrastructure/discovery.py`](../../src/_core/infrastructure/discovery.py).)
+
+```bash
+find src/order tests/unit/order -type d -exec touch {}/__init__.py \;
+```
+
+---
+
+## Step 3 — Describe an order
+
+An order has a product name, a quantity, and a unit price. Four files
+define that shape across three DDD layers — Domain, Interface, and
+Infrastructure. A fifth file wires the three together via DI.
+
+### 3.1 Domain — DTO, Protocol, Service
+
+`src/order/domain/dtos/order_dto.py`
+
+```python
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class OrderDTO(BaseModel):
+    id: int = Field(..., description="Order unique identifier")
+    product_name: str = Field(..., description="Product name")
+    quantity: int = Field(..., description="Quantity ordered")
+    unit_price: int = Field(..., description="Unit price (minor units)")
+    created_at: datetime = Field(..., description="Created at")
+    updated_at: datetime = Field(..., description="Updated at")
+```
+
+`src/order/domain/protocols/order_repository_protocol.py`
+
+```python
+from src._core.domain.protocols.repository_protocol import BaseRepositoryProtocol
+from src.order.domain.dtos.order_dto import OrderDTO
+
+
+class OrderRepositoryProtocol(BaseRepositoryProtocol[OrderDTO]):
+    pass
+```
+
+`src/order/domain/services/order_service.py`
+
+```python
+from src._core.domain.services.base_service import BaseService
+from src.order.domain.dtos.order_dto import OrderDTO
+from src.order.domain.protocols.order_repository_protocol import (
+    OrderRepositoryProtocol,
+)
+from src.order.interface.server.schemas.order_schema import (
+    CreateOrderRequest,
+    UpdateOrderRequest,
+)
+
+
+class OrderService(BaseService[CreateOrderRequest, UpdateOrderRequest, OrderDTO]):
+    def __init__(self, order_repository: OrderRepositoryProtocol) -> None:
+        super().__init__(repository=order_repository)
+```
+
+Inheriting `BaseService[Create, Update, DTO]` is what gives you 7 async
+CRUD methods (`create_data`, `get_data_by_data_id`, `get_datas`,
+`update_data_by_data_id`, `delete_data_by_data_id`, …) for free.
+
+### 3.2 Interface — Request / Response schemas
+
+`src/order/interface/server/schemas/order_schema.py`
+
+```python
+from datetime import datetime
+
+from pydantic import Field
+
+from src._core.application.dtos.base_request import BaseRequest
+from src._core.application.dtos.base_response import BaseResponse
+
+
+class OrderResponse(BaseResponse):
+    id: int
+    product_name: str
+    quantity: int
+    unit_price: int
+    created_at: datetime
+    updated_at: datetime
+
+
+class CreateOrderRequest(BaseRequest):
+    product_name: str = Field(max_length=255)
+    quantity: int = Field(ge=1)
+    unit_price: int = Field(ge=0)
+
+
+class UpdateOrderRequest(BaseRequest):
+    product_name: str | None = Field(default=None, max_length=255)
+    quantity: int | None = Field(default=None, ge=1)
+    unit_price: int | None = Field(default=None, ge=0)
+```
+
+### 3.3 Infrastructure — ORM model + Repository
+
+`src/order/infrastructure/database/models/order_model.py`
+
+```python
+from sqlalchemy import DateTime, Integer, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src._core.infrastructure.database.database import Base
+
+
+class OrderModel(Base):
+    __tablename__ = "order"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    product_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    quantity: Mapped[int] = mapped_column(Integer, nullable=False)
+    unit_price: Mapped[int] = mapped_column(Integer, nullable=False)
+    created_at: Mapped[DateTime] = mapped_column(
+        DateTime, server_default=func.now(), nullable=True
+    )
+    updated_at: Mapped[DateTime] = mapped_column(
+        DateTime, server_default=func.now(), onupdate=func.now(), nullable=True
+    )
+```
+
+`src/order/infrastructure/repositories/order_repository.py`
+
+```python
+from src._core.infrastructure.database.base_repository import BaseRepository
+from src._core.infrastructure.database.database import Database
+from src.order.domain.dtos.order_dto import OrderDTO
+from src.order.infrastructure.database.models.order_model import OrderModel
+
+
+class OrderRepository(BaseRepository[OrderDTO]):
+    def __init__(self, database: Database) -> None:
+        super().__init__(
+            database=database,
+            model=OrderModel,
+            return_entity=OrderDTO,
+        )
+```
+
+### 3.4 DI Container — wire service to repository
+
+`src/order/infrastructure/di/order_container.py`
+
+```python
+from dependency_injector import containers, providers
+
+from src.order.domain.services.order_service import OrderService
+from src.order.infrastructure.repositories.order_repository import OrderRepository
+
+
+class OrderContainer(containers.DeclarativeContainer):
+    core_container = providers.DependenciesContainer()
+
+    order_repository = providers.Singleton(
+        OrderRepository,
+        database=core_container.database,
+    )
+
+    order_service = providers.Factory(
+        OrderService,
+        order_repository=order_repository,
+    )
+```
+
+### 3.5 Interface — Router + domain bootstrap
+
+`src/order/interface/server/routers/order_router.py`
+
+```python
+from dependency_injector.wiring import Provide, inject
+from fastapi import APIRouter, Depends, Query
+
+from src._core.application.dtos.base_response import SuccessResponse
+from src.order.domain.services.order_service import OrderService
+from src.order.infrastructure.di.order_container import OrderContainer
+from src.order.interface.server.schemas.order_schema import (
+    CreateOrderRequest,
+    OrderResponse,
+    UpdateOrderRequest,
+)
+
+router = APIRouter()
+
+
+@router.post(
+    "/order",
+    summary="Create order",
+    response_model=SuccessResponse[OrderResponse],
+    response_model_exclude={"pagination"},
+)
+@inject
+async def create_order(
+    item: CreateOrderRequest,
+    order_service: OrderService = Depends(Provide[OrderContainer.order_service]),
+) -> SuccessResponse[OrderResponse]:
+    data = await order_service.create_data(entity=item)
+    return SuccessResponse(data=OrderResponse(**data.model_dump()))
+
+
+@router.get(
+    "/orders",
+    summary="List orders",
+    response_model=SuccessResponse[list[OrderResponse]],
+)
+@inject
+async def list_orders(
+    page: int = 1,
+    page_size: int = Query(10, alias="pageSize"),
+    order_service: OrderService = Depends(Provide[OrderContainer.order_service]),
+) -> SuccessResponse[list[OrderResponse]]:
+    datas, pagination = await order_service.get_datas(page=page, page_size=page_size)
+    return SuccessResponse(
+        data=[OrderResponse(**d.model_dump()) for d in datas],
+        pagination=pagination,
+    )
+
+
+@router.get(
+    "/order/{order_id}",
+    summary="Get order by ID",
+    response_model=SuccessResponse[OrderResponse],
+    response_model_exclude={"pagination"},
+)
+@inject
+async def get_order_by_id(
+    order_id: int,
+    order_service: OrderService = Depends(Provide[OrderContainer.order_service]),
+) -> SuccessResponse[OrderResponse]:
+    data = await order_service.get_data_by_data_id(data_id=order_id)
+    return SuccessResponse(data=OrderResponse(**data.model_dump()))
+
+
+@router.put(
+    "/order/{order_id}",
+    summary="Update order",
+    response_model=SuccessResponse[OrderResponse],
+    response_model_exclude={"pagination"},
+)
+@inject
+async def update_order_by_id(
+    order_id: int,
+    item: UpdateOrderRequest,
+    order_service: OrderService = Depends(Provide[OrderContainer.order_service]),
+) -> SuccessResponse[OrderResponse]:
+    data = await order_service.update_data_by_data_id(data_id=order_id, entity=item)
+    return SuccessResponse(data=OrderResponse(**data.model_dump()))
+
+
+@router.delete(
+    "/order/{order_id}",
+    summary="Delete order",
+    response_model=SuccessResponse,
+    response_model_exclude={"data", "pagination"},
+)
+@inject
+async def delete_order_by_id(
+    order_id: int,
+    order_service: OrderService = Depends(Provide[OrderContainer.order_service]),
+) -> SuccessResponse:
+    success = await order_service.delete_data_by_data_id(data_id=order_id)
+    return SuccessResponse(success=success)
+```
+
+`src/order/interface/server/bootstrap/order_bootstrap.py`
+
+```python
+"""Order domain independent bootstrap"""
+
+from fastapi import FastAPI
+
+from src._core.infrastructure.database.database import Database
+from src.order.infrastructure.di.order_container import OrderContainer
+from src.order.interface.server.routers import order_router
+
+
+def create_order_container(order_container: OrderContainer):
+    order_container.wire(packages=["src.order.interface.server.routers"])
+    return order_container
+
+
+def setup_order_routes(app: FastAPI):
+    app.include_router(router=order_router.router, prefix="/v1", tags=["Order"])
+
+
+def bootstrap_order_domain(
+    app: FastAPI, database: Database, order_container: OrderContainer
+):
+    order_container = create_order_container(order_container=order_container)
+    setup_order_routes(app=app)
+```
+
+---
+
+## Step 4 — Verify it works
+
+Restart the quickstart server (leave the running one running — it
+**already picked up the new domain** via `discover_domains()`; you just
+need `make quickstart` to re-create the SQLite schema with the new
+table):
+
+```bash
+rm -f ./quickstart.db
+# restart make quickstart in the first terminal
+```
+
+> The `order` table is auto-created at boot in `ENV=quickstart` mode
+> (see [`src/_apps/server/bootstrap.py`](../../src/_apps/server/bootstrap.py)).
+> Real environments use Alembic — see
+> [`migrate-domain`](../ai-development.md) skill or
+> `alembic revision --autogenerate`.
+
+Exercise the new endpoints:
+
+```bash
+curl -sS -X POST http://127.0.0.1:8001/v1/order \
+  -H 'Content-Type: application/json' \
+  -d '{"productName":"Mechanical keyboard","quantity":2,"unitPrice":12900}'
+```
+
+```json
+{
+  "success": true,
+  "message": "Request processed successfully",
+  "data": {
+    "id": 1,
+    "productName": "Mechanical keyboard",
+    "quantity": 2,
+    "unitPrice": 12900,
+    "createdAt": "...",
+    "updatedAt": "..."
+  }
+}
+```
+
+```bash
+curl -sS http://127.0.0.1:8001/v1/orders?page=1\&pageSize=10
+curl -sS -X PUT http://127.0.0.1:8001/v1/order/1 \
+  -H 'Content-Type: application/json' -d '{"quantity":3}'
+curl -sS -X DELETE http://127.0.0.1:8001/v1/order/1
+```
+
+Open <http://127.0.0.1:8001/docs-swagger> — the `Order` tag is now
+listed alongside `User`. **No edits were needed in `src/_apps/`**:
+domain auto-discovery picked the new folder up.
+
+---
+
+## Step 5 — Add a unit test
+
+### Path A
+
+```text
+/test-domain order generate
+```
+
+### Path B
+
+Tests in this repo use a **protocol-based mock** — you don't inherit
+the real repository, you just implement the methods the service calls.
+
+`tests/unit/order/test_order_service.py`
+
+```python
+from datetime import datetime
+
+import pytest
+from pydantic import BaseModel
+
+from src.order.domain.dtos.order_dto import OrderDTO
+from src.order.domain.services.order_service import OrderService
+from src.order.interface.server.schemas.order_schema import (
+    CreateOrderRequest,
+    UpdateOrderRequest,
+)
+
+
+class MockOrderRepository:
+    def __init__(self):
+        self._store: dict[int, OrderDTO] = {}
+        self._next_id = 1
+
+    async def insert_data(self, entity: BaseModel) -> OrderDTO:
+        now = datetime.now()
+        dto = OrderDTO(
+            id=self._next_id, created_at=now, updated_at=now, **entity.model_dump()
+        )
+        self._store[self._next_id] = dto
+        self._next_id += 1
+        return dto
+
+    async def select_data_by_id(self, data_id: int) -> OrderDTO:
+        return self._store[data_id]
+
+    async def select_datas_with_count(self, page, page_size, query_filter=None):
+        items = list(self._store.values())
+        start = (page - 1) * page_size
+        return items[start : start + page_size], len(items)
+
+    async def update_data_by_data_id(self, data_id: int, entity: BaseModel) -> OrderDTO:
+        dto = self._store[data_id]
+        updated = dto.model_copy(
+            update={k: v for k, v in entity.model_dump().items() if v is not None}
+        )
+        self._store[data_id] = updated
+        return updated
+
+    async def delete_data_by_data_id(self, data_id: int) -> bool:
+        self._store.pop(data_id, None)
+        return True
+
+    async def count_datas(self) -> int:
+        return len(self._store)
+
+
+@pytest.fixture
+def order_service():
+    return OrderService(order_repository=MockOrderRepository())
+
+
+@pytest.mark.asyncio
+async def test_create_and_get_order(order_service):
+    request = CreateOrderRequest(
+        product_name="Mechanical keyboard", quantity=2, unit_price=12900
+    )
+    created = await order_service.create_data(entity=request)
+    assert created.id == 1
+    assert created.product_name == "Mechanical keyboard"
+
+    fetched = await order_service.get_data_by_data_id(data_id=created.id)
+    assert fetched.quantity == 2
+
+
+@pytest.mark.asyncio
+async def test_update_order(order_service):
+    created = await order_service.create_data(
+        entity=CreateOrderRequest(
+            product_name="Mouse pad", quantity=1, unit_price=1500
+        )
+    )
+    updated = await order_service.update_data_by_data_id(
+        data_id=created.id, entity=UpdateOrderRequest(quantity=3)
+    )
+    assert updated.quantity == 3
+    assert updated.product_name == "Mouse pad"
+```
+
+Run it:
+
+```bash
+pytest tests/unit/order/ -v
+```
+
+```text
+tests/unit/order/test_order_service.py::test_create_and_get_order PASSED
+tests/unit/order/test_order_service.py::test_update_order         PASSED
+============================== 2 passed in 0.05s ===============================
+```
+
+---
+
+## You just wrote
+
+- A DDD-layered domain with zero `Domain → Infrastructure` imports (the pre-commit hook enforces this).
+- A service that inherits 7 async CRUD methods from `BaseService` without writing them.
+- An ORM model that never leaves the Repository boundary (conversion to `OrderDTO` happens inside `BaseRepository`).
+- A router that `Depends` on an IoC-wired service — no manual `get_db()`, no global state.
+- A unit test against a protocol-based mock — no database spin-up, no SQLAlchemy patching.
+- All of it auto-registered via `discover_domains()`. **Not one line of `src/_apps/` was touched.**
+
+## Next
+
+- **Add a background job** — same domain, new interface. See
+  [`add-worker-task`](../ai-development.md) skill or
+  [`src/user/interface/worker/`](../../src/user/interface/worker/).
+- **Add an admin page** — auto-generated CRUD UI via NiceGUI. See
+  [`add-admin-page`](../ai-development.md) skill or
+  [`src/user/interface/admin/`](../../src/user/interface/admin/).
+- **Wire an Alembic migration** — the quickstart path uses `create_all`;
+  for real environments, generate a migration with
+  `alembic revision --autogenerate -m "order: add order table"`.
+- **Connect domains** — see the
+  [`add-cross-domain`](../ai-development.md) skill for the Protocol-based
+  DIP pattern that lets `order` depend on `user` without an import cycle.
+
+Stuck? The reference `user` domain under [`src/user/`](../../src/user/)
+is the same pattern with password hashing, batch create, and a worker
+task added on top.


### PR DESCRIPTION
Closes #84.

## Summary

- Adds [`docs/tutorial/first-domain.md`](docs/tutorial/first-domain.md): a 10-minute walk-through that builds a working `order` domain from scratch — CRUD endpoints, SQLite, and a passing unit test. Path A (AI-assisted: `/new-domain order` + `/test-domain order`) and Path B (9 Python files by hand) are shown **side-by-side** so the blueprint does not look AI-harness-locked.
- Ends with `curl` against the running quickstart server plus a `pytest tests/unit/order/` run — both verified on my machine while writing this PR.
- Updates [`README.md`](README.md) and [`docs/README.ko.md`](docs/README.ko.md): the "first domain in 10 minutes" section and "Learn more" table now point at the tutorial instead of the `docs/reference.md#manual-domain-scaffolding` placeholder left by #79.
- Adds a cross-link in [`docs/reference.md`](docs/reference.md) so readers who land on the compact reference card get pointed at the guided tutorial first.

## Why a tutorial (not just more README)

- #79 made the README demo-first but left a placeholder for the manual walkthrough — that placeholder is what this tutorial fills.
- The issue (#84) flagged a perceptual risk: the blueprint has 14 Claude Code skills + 15 Codex CLI skills, so without a written walk-through the architecture looks locked behind a specific AI tool. Path B is the explicit counter-argument: "it's just Python."
- The `order` domain (not `product`) was chosen so the tutorial doesn't overlap with the Product example in `docs/reference.md`; they now teach the same pattern at two depths.

## How this was verified

I actually scaffolded the tutorial's `order` domain in this working tree, ran `make quickstart`, hit every endpoint with `curl`, and ran the unit test. 2/2 tests passed, all 5 CRUD endpoints returned expected JSON. The temporary `src/order/` + `tests/unit/order/` were removed before committing — only the tutorial doc that teaches readers to reproduce them is part of this PR. `make quickstart` was then re-run against the cleaned tree to confirm nothing else depends on those files.

## Test plan

- [ ] Render `docs/tutorial/first-domain.md` on GitHub and confirm all fenced code blocks + tables render cleanly
- [ ] Follow Path B start-to-finish from a fresh clone: paste each file, run `make quickstart`, hit `curl`, run `pytest`
- [ ] Follow Path A start-to-finish with Claude Code or Codex CLI and confirm the skill outputs are compatible with the tutorial's framing
- [ ] Verify the updated `README.md` / `docs/README.ko.md` links jump to the tutorial
- [ ] Confirm `docs/reference.md#manual-domain-scaffolding` preamble reads sensibly in the context of having a dedicated tutorial

## Out of scope

- End-to-end RAG example domain (#80) — referenced under "Next" in the tutorial but not created
- `examples/` seed + good-first-issues curation (#85)
- ADR consolidation (#83)
- `fab init` CLI expansion (#82)