### PR TITLE
docs: scaffold examples/ directory as contributor funnel

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,7 +146,18 @@ Use the built-in Claude Code skill:
 /new-domain {name}
 ```
 
-Or follow the [manual steps in the README](README.md#adding-a-new-domain).
+Or follow the [10-minute tutorial](docs/tutorial/first-domain.md) which
+walks both the harness-assisted and manual paths side-by-side.
+
+## Contributing an Example
+
+Small pattern-focused apps live under [`examples/`](examples/). Each
+example is scoped to one pattern (CRUD, worker task, cross-domain link,
+LLM agent) and is mirrored by a `good first issue` on the tracker.
+
+Start at [`examples/README.md`](examples/README.md) — it covers the
+layout expectation, the "copy into `src/` to run" workflow, and the
+acceptance criteria every example PR must meet.
 
 ## Running Tests
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Full table and setup guide: [`docs/ai-development.md`](docs/ai-development.md).
 |---|---|
 | Spin it up and poke around | [`docs/quickstart.md`](docs/quickstart.md) |
 | Build a real domain, end-to-end | [`docs/tutorial/first-domain.md`](docs/tutorial/first-domain.md) |
+| See small, pattern-focused example apps | [`examples/`](examples/) |
 | Understand the architecture in depth | [`docs/ai/shared/architecture-diagrams.md`](docs/ai/shared/architecture-diagrams.md) · [`AGENTS.md`](AGENTS.md) |
 | Set up Claude Code or Codex CLI | [`docs/ai-development.md`](docs/ai-development.md) |
 | Add a domain by hand (no AI tools) | [`docs/tutorial/first-domain.md`](docs/tutorial/first-domain.md) (Path B) |
@@ -243,7 +244,8 @@ Full table and setup guide: [`docs/ai-development.md`](docs/ai-development.md).
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) for dev setup, coding guidelines,
 and the PR workflow. Newcomers — check the
 [`good first issue`](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues?q=is%3Aopen+label%3A%22good+first+issue%22)
-label.
+label; the small apps tracked under [`examples/`](examples/) are a
+low-friction place to land your first PR.
 
 ## License
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -224,6 +224,7 @@ Codex CLI 를 쓴다면 `/` 대신 `$`. 하네스 없이 손으로 만들고 싶
 |---|---|
 | 일단 띄워보기 | [`docs/quickstart.md`](quickstart.md) |
 | 도메인 하나 end-to-end 로 만들기 | [`docs/tutorial/first-domain.md`](tutorial/first-domain.md) |
+| 작은 패턴 중심 예제 앱 둘러보기 | [`examples/`](../examples/) |
 | 아키텍처를 깊이 이해 | [`docs/ai/shared/architecture-diagrams.md`](ai/shared/architecture-diagrams.md) · [`AGENTS.md`](../AGENTS.md) |
 | Claude Code / Codex CLI 설정 | [`docs/ai-development.ko.md`](ai-development.ko.md) |
 | 도메인을 수동으로 추가 (AI 도구 없이) | [`docs/tutorial/first-domain.md`](tutorial/first-domain.md) (Path B) |
@@ -246,7 +247,8 @@ Codex CLI 를 쓴다면 `/` 대신 `$`. 하네스 없이 손으로 만들고 싶
 개발 환경 설정, 코딩 가이드라인, PR 워크플로우는
 [`CONTRIBUTING.md`](../CONTRIBUTING.md) 를 참고하세요. 새로 오신 분은
 [`good first issue`](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues?q=is%3Aopen+label%3A%22good+first+issue%22)
-라벨을 먼저 확인해주세요.
+라벨을 먼저 확인해주세요. [`examples/`](../examples/) 아래 작은 예제
+앱들이 첫 PR을 내기 좋은 저마찰 진입점입니다.
 
 ## License
 

--- a/docs/tutorial/first-domain.md
+++ b/docs/tutorial/first-domain.md
@@ -544,6 +544,9 @@ tests/unit/order/test_order_service.py::test_update_order         PASSED
 
 ## Next
 
+- **Browse more patterns** — [`examples/`](../../examples/) has small
+  self-contained apps contributors can read and paste: CRUD, worker
+  tasks, cross-domain dependencies, minimal LLM agent.
 - **Add a background job** — same domain, new interface. See
   [`add-worker-task`](../ai-development.md) skill or
   [`src/user/interface/worker/`](../../src/user/interface/worker/).

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,110 @@
+# Examples
+
+Small, self-contained example applications built with this blueprint.
+Each example is a **contributor-built** reference showing one pattern —
+plain CRUD, background workers, cross-domain dependencies, LLM agents —
+without the extra tooling that ships with the production reference
+domains in [`src/`](../src/).
+
+> 👀 New here?
+> - Evaluate first with [`make quickstart`](../docs/quickstart.md).
+> - Build your own first domain with the [10-minute tutorial](../docs/tutorial/first-domain.md).
+> - Then come back to pattern-match against these examples.
+
+## How to run an example
+
+Each example is laid out **exactly like a production domain** under
+`src/{name}/`. The blueprint's auto-discovery
+([`src/_core/infrastructure/discovery.py`](../src/_core/infrastructure/discovery.py))
+only scans `src/`, so an example is "installed" by copying it in:
+
+```bash
+# Pick an example you want to try (e.g., todo).
+cp -r examples/todo src/todo
+
+# Boot the quickstart server — auto-discovery picks it up on startup.
+rm -f ./quickstart.db         # so the new table is created at boot
+make quickstart
+```
+
+Swagger at <http://127.0.0.1:8001/docs-swagger> will now list the new
+tag alongside `User`. Remove the example when you are done:
+
+```bash
+rm -rf src/todo
+rm -f ./quickstart.db
+```
+
+> **Why copy instead of symlink?** Examples are meant to be *read* as
+> much as *run*. Copying is explicit, works on every OS, and matches
+> what a contributor would do when turning an example into a real
+> domain inside their own fork.
+
+## Contributing a new example
+
+Each `good first issue` under the `examples/` area maps one-to-one to a
+planned folder in this directory. See the
+[`good first issue` list](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues?q=is%3Aopen+label%3A%22good+first+issue%22)
+for what is up for grabs.
+
+An example PR should include:
+
+1. **Code** under `examples/{name}/` mirroring the `src/{domain}/`
+   layout (Domain, Infrastructure, Interface) exactly — see the
+   [tutorial](../docs/tutorial/first-domain.md#step-3--describe-an-order)
+   for the canonical structure.
+2. **A README** in `examples/{name}/README.md` covering:
+   - What pattern the example teaches (2–3 sentences).
+   - `curl` requests a reader can paste to exercise the endpoints.
+   - Relevant production-domain reference (e.g. "compare with
+     [`src/user/`](../src/user/) for password hashing").
+3. **A unit test** under `examples/{name}/tests/` (or at least a
+   protocol-based mock test pattern like the
+   [tutorial unit test](../docs/tutorial/first-domain.md#step-5--add-a-unit-test))
+   so a contributor can verify locally before pasting into `src/`.
+4. **No new dependencies** unless explicitly called for by the issue.
+   If your example needs a library not already in `pyproject.toml`,
+   open a discussion on the issue first.
+
+Architectural rules in [`AGENTS.md`](../AGENTS.md) apply to examples
+just like production domains — no `Domain → Infrastructure` imports,
+no Model objects leaving the Repository, no Mapper classes.
+
+## Available examples
+
+Populated incrementally as contributors land the good-first-issues:
+
+| Example | Pattern it teaches | Status |
+|---|---|---|
+| `todo/` | Minimal CRUD domain (zero infra) | 🟡 tracked issue |
+| `url-shortener/` | CRUD + Taskiq worker cleanup task | 🟡 tracked issue |
+| `blog/` | Two domains + Protocol-based cross-domain DIP | 🟡 tracked issue |
+| `webhook-receiver/` | Worker task driven by a broker message | 🟡 tracked issue |
+| `simple-chatbot/` | Minimal PydanticAI Agent — no RAG | 🟡 tracked issue |
+
+Finished examples move from 🟡 to ✅ with a link to the PR that landed
+them. If an example you want is not on the list, open a
+[feature request](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/new?template=feature_request.yml)
+describing the pattern it would teach.
+
+## What belongs here (and what does not)
+
+**Good fit for `examples/`**
+
+- Demonstrates a single blueprint pattern end-to-end in under a day of work.
+- Standalone: can be copied into `src/` of a fresh clone and run with
+  `make quickstart`, no external infrastructure.
+- Small enough for a reviewer to read the full diff in one sitting.
+
+**Belongs in `src/` instead**
+
+- Showcases the full stack (e.g. the planned RAG domain in
+  [#80](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/80)
+  lives in `src/` because it exercises embeddings + vector store + LLM
+  together and needs to be covered by the main test suite).
+
+**Belongs in a separate repo**
+
+- Consumer applications built *with* the blueprint (e.g. a SaaS product).
+  Those are the payoff, not examples. Link them from your own README
+  and we will happily feature them in a "built with" section.


### PR DESCRIPTION
Part 1 of #85. Sets up the infrastructure so the 5 seed example issues have somewhere coherent to land. Issue creation for the seeds themselves is a follow-up step (proposed bodies below, to be created on approval).

## Summary

- [`examples/README.md`](examples/README.md): purpose statement, "copy to `src/` to run" workflow (auto-discovery only scans `src/`), acceptance criteria every example PR must meet, planned-examples table, and an explicit boundary ("RAG lives in `src/`, showcase apps go in their own repos").
- [`README.md`](README.md) + [`docs/README.ko.md`](docs/README.ko.md): new "Learn more" row surfacing `examples/`; Contributing blurb calls `examples/` out as the low-friction first-PR entry point.
- [`CONTRIBUTING.md`](CONTRIBUTING.md): fixes the stale `README.md#adding-a-new-domain` link (that anchor disappeared in #79) by pointing to the tutorial, and adds a short "Contributing an Example" section pointing at `examples/README.md`.
- [`docs/tutorial/first-domain.md`](docs/tutorial/first-domain.md): "Next" list now leads with `examples/` so readers who just finished their first domain see pattern variety as the logical next step.

## Why split this out of issue creation

Issues are public artefacts and harder to revise than code. Landing the scaffolding first means the issue bodies can cite the real `examples/README.md` acceptance criteria instead of aspirational markdown. It also lets reviewers assess the "copy to `src/`" workflow on its own merits before 5 issues go out referencing it.

## Proposed follow-up (after this lands)

### Seed issues to create (all labeled `good first issue`, `enhancement`)

1. **`examples/todo/` — Minimal CRUD example**
   Introduces one domain (`todo`: title, description, done, timestamps) with the 5 standard CRUD endpoints and one protocol-based mock unit test. Reference: [docs/tutorial/first-domain.md](docs/tutorial/first-domain.md), [src/user/](src/user/). Out of scope: auth, tags, pagination UX.

2. **`examples/url-shortener/` — CRUD + Taskiq cleanup worker**
   One `link` domain (short_code, target_url, expires_at) plus a Taskiq task that deletes expired links. Demonstrates the worker interface sharing the same domain service. Reference: [src/user/interface/worker/](src/user/interface/worker/), [docs/tutorial/first-domain.md](docs/tutorial/first-domain.md). Out of scope: analytics, custom slug validation.

3. **`examples/blog/` — Two domains with Protocol-based cross-domain DIP**
   `author` + `post` domains where `post` depends on `author` via `AuthorRepositoryProtocol`, not via direct import. Demonstrates the cross-domain pattern described in ADR 007 without the complexity of a third domain. Reference: `$add-cross-domain` / `/add-cross-domain` skill, [AGENTS.md](AGENTS.md) "cross-domain" section. Out of scope: comments, markdown rendering.

4. **`examples/webhook-receiver/` — Worker task driven by broker message**
   One `webhook_event` domain stores received payloads; a Taskiq worker processes them asynchronously. Demonstrates the full POST → enqueue → worker loop against `BROKER_TYPE=inmemory`. Reference: [src/_core/infrastructure/taskiq/](src/_core/infrastructure/taskiq/), [src/user/interface/worker/](src/user/interface/worker/). Out of scope: signature verification, retry policy.

5. **`examples/simple-chatbot/` — Minimal PydanticAI Agent, no RAG**
   One `chat` domain that wraps a PydanticAI `Agent` with a structured output type (`ChatReply`). Demonstrates the LLM path without vector storage — contrast point for the full RAG domain planned in #80. Reference: [src/classification/](src/classification/) (production-grade LLM Agent reference). Out of scope: conversation history, streaming responses.

### Existing issues to relabel with `good first issue`

After a quick audit, these fit the "newcomer-appropriate, \<1 day, well-scoped" bar:

- **#10 Add CRUD data validation** — self-contained, well-scoped, mirrors existing patterns.
- **#2 Expand test coverage** — ideal newcomer work, reads existing code and writes tests.

Not added (too much context required to land a first PR): #9 structlog, #17 error notification, #18 FastMCP, #4 JWT.

I'll present the exact `gh issue create` / `gh issue edit` commands for confirmation in the PR thread before running them.

## Test plan

- [ ] Render `examples/README.md`, `CONTRIBUTING.md`, `docs/tutorial/first-domain.md`, both READMEs on GitHub and confirm every relative link resolves
- [ ] Sanity-check the "copy `examples/{name}/` to `src/{name}/`" workflow by picking any existing domain layout and confirming `discover_domains()` would pick it up
- [ ] Review the 5 proposed seed issue descriptions above and flag anything that's out of scope or missing
- [ ] Confirm the #10 / #2 relabel proposal before I run `gh issue edit`

## Out of scope

- The 5 example apps themselves (will land as the seed issues above)
- End-to-end RAG example domain (#80, lives in `src/` not `examples/`)
- `fab init` CLI expansion (#82)
- ADR consolidation (#83)