### PR TITLE
refactor(_core): make CoreContainer infra truly optional (#101 Part A)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,21 @@ When fields match, Request is passed directly to Service — creating a separate
 - UseCase criteria: multiple Service composition, cross-transaction boundaries, or other orchestration complexity
 - When in doubt: start without UseCase, add it when complexity grows
 
+## Optional Infrastructure
+
+Every non-DB infra in `CoreContainer` is optional — toggle via env vars, no code change. When a group is disabled, the provider returns a stub (where graceful degradation matters) or `None` (for data stores). Background: [ADR 042](docs/history/042-optional-infrastructure-di-pattern.md).
+
+| Infra | Enable flag | Disabled behavior |
+|---|---|---|
+| Storage (S3 / MinIO) | `STORAGE_TYPE=s3` or `minio` | `storage_client()` / `storage()` return `None` |
+| DynamoDB | `DYNAMODB_ACCESS_KEY` set | `dynamodb_client()` returns `None` |
+| S3 Vectors | `S3VECTORS_ACCESS_KEY` set | `s3vector_client()` returns `None` |
+| Embedding | `EMBEDDING_PROVIDER` + `EMBEDDING_MODEL` both set | `embedding_client()` returns `StubEmbedder` (keyword bag-of-words) |
+| LLM | `LLM_PROVIDER` + `LLM_MODEL` both set | `llm_model()` returns `None` (→ `StubLLMModel` after #101 Part B) |
+| Broker | `BROKER_TYPE=sqs` / `rabbitmq` / `inmemory` | Defaults to `inmemory` — no external broker required |
+
+**Consumer rule:** data-store clients (`None`-returning) require an explicit guard at the call site when your domain needs them; stub-returning infras just work (but signal "stub" via startup warning logs). Use `providers.Selector` in your domain container to branch between real and stub paths if needed — `src/docs/infrastructure/di/docs_container.py` is the reference pattern.
+
 ## Terminology
 
 - **Request/Response**: API communication schema (`interface/server/schemas/`)

--- a/docs/history/042-optional-infrastructure-di-pattern.md
+++ b/docs/history/042-optional-infrastructure-di-pattern.md
@@ -1,0 +1,131 @@
+# 042. Optional Infrastructure — Selector + Lazy Factory Pattern in CoreContainer
+
+- Status: Accepted
+- Date: 2026-04-21
+- Related issue: #101 (Make CoreContainer infra truly optional)
+- Precursor to: #82 (`fab init` CLI — unblocked by this ADR)
+- Extends: [ADR 029](archive/029-broker-abstraction-selector.md) (broker Selector was the first instance of this pattern)
+
+## Summary
+
+Every non-DB infrastructure in `CoreContainer` (storage, DynamoDB, S3 Vectors, embedding, LLM) now follows a single pattern:
+
+1. A module-scope `_<infra>_selector()` function reads `settings` at resolution time and returns `"enabled"` or `"disabled"`.
+2. A module-scope `_build_<infra>()` factory does a **lazy import** of the real client inside its body, so removing an optional extra (`pydantic-ai-slim`, etc.) does not break app boot when the infra is not configured.
+3. The container exposes the provider as `providers.Selector(_selector, enabled=..., disabled=...)`.
+4. The **disabled branch** is per-infra:
+   - Stub instance for infras where consumer domains need graceful degradation (`embedding_client` → `StubEmbedder`; `llm_model` → `StubLLMModel` once #101 Part B lands).
+   - `providers.Object(None)` for data-storage infras (`storage_client`, `storage`, `dynamodb_client`, `s3vector_client`) where a fake client would mislead.
+
+Broker continues to use its three-way Selector (`sqs` / `rabbitmq` / `inmemory`) as the original template.
+
+## Background
+
+Before this ADR, `core_container.py` imported every optional infra client at module top and instantiated each as an unconditional `providers.Singleton(...)`, regardless of whether the user had configured that infra. Two real-world failures followed:
+
+1. **`pyproject.toml` optional extras were a lie.** Even though `pydantic-ai-slim`, `taskiq-aws`, `taskiq-aio-pika` were listed under `[project.optional-dependencies]`, uninstalling them caused `ImportError` at app boot. Users could not opt out.
+2. **Disabled-but-instantiated dead clients.** `LLMConfig(model_name="")` and friends were constructed with empty credentials when `LLM_*` was unset. The first call down the chain (e.g. `Agent(model="")` inside `ClassificationService`) raised a deep PydanticAI error rather than a clear "this infra is not enabled" signal.
+
+The broker already had the right shape (see [ADR 029](archive/029-broker-abstraction-selector.md)). This ADR generalises that shape to the remaining five optional infras and records the per-infra disabled-branch rule so future additions don't re-litigate.
+
+`#82` (interactive `fab init` CLI) was blocked on this: a CLI that "removes DynamoDB" would otherwise have to physically rewrite `core_container.py`. After this ADR lands, the CLI becomes a thin `.env` scaffolder (or is unnecessary — see #82 re-evaluation).
+
+## Decision
+
+### 1. Pattern shape (all five infras)
+
+```python
+# module scope
+def _dynamodb_selector() -> str:
+    return "enabled" if settings.dynamodb_access_key else "disabled"
+
+
+def _build_dynamodb_client(access_key, secret_access_key, region_name, endpoint_url):
+    # Lazy import — removing the matching optional extra (boto3 in this case,
+    # pydantic-ai-slim for llm/embedding) does not break import of this module.
+    from src._core.infrastructure.persistence.nosql.dynamodb.dynamodb_client import (
+        DynamoDBClient,
+    )
+    return DynamoDBClient(
+        access_key=access_key or "",
+        secret_access_key=secret_access_key or "",
+        region_name=region_name or "ap-northeast-2",
+        endpoint_url=endpoint_url,
+    )
+
+
+# in CoreContainer class body
+dynamodb_client = providers.Selector(
+    _dynamodb_selector,
+    enabled=providers.Singleton(
+        _build_dynamodb_client,
+        access_key=settings.dynamodb_access_key,
+        secret_access_key=settings.dynamodb_secret_key,
+        region_name=settings.dynamodb_region,
+        endpoint_url=settings.dynamodb_endpoint_url,
+    ),
+    disabled=providers.Object(None),
+)
+```
+
+Key discipline:
+
+- Selector functions read `settings` **at call time**, not at import time, so tests can monkeypatch a settings field to flip the branch.
+- Factory imports live **inside the function body**, never at module top. `try/except ImportError` with an install hint is used only where the dependency itself might be missing (`pydantic-ai` for embedding/LLM — see `broker.py` for the original template).
+- Factory signatures type settings fields as `str | None` (their real type) and use `value or default` fallbacks, since pyright cannot see the Selector invariant that guarantees non-None in the enabled branch.
+
+### 2. Per-infra disabled-branch strategy
+
+| Infra | Disabled branch | Reason |
+|---|---|---|
+| `storage_client`, `storage` | `providers.Object(None)` | No current consumer; fake storage would make saved uploads silently vanish. Future consumers must guard or declare storage mandatory. |
+| `dynamodb_client` | `providers.Object(None)` | A fake DynamoDB client would accept writes that never persist; user debugging would blame the wrong layer. |
+| `s3vector_client` | `providers.Object(None)` | Same as DynamoDB. The `docs` domain already falls back to in-memory via its own `chunk_vector_store` selector, so the S3 client genuinely goes unused when disabled. |
+| `embedding_client` | `Singleton(StubEmbedder, dimension=...)` | Consumer domains (`docs`) need to answer questions even without an embedding provider. `StubEmbedder` already exists (keyword bag-of-words). |
+| `llm_model` | `providers.Object(None)` in this PR; `Singleton(StubLLMModel)` after #101 Part B | `classification` / `docs` need graceful degradation once `StubLLMModel` exists. Intermediate None does not regress: today's empty-string path also fails at request time. |
+
+The rule of thumb: **stub when the disabled path must still serve traffic; None when the disabled path should never be touched.** Data stores fall in the second bucket because a fake that accepts writes is worse than a `NoneType` error at the call site.
+
+### 3. Drop `llm_config` / `embedding_config` as standalone providers
+
+Previously each infra exposed both a config VO (`LLMConfig` / `EmbeddingConfig`) and the client it configured. Nothing outside `core_container.py` referenced the config providers. The new build functions construct the VO locally and return the client directly, removing two unused entries from the container's public surface. The VO classes themselves are unchanged and still used inside the infra layer.
+
+### 4. Selector functions read computed Settings properties
+
+`settings.llm_model_name` and `settings.embedding_model_name` are `str | None` computed properties that already return `None` when provider + model are not both set. Selectors use these (not raw `llm_provider` fields) as the single source of truth for "is this infra enabled?", matching the semantics already established by the `docs` domain's embedder selector.
+
+## Alternatives Considered
+
+### A.1 — `providers.Selector` + `providers.Object(None)` with top-level imports kept
+
+Replace the unconditional `providers.Singleton` with a Selector, but keep the `from ... import DynamoDBClient` at module top. Rejected: acceptance criterion for #101 was "boot with optional extras uninstalled → no ImportError". Top-level imports survive that uninstall and violate it. This is the minimum-viable rewrite and it does not satisfy the goal.
+
+### A.2 — Lazy factory without Selector (bare `providers.Singleton(_factory)` that returns `None` when disabled)
+
+```python
+def _build_dynamodb_client():
+    if not settings.dynamodb_access_key:
+        return None
+    from ... import DynamoDBClient
+    return DynamoDBClient(...)
+
+dynamodb_client = providers.Singleton(_build_dynamodb_client)
+```
+
+Rejected: dependency-injector introspection (`.provided`, `.override`, `.reset`) becomes awkward when the Singleton can return `None` — `.provided.<attr>` on `None` fails silently. Selector encodes the branch choice in the DI graph, which is what downstream overrides expect. Also, having the disabled path be a `providers.Object(None)` (not a Singleton call) means zero allocation — the `None` literal is returned directly.
+
+### A.3 — Selector + lazy factory (chosen)
+
+Combines (1) lazy import inside the factory with (2) Selector for branch encoding. Satisfies acceptance criterion and keeps DI introspection honest. Mirrors the existing `broker` pattern (ADR 029) and the lazy imports already present in `build_llm_model` / `broker.create_sqs_broker`.
+
+### B — Single StubClient class per infra (`StubDynamoDBClient`, `StubS3VectorClient`)
+
+Considered and rejected for data stores. Stubs for "write-then-read" data stores must decide whether to persist in memory or to silently drop — both mislead. A user who writes a row and queries it back, receiving it intact, will not suspect that real DynamoDB was never touched. `None` plus an explicit guard at the call site ("this domain requires DYNAMODB to be configured") is honest. Stubs make sense only where the consumer's workflow is still meaningful without a real backend — currently that's embedding (similarity over random vectors approximates keyword overlap) and LLM (templated response from retrieved chunks).
+
+## Consequences
+
+- **Boot-time guarantee:** with only `DATABASE_ENGINE=sqlite` set and all optional extras uninstalled (`pydantic-ai-slim`, `taskiq-aws`, `taskiq-aio-pika`), the app imports cleanly and `/docs` serves OpenAPI. Regression-guarded by `tests/integration/test_optional_infra.py`.
+- **Domain degradation is localised.** `docs` already degrades via its domain-level Selector (kept in place as a self-contained example). `classification` still fails at request time when `LLM_*` is unset — #101 Part B replaces the `llm_model` disabled branch with `StubLLMModel` to close that gap.
+- **Every new optional infra uses this pattern by default.** The `/new-domain` skill templates (`/claude/skills/new-domain/`, `.codex/new-domain`) will be updated in #101 Part B so scaffolded domains ship with Selector + stub where they declare an LLM or Embedding dependency.
+- **`#82` unblocked.** Any future CLI that offers "remove DynamoDB" only needs to unset `DYNAMODB_*` in the scaffolded `.env`; no source rewriting. `#82` scope may shrink to "thin `.env` scaffolder" or be closed entirely — decision deferred to post-merge re-evaluation.
+- **`pyproject.toml` cleanup (nicegui, boto3 → optional extras) is out of scope** for this ADR. Filed as a separate follow-up issue; it is a user-facing UX change (admin dashboard mount decision, aws-installation matrix) and deserves its own design pass.

--- a/src/_core/infrastructure/di/core_container.py
+++ b/src/_core/infrastructure/di/core_container.py
@@ -1,32 +1,193 @@
+"""Core DI container.
+
+Optional infrastructure follows the same pattern as ``broker`` (see
+``src/_core/infrastructure/taskiq/broker.py`` and ADR 029 / ADR 042):
+
+- A ``_<infra>_selector()`` module-scope function reads ``settings`` and
+  returns ``"enabled"`` or ``"disabled"``.
+- A ``_build_<infra>()`` factory lazy-imports the real client inside, so
+  removing an optional extra (``pydantic-ai-slim``, etc.) does not break
+  app boot when the infra is not configured.
+- The provider is a ``providers.Selector`` whose disabled branch returns
+  either ``providers.Object(None)`` (data stores — a fake client would
+  mislead) or a stub instance (LLM / Embedding — domains need graceful
+  degradation).
+
+Infrastructure that is always required (RDB database, HTTP client) is
+registered as a plain ``providers.Singleton`` as before.
+"""
+
 from dependency_injector import containers, providers
 from taskiq import InMemoryBroker
 
 from src._core.config import settings
-from src._core.domain.value_objects.embedding_config import EmbeddingConfig
-from src._core.domain.value_objects.llm_config import LLMConfig
-from src._core.infrastructure.embedding.pydantic_ai_embedding_adapter import (
-    PydanticAIEmbeddingAdapter,
-)
 from src._core.infrastructure.http.http_client import HttpClient
-from src._core.infrastructure.llm.model_factory import build_llm_model
-from src._core.infrastructure.persistence.nosql.dynamodb.dynamodb_client import (
-    DynamoDBClient,
-)
 from src._core.infrastructure.persistence.rdb.config import DatabaseConfig
 from src._core.infrastructure.persistence.rdb.database import Database
-from src._core.infrastructure.storage.object_storage import ObjectStorage
-from src._core.infrastructure.storage.object_storage_client import ObjectStorageClient
 from src._core.infrastructure.taskiq.broker import (
     create_rabbitmq_broker,
     create_sqs_broker,
 )
 from src._core.infrastructure.taskiq.manager import TaskiqManager
-from src._core.infrastructure.vectors.s3.client import S3VectorClient
+
+# ---------------------------------------------------------------------------
+# Selector functions — read ``settings`` at resolution time, so tests can
+# monkeypatch settings fields to flip branches.
+# ---------------------------------------------------------------------------
+
+
+def _storage_selector() -> str:
+    return "enabled" if settings.storage_type else "disabled"
+
+
+def _dynamodb_selector() -> str:
+    return "enabled" if settings.dynamodb_access_key else "disabled"
+
+
+def _s3vector_selector() -> str:
+    return "enabled" if settings.s3vectors_access_key else "disabled"
+
+
+def _embedding_selector() -> str:
+    return "enabled" if settings.embedding_model_name else "disabled"
+
+
+def _llm_selector() -> str:
+    return "enabled" if settings.llm_model_name else "disabled"
+
+
+# ---------------------------------------------------------------------------
+# Lazy factories — imports happen inside so that uninstalling the matching
+# optional extra (aws, pydantic-ai, …) does not break import of this module.
+# ---------------------------------------------------------------------------
+
+
+def _build_storage_client(
+    access_key: str | None,
+    secret_access_key: str | None,
+    region_name: str | None,
+    endpoint_url: str | None,
+):
+    from src._core.infrastructure.storage.object_storage_client import (
+        ObjectStorageClient,
+    )
+
+    # Selector guarantees these are populated when the enabled branch runs;
+    # ``or ""`` keeps pyright happy without a runtime guard.
+    return ObjectStorageClient(
+        access_key=access_key or "",
+        secret_access_key=secret_access_key or "",
+        region_name=region_name or "ap-northeast-2",
+        endpoint_url=endpoint_url,
+    )
+
+
+def _build_storage(storage_client, bucket_name: str | None):
+    from src._core.infrastructure.storage.object_storage import ObjectStorage
+
+    return ObjectStorage(
+        storage_client=storage_client,
+        bucket_name=bucket_name or "",
+    )
+
+
+def _build_dynamodb_client(
+    access_key: str | None,
+    secret_access_key: str | None,
+    region_name: str | None,
+    endpoint_url: str | None,
+):
+    from src._core.infrastructure.persistence.nosql.dynamodb.dynamodb_client import (
+        DynamoDBClient,
+    )
+
+    return DynamoDBClient(
+        access_key=access_key or "",
+        secret_access_key=secret_access_key or "",
+        region_name=region_name or "ap-northeast-2",
+        endpoint_url=endpoint_url,
+    )
+
+
+def _build_s3vector_client(
+    access_key: str | None,
+    secret_access_key: str | None,
+    region_name: str | None,
+):
+    from src._core.infrastructure.vectors.s3.client import S3VectorClient
+
+    return S3VectorClient(
+        access_key=access_key or "",
+        secret_access_key=secret_access_key or "",
+        region_name=region_name or "us-east-2",
+    )
+
+
+def _build_embedding_client(
+    model_name: str | None,
+    dimension: int,
+    api_key: str | None,
+    aws_access_key_id: str | None,
+    aws_secret_access_key: str | None,
+    aws_region: str | None,
+):
+    try:
+        from src._core.domain.value_objects.embedding_config import EmbeddingConfig
+        from src._core.infrastructure.embedding.pydantic_ai_embedding_adapter import (
+            PydanticAIEmbeddingAdapter,
+        )
+    except ImportError as exc:
+        raise ImportError(
+            "pydantic-ai is required for the configured EMBEDDING_PROVIDER. "
+            "Install it with: uv sync --extra pydantic-ai"
+        ) from exc
+
+    config = EmbeddingConfig(
+        model_name=model_name or "",
+        dimension=dimension,
+        api_key=api_key,
+        aws_access_key_id=aws_access_key_id,
+        aws_secret_access_key=aws_secret_access_key,
+        aws_region=aws_region,
+    )
+    return PydanticAIEmbeddingAdapter(embedding_config=config)
+
+
+def _build_stub_embedder(dimension: int):
+    from src._core.infrastructure.rag.stub_embedder import StubEmbedder
+
+    return StubEmbedder(dimension=dimension)
+
+
+def _build_llm_model(
+    model_name: str,
+    api_key: str | None,
+    aws_access_key_id: str | None,
+    aws_secret_access_key: str | None,
+    aws_region: str | None,
+):
+    try:
+        from src._core.domain.value_objects.llm_config import LLMConfig
+        from src._core.infrastructure.llm.model_factory import build_llm_model
+    except ImportError as exc:
+        raise ImportError(
+            "pydantic-ai is required for the configured LLM_PROVIDER. "
+            "Install it with: uv sync --extra pydantic-ai"
+        ) from exc
+
+    config = LLMConfig(
+        model_name=model_name,
+        api_key=api_key,
+        aws_access_key_id=aws_access_key_id,
+        aws_secret_access_key=aws_secret_access_key,
+        aws_region=aws_region,
+    )
+    return build_llm_model(llm_config=config)
 
 
 class CoreContainer(containers.DeclarativeContainer):
     #########################################################
-    # Database
+    # Database (always required)
     #########################################################
 
     db_config = providers.Factory(
@@ -51,7 +212,7 @@ class CoreContainer(containers.DeclarativeContainer):
     )
 
     #########################################################
-    # HTTP Client
+    # HTTP Client (always available — pure-Python client)
     #########################################################
 
     http_client = providers.Singleton(
@@ -60,48 +221,64 @@ class CoreContainer(containers.DeclarativeContainer):
     )
 
     #########################################################
-    # Storage
+    # Storage (optional — STORAGE_TYPE=s3|minio)
     #########################################################
 
-    storage_client = providers.Singleton(
-        ObjectStorageClient,
-        access_key=settings.storage_access_key,
-        secret_access_key=settings.storage_secret_key,
-        region_name=settings.storage_region,
-        endpoint_url=settings.storage_endpoint_url,
+    storage_client = providers.Selector(
+        _storage_selector,
+        enabled=providers.Singleton(
+            _build_storage_client,
+            access_key=settings.storage_access_key,
+            secret_access_key=settings.storage_secret_key,
+            region_name=settings.storage_region,
+            endpoint_url=settings.storage_endpoint_url,
+        ),
+        disabled=providers.Object(None),
     )
 
-    storage = providers.Factory(
-        ObjectStorage,
-        storage_client=storage_client,
-        bucket_name=settings.storage_bucket_name,
-    )
-
-    #########################################################
-    # DynamoDB
-    #########################################################
-
-    dynamodb_client = providers.Singleton(
-        DynamoDBClient,
-        access_key=settings.dynamodb_access_key,
-        secret_access_key=settings.dynamodb_secret_key,
-        region_name=settings.dynamodb_region,
-        endpoint_url=settings.dynamodb_endpoint_url,
+    storage = providers.Selector(
+        _storage_selector,
+        enabled=providers.Factory(
+            _build_storage,
+            storage_client=storage_client,
+            bucket_name=settings.storage_bucket_name,
+        ),
+        disabled=providers.Object(None),
     )
 
     #########################################################
-    # S3 Vectors
+    # DynamoDB (optional — DYNAMODB_* env vars)
     #########################################################
 
-    s3vector_client = providers.Singleton(
-        S3VectorClient,
-        access_key=settings.s3vectors_access_key,
-        secret_access_key=settings.s3vectors_secret_key,
-        region_name=settings.s3vectors_region,
+    dynamodb_client = providers.Selector(
+        _dynamodb_selector,
+        enabled=providers.Singleton(
+            _build_dynamodb_client,
+            access_key=settings.dynamodb_access_key,
+            secret_access_key=settings.dynamodb_secret_key,
+            region_name=settings.dynamodb_region,
+            endpoint_url=settings.dynamodb_endpoint_url,
+        ),
+        disabled=providers.Object(None),
     )
 
     #########################################################
-    # Message Queue (Taskiq)
+    # S3 Vectors (optional — S3VECTORS_* env vars)
+    #########################################################
+
+    s3vector_client = providers.Selector(
+        _s3vector_selector,
+        enabled=providers.Singleton(
+            _build_s3vector_client,
+            access_key=settings.s3vectors_access_key,
+            secret_access_key=settings.s3vectors_secret_key,
+            region_name=settings.s3vectors_region,
+        ),
+        disabled=providers.Object(None),
+    )
+
+    #########################################################
+    # Message Queue (Taskiq) — Broker selector (SQS/RabbitMQ/InMemory)
     #########################################################
 
     broker = providers.Selector(
@@ -126,38 +303,42 @@ class CoreContainer(containers.DeclarativeContainer):
     )
 
     #########################################################
-    # LLM Config (Optional — for PydanticAI agents)
+    # Embedding (optional — EMBEDDING_PROVIDER + EMBEDDING_MODEL)
+    # Disabled → StubEmbedder so consumer domains degrade gracefully.
     #########################################################
 
-    llm_config = providers.Singleton(
-        LLMConfig,
-        model_name=settings.llm_model_name or "",
-        api_key=settings.llm_api_key,
-        aws_access_key_id=settings.llm_bedrock_access_key,
-        aws_secret_access_key=settings.llm_bedrock_secret_key,
-        aws_region=settings.llm_bedrock_region,
-    )
-
-    llm_model = providers.Singleton(
-        build_llm_model,
-        llm_config=llm_config,
+    embedding_client = providers.Selector(
+        _embedding_selector,
+        enabled=providers.Singleton(
+            _build_embedding_client,
+            model_name=settings.embedding_model_name,
+            dimension=settings.embedding_dimension,
+            api_key=settings.embedding_openai_api_key,
+            aws_access_key_id=settings.embedding_bedrock_access_key,
+            aws_secret_access_key=settings.embedding_bedrock_secret_key,
+            aws_region=settings.embedding_bedrock_region,
+        ),
+        disabled=providers.Singleton(
+            _build_stub_embedder,
+            dimension=settings.embedding_dimension,
+        ),
     )
 
     #########################################################
-    # Embedding Config + Client (Optional — for PydanticAI)
+    # LLM (optional — LLM_PROVIDER + LLM_MODEL)
+    # Disabled → None for PR 1; PR 2 (#101 Part B) swaps in StubLLMModel
+    # so domains like ``classification`` can degrade gracefully.
     #########################################################
 
-    embedding_config = providers.Singleton(
-        EmbeddingConfig,
-        model_name=settings.embedding_model_name or "",
-        dimension=settings.embedding_dimension,
-        api_key=settings.embedding_openai_api_key,
-        aws_access_key_id=settings.embedding_bedrock_access_key,
-        aws_secret_access_key=settings.embedding_bedrock_secret_key,
-        aws_region=settings.embedding_bedrock_region,
-    )
-
-    embedding_client = providers.Singleton(
-        PydanticAIEmbeddingAdapter,
-        embedding_config=embedding_config,
+    llm_model = providers.Selector(
+        _llm_selector,
+        enabled=providers.Singleton(
+            _build_llm_model,
+            model_name=settings.llm_model_name or "",
+            api_key=settings.llm_api_key,
+            aws_access_key_id=settings.llm_bedrock_access_key,
+            aws_secret_access_key=settings.llm_bedrock_secret_key,
+            aws_region=settings.llm_bedrock_region,
+        ),
+        disabled=providers.Object(None),
     )

--- a/tests/integration/_core/infrastructure/test_optional_infra.py
+++ b/tests/integration/_core/infrastructure/test_optional_infra.py
@@ -1,0 +1,117 @@
+"""Boot-regression tests for optional infrastructure (#101, ADR 042).
+
+Acceptance criterion: with only ``DATABASE_ENGINE=sqlite`` set and every other
+optional-infra env var unset, the app must:
+
+- import cleanly (no ImportError even if the matching optional extra is not
+  installed — this is tested via lazy-import factories inside
+  ``core_container``);
+- return the documented disabled-branch value for each infra provider
+  (``None`` for data stores, ``StubEmbedder`` for the embedder);
+- keep the broker selector defaulting to ``inmemory`` when ``BROKER_TYPE`` is
+  unset.
+
+Tests here do not hit the network or instantiate real AWS / PydanticAI
+clients; they only verify the container's wiring.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src._core.config import settings
+from src._core.infrastructure.di.core_container import CoreContainer
+from src._core.infrastructure.rag.stub_embedder import StubEmbedder
+
+
+@pytest.fixture
+def clean_optional_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force every optional-infra Settings field to its ``disabled`` value.
+
+    This isolates the test from whatever the developer has in ``_env/.env``
+    without mutating the shared Settings singleton outside this test's scope.
+    """
+    for field in (
+        "storage_type",
+        "dynamodb_access_key",
+        "s3vectors_access_key",
+        "embedding_provider",
+        "embedding_model",
+        "llm_provider",
+        "llm_model",
+    ):
+        monkeypatch.setattr(settings, field, None)
+    monkeypatch.setattr(settings, "broker_type", None)
+
+
+class TestCoreContainerMinimalBoot:
+    def test_storage_providers_return_none(self, clean_optional_env: None):
+        container = CoreContainer()
+        assert container.storage_client() is None
+        assert container.storage() is None
+
+    def test_dynamodb_client_returns_none(self, clean_optional_env: None):
+        container = CoreContainer()
+        assert container.dynamodb_client() is None
+
+    def test_s3vector_client_returns_none(self, clean_optional_env: None):
+        container = CoreContainer()
+        assert container.s3vector_client() is None
+
+    def test_embedding_client_returns_stub(self, clean_optional_env: None):
+        container = CoreContainer()
+        assert isinstance(container.embedding_client(), StubEmbedder)
+
+    def test_llm_model_returns_none_pr1(self, clean_optional_env: None):
+        """PR 1 leaves LLM disabled branch as ``None``.
+
+        PR 2 (#101 Part B) replaces this with ``StubLLMModel`` so
+        classification can degrade gracefully. Update this assertion then.
+        """
+        container = CoreContainer()
+        assert container.llm_model() is None
+
+    def test_broker_defaults_to_inmemory(self, clean_optional_env: None):
+        from taskiq import InMemoryBroker
+
+        container = CoreContainer()
+        assert isinstance(container.broker(), InMemoryBroker)
+
+
+class TestCoreContainerEnabledBranches:
+    """Smoke check: when enable flags are set, selectors flip and the
+    container resolves to the real-client branch (constructor not called in
+    these tests — pyright-level only)."""
+
+    def test_storage_selector_enabled(self, monkeypatch: pytest.MonkeyPatch):
+        from src._core.infrastructure.di.core_container import _storage_selector
+
+        monkeypatch.setattr(settings, "storage_type", "s3")
+        assert _storage_selector() == "enabled"
+
+    def test_embedding_selector_enabled(self, monkeypatch: pytest.MonkeyPatch):
+        from src._core.infrastructure.di.core_container import _embedding_selector
+
+        monkeypatch.setattr(settings, "embedding_provider", "openai")
+        monkeypatch.setattr(settings, "embedding_model", "text-embedding-3-small")
+        assert _embedding_selector() == "enabled"
+
+
+class TestAppBootsWithoutOptionalInfra:
+    """Smoke test that the FastAPI app imports and wires up without any
+    optional infra env vars set.
+
+    Does not hit HTTP; just asserts the bootstrap completes.
+    """
+
+    def test_app_imports_and_container_wires(self, clean_optional_env: None):
+        # Importing triggers ``bootstrap_app`` which exercises every domain's
+        # container wiring. If any optional provider's disabled branch blew
+        # up (e.g. eagerly importing ``pydantic_ai``), this would fail.
+        from src._apps.server.app import app
+
+        assert app is not None
+        assert app.state.container is not None
+        core = app.state.container.core_container()
+        assert core.embedding_client() is not None  # StubEmbedder
+        assert core.llm_model() is None

--- a/tests/unit/_core/infrastructure/di/test_core_container_selectors.py
+++ b/tests/unit/_core/infrastructure/di/test_core_container_selectors.py
@@ -1,0 +1,90 @@
+"""Unit tests for CoreContainer's optional-infra Selector functions (#101, ADR 042).
+
+The selector functions read ``settings`` dynamically at call time, so we can
+flip the branch each test picks by monkeypatching the relevant Settings field.
+These tests exercise the *decision logic*; the container-level branch resolution
+(real client vs ``None``/Stub) is covered by
+``tests/integration/test_optional_infra.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src._core.config import settings
+from src._core.infrastructure.di.core_container import (
+    _dynamodb_selector,
+    _embedding_selector,
+    _llm_selector,
+    _s3vector_selector,
+    _storage_selector,
+)
+
+
+class TestStorageSelector:
+    def test_disabled_when_storage_type_unset(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(settings, "storage_type", None)
+        assert _storage_selector() == "disabled"
+
+    def test_enabled_when_storage_type_s3(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(settings, "storage_type", "s3")
+        assert _storage_selector() == "enabled"
+
+    def test_enabled_when_storage_type_minio(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(settings, "storage_type", "minio")
+        assert _storage_selector() == "enabled"
+
+
+class TestDynamoDBSelector:
+    def test_disabled_when_access_key_unset(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(settings, "dynamodb_access_key", None)
+        assert _dynamodb_selector() == "disabled"
+
+    def test_enabled_when_access_key_set(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(settings, "dynamodb_access_key", "AKIA_TEST")
+        assert _dynamodb_selector() == "enabled"
+
+
+class TestS3VectorSelector:
+    def test_disabled_when_access_key_unset(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(settings, "s3vectors_access_key", None)
+        assert _s3vector_selector() == "disabled"
+
+    def test_enabled_when_access_key_set(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(settings, "s3vectors_access_key", "AKIA_TEST")
+        assert _s3vector_selector() == "enabled"
+
+
+class TestEmbeddingSelector:
+    def test_disabled_when_provider_unset(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(settings, "embedding_provider", None)
+        monkeypatch.setattr(settings, "embedding_model", None)
+        assert _embedding_selector() == "disabled"
+
+    def test_disabled_when_only_provider_set(self, monkeypatch: pytest.MonkeyPatch):
+        # Both provider AND model required per ``embedding_model_name`` computed property.
+        monkeypatch.setattr(settings, "embedding_provider", "openai")
+        monkeypatch.setattr(settings, "embedding_model", None)
+        assert _embedding_selector() == "disabled"
+
+    def test_enabled_when_provider_and_model_set(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(settings, "embedding_provider", "openai")
+        monkeypatch.setattr(settings, "embedding_model", "text-embedding-3-small")
+        assert _embedding_selector() == "enabled"
+
+
+class TestLLMSelector:
+    def test_disabled_when_provider_unset(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(settings, "llm_provider", None)
+        monkeypatch.setattr(settings, "llm_model", None)
+        assert _llm_selector() == "disabled"
+
+    def test_disabled_when_only_provider_set(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(settings, "llm_provider", "openai")
+        monkeypatch.setattr(settings, "llm_model", None)
+        assert _llm_selector() == "disabled"
+
+    def test_enabled_when_provider_and_model_set(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(settings, "llm_provider", "openai")
+        monkeypatch.setattr(settings, "llm_model", "gpt-4o-mini")
+        assert _llm_selector() == "enabled"


### PR DESCRIPTION
## Related Issue
- Part 1 of 2 for #101 (Part B follows: StubLLMModel + classification degradation + `/new-domain` skill templates)
- Unblocks #82 — after this, `fab init` can remove DynamoDB/S3 Vectors/etc. by flipping `.env` flags alone, no source rewriting

## Change Summary
- CoreContainer's 5 optional infras (storage, DynamoDB, S3 Vectors, embedding, LLM) now each use the `providers.Selector + lazy factory` pattern broker already follows (ADR 029). Top-level imports of optional-dep modules are gone.
- Per-infra disabled-branch strategy (ADR 042): `providers.Object(None)` for data-store infras where a fake client would silently drop writes; `StubEmbedder` for embedding so consumer domains (`docs`) degrade gracefully; `None` for `llm_model` in this PR (Part B replaces with `StubLLMModel`).
- Added `AGENTS.md` "Optional Infrastructure" reference section (env-var → disabled-behavior table) and ADR 042 recording the decision + rationale.
- Added boot-regression test (`tests/integration/_core/infrastructure/test_optional_infra.py`) and per-selector unit tests (`tests/unit/_core/infrastructure/di/test_core_container_selectors.py`).

## Type of Change
- [x] refactor: Code restructuring
- [x] docs: Documentation
- [x] test: Tests

## Checklist
- [x] Architecture rules followed (no Domain → Infrastructure imports; Domain layer untouched)
- [x] Tests pass — 255 passed / 3 skipped (was 233 / 3 → +22 from this PR)
- [x] Linting passes (`ruff check` clean across all modified files)

## Architecture Highlights
- **Pattern is inherited, not invented** — `broker`'s Selector + `broker.py`'s lazy-import factories (ADR 029) were the template. `build_llm_model()` and `create_sqs_broker()` already lazy-import pydantic-ai/taskiq-aws internally; this PR lifts that lazy-ness to the container layer where it actually matters for `uv sync --no-install-package …` scenarios.
- **`llm_config` / `embedding_config` dropped** from the public container surface — nothing outside `core_container.py` referenced them. The build functions construct the VO locally and return the final client.
- **`docs` domain's Selector stays in place** — after this PR, `core_container.embedding_client` already falls back to `StubEmbedder` when disabled, so the domain-level Selector in `docs_container.py:59-63` becomes a belt-and-suspenders redundancy. Keeping it for now because it makes the docs domain self-contained and readable as a reference pattern; removal can happen in a later cleanup PR.
- **Type narrowing** — factories accept `str | None` for optional settings fields and coerce `or ""` at the ObjectStorageClient / DynamoDBClient / S3VectorClient call site. Pyright is happy; the `or ""` branch never fires in practice because the selector gates construction.

## How to Test
- `pytest tests/ -v` — 255 passed / 3 skipped locally. New suites live under `tests/unit/_core/infrastructure/di/` and `tests/integration/_core/infrastructure/`.
- `make quickstart` in one terminal, `make demo-rag` in another — verifies the stub pipeline (`EMBEDDING_*` / `LLM_*` unset) still works end-to-end and citations come back with distances.
- Manual optional-extra uninstall check:
  ```bash
  uv sync --no-install-package pydantic-ai-slim --no-install-package taskiq-aws
  python run_server_local.py --env quickstart
  # expect: server boots, /api/health → 200, /docs-swagger → 200
  ```

## What's Out of Scope (Filed Separately After This Lands)
- **Part B (#101 PR 2):** `StubLLMModel` + `classification_container` degradation + `/new-domain` skill template update so scaffolded domains ship the `Selector(real/stub)` pattern.
- **Separate follow-up issue:** move `nicegui` → `[project.optional-dependencies].admin`, `aioboto3` / `boto3` → `[project.optional-dependencies].aws`. These are user-facing UX changes (admin dashboard mount decision, non-AWS install matrix) and deserve their own design pass.
- **`#82` re-evaluation:** `fab init` CLI may shrink to thin `.env` scaffolder or close entirely once the `.env` toggle UX has been exercised in practice. Decision deferred to post-merge.

## Notes for Reviewers
- Three sequential commits tell the story: (1) the CoreContainer rewrite, (2) ADR 042 + AGENTS.md, (3) tests. Each builds on the previous but stays reviewable on its own.
- Pattern consistency hint — when reading `_build_*()` factories, cross-reference `src/_core/infrastructure/taskiq/broker.py:12-84` (the `create_sqs_broker` / `create_rabbitmq_broker` shape). The intent was structural mirroring so that future infra additions have a clear template.