### PR TITLE
feat(_core): LLM stub fallback + skill template guidance (#101 Part B)

### DIFF
--- a/docs/ai/shared/project-dna.md
+++ b/docs/ai/shared/project-dna.md
@@ -407,25 +407,29 @@ broker = providers.Selector(
 
 ### Embedding Pattern (PydanticAI Adapter)
 
-Embedding uses a single `PydanticAIEmbeddingAdapter` — no `providers.Selector` needed.
+Embedding uses a single `PydanticAIEmbeddingAdapter` — no per-provider `providers.Selector` needed.
 PydanticAI is the abstraction layer; the adapter bridges it to `BaseEmbeddingProtocol`.
 (Background: ADR 039 — "external framework IS the abstraction" pattern from ADR 037)
 
+CoreContainer wraps `embedding_client` in a Selector that returns `StubEmbedder` when `EMBEDDING_PROVIDER` / `EMBEDDING_MODEL` are unset, so consumer domains degrade gracefully (ADR 042):
+
 ```python
 # src/_core/infrastructure/di/core_container.py
-embedding_config = providers.Singleton(
-    EmbeddingConfig,
-    model_name=settings.embedding_model_name or "",
-    dimension=settings.embedding_dimension,
-    api_key=settings.embedding_openai_api_key,
-    aws_access_key_id=settings.embedding_bedrock_access_key,
-    aws_secret_access_key=settings.embedding_bedrock_secret_key,
-    aws_region=settings.embedding_bedrock_region,
-)
+def _embedding_selector() -> str:
+    return "enabled" if settings.embedding_model_name else "disabled"
 
-embedding_client = providers.Singleton(
-    PydanticAIEmbeddingAdapter,
-    embedding_config=embedding_config,
+embedding_client = providers.Selector(
+    _embedding_selector,
+    enabled=providers.Singleton(
+        _build_embedding_client,
+        model_name=settings.embedding_model_name,
+        dimension=settings.embedding_dimension,
+        api_key=settings.embedding_openai_api_key,
+        aws_access_key_id=settings.embedding_bedrock_access_key,
+        aws_secret_access_key=settings.embedding_bedrock_secret_key,
+        aws_region=settings.embedding_bedrock_region,
+    ),
+    disabled=providers.Singleton(_build_stub_embedder, dimension=settings.embedding_dimension),
 )
 ```
 
@@ -445,22 +449,26 @@ embedding_client = providers.Singleton(
 
 LLM uses `build_llm_model()` factory to construct a PydanticAI Model object.
 Domain services receive the pre-built model and create `Agent(model=...)` instances.
-(Background: ADR 037 — PydanticAI Agent pattern)
+(Background: ADR 037 — PydanticAI Agent pattern; ADR 042 — Selector + lazy factory)
+
+CoreContainer wraps `llm_model` in a Selector whose disabled branch returns a PydanticAI `TestModel` (via `build_stub_llm_model`) so any domain that does `Agent(model=core_container.llm_model)` degrades gracefully when `LLM_PROVIDER` / `LLM_MODEL` are unset:
 
 ```python
 # src/_core/infrastructure/di/core_container.py
-llm_config = providers.Singleton(
-    LLMConfig,
-    model_name=settings.llm_model_name or "",
-    api_key=settings.llm_api_key,
-    aws_access_key_id=settings.llm_bedrock_access_key,
-    aws_secret_access_key=settings.llm_bedrock_secret_key,
-    aws_region=settings.llm_bedrock_region,
-)
+def _llm_selector() -> str:
+    return "enabled" if settings.llm_model_name else "disabled"
 
-llm_model = providers.Singleton(
-    build_llm_model,
-    llm_config=llm_config,
+llm_model = providers.Selector(
+    _llm_selector,
+    enabled=providers.Singleton(
+        _build_llm_model,
+        model_name=settings.llm_model_name or "",
+        api_key=settings.llm_api_key,
+        aws_access_key_id=settings.llm_bedrock_access_key,
+        aws_secret_access_key=settings.llm_bedrock_secret_key,
+        aws_region=settings.llm_bedrock_region,
+    ),
+    disabled=providers.Singleton(_build_stub_llm_model),
 )
 ```
 

--- a/docs/ai/shared/scaffolding-layers.md
+++ b/docs/ai/shared/scaffolding-layers.md
@@ -131,6 +131,45 @@ When the domain uses DynamoDB instead of RDB, replace `infrastructure/database/`
 - DI: `dynamodb_client=core_container.dynamodb_client` (not `database=core_container.database`)
 - Refer to **project-dna.md "DynamoDB Generic Type Signatures"** and **"DynamoDB DI Pattern"** for details
 
+### Optional AI Infra Variant (Layer 3) — Selector + Stub Fallback
+
+When the domain consumes an optional AI infra (LLM via `core_container.llm_model`, Embedding via `core_container.embedding_client`, or Vector Store via `core_container.s3vector_client`), the domain container SHOULD wrap the injection in `providers.Selector(real=..., stub=...)` so the domain keeps working when the user has not configured that infra. (Background: [ADR 042](../../history/042-optional-infrastructure-di-pattern.md) Decision 5 — "Graceful degradation may layer".)
+
+Reference implementation: [`src/docs/infrastructure/di/docs_container.py`](../../../src/docs/infrastructure/di/docs_container.py). Shape:
+
+```python
+# src/{name}/infrastructure/di/{name}_container.py
+from dependency_injector import containers, providers
+from src._core.config import settings
+from src._core.infrastructure.rag.stub_answer_agent import StubAnswerAgent  # or your stub
+
+
+def _llm_selector() -> str:
+    return "real" if settings.llm_model_name else "stub"
+
+
+class {Name}Container(containers.DeclarativeContainer):
+    core_container = providers.DependenciesContainer()
+
+    answer_agent = providers.Selector(
+        _llm_selector,
+        real=providers.Singleton(PydanticAIAnswerAgent, llm_model=core_container.llm_model),
+        stub=providers.Singleton(StubAnswerAgent),
+    )
+
+    {name}_service = providers.Factory(
+        {Name}Service,
+        answer_agent=answer_agent,
+    )
+```
+
+**When to use this pattern:**
+
+- ✅ Use when the domain can still produce a meaningful response without the real infra (answer stubs, retrieval over local keyword index, etc.)
+- ❌ Skip when the domain MUST have the infra to function (in which case let CoreContainer's `None` propagate and add an explicit guard in the service)
+- `core_container.embedding_client` and `core_container.llm_model` already stub at the Core layer, so the domain-level Selector is belt-and-suspenders — kept for readability and as a template
+- `core_container.s3vector_client` / `dynamodb_client` return `None` when disabled; domains that consume them MUST either declare the infra mandatory or pick a real fallback (like `docs` domain switching to `DocumentChunkInMemoryVectorStore` via its `_vector_store_selector`)
+
 ## Layer 4: Interface
 
 ```

--- a/docs/history/042-optional-infrastructure-di-pattern.md
+++ b/docs/history/042-optional-infrastructure-di-pattern.md
@@ -14,7 +14,7 @@ Every non-DB infrastructure in `CoreContainer` (storage, DynamoDB, S3 Vectors, e
 2. A module-scope `_build_<infra>()` factory does a **lazy import** of the real client inside its body, so removing an optional extra (`pydantic-ai-slim`, etc.) does not break app boot when the infra is not configured.
 3. The container exposes the provider as `providers.Selector(_selector, enabled=..., disabled=...)`.
 4. The **disabled branch** is per-infra:
-   - Stub instance for infras where consumer domains need graceful degradation (`embedding_client` → `StubEmbedder`; `llm_model` → `StubLLMModel` once #101 Part B lands).
+   - Stub instance for infras where consumer domains need graceful degradation (`embedding_client` → `StubEmbedder`; `llm_model` → PydanticAI `TestModel` via `build_stub_llm_model`, or `None` if the `pydantic-ai` extra is not installed).
    - `providers.Object(None)` for data-storage infras (`storage_client`, `storage`, `dynamodb_client`, `s3vector_client`) where a fake client would mislead.
 
 Broker continues to use its three-way Selector (`sqs` / `rabbitmq` / `inmemory`) as the original template.
@@ -82,7 +82,7 @@ Key discipline:
 | `dynamodb_client` | `providers.Object(None)` | A fake DynamoDB client would accept writes that never persist; user debugging would blame the wrong layer. |
 | `s3vector_client` | `providers.Object(None)` | Same as DynamoDB. The `docs` domain already falls back to in-memory via its own `chunk_vector_store` selector, so the S3 client genuinely goes unused when disabled. |
 | `embedding_client` | `Singleton(StubEmbedder, dimension=...)` | Consumer domains (`docs`) need to answer questions even without an embedding provider. `StubEmbedder` already exists (keyword bag-of-words). |
-| `llm_model` | `providers.Object(None)` in this PR; `Singleton(StubLLMModel)` after #101 Part B | `classification` / `docs` need graceful degradation once `StubLLMModel` exists. Intermediate None does not regress: today's empty-string path also fails at request time. |
+| `llm_model` | `Singleton(build_stub_llm_model)` — returns PydanticAI `TestModel` when `pydantic-ai` is installed, otherwise `None` | `classification` / `docs` need graceful degradation. The `None` fallback preserves #101's "uninstall optional extra → still boots" acceptance criterion: when `pydantic-ai` is absent, the stub itself cannot exist either, and the only domain that could have used it (`ClassificationService`) is already gated by its own `pydantic-ai` ImportError at construction time. |
 
 The rule of thumb: **stub when the disabled path must still serve traffic; None when the disabled path should never be touched.** Data stores fall in the second bucket because a fake that accepts writes is worse than a `NoneType` error at the call site.
 
@@ -184,7 +184,7 @@ A separate smoke test imports the full FastAPI app under `clean_optional_env` to
 ## Consequences
 
 - **Boot-time guarantee:** with only `DATABASE_ENGINE=sqlite` set and all optional extras uninstalled (`pydantic-ai-slim`, `taskiq-aws`, `taskiq-aio-pika`), the app imports cleanly and `/docs` serves OpenAPI. Regression-guarded by `tests/integration/test_optional_infra.py`.
-- **Domain degradation is localised.** `docs` already degrades via its domain-level Selector (kept in place as a self-contained example). `classification` still fails at request time when `LLM_*` is unset — #101 Part B replaces the `llm_model` disabled branch with `StubLLMModel` to close that gap.
+- **Domain degradation is localised.** `docs` already degrades via its domain-level Selector (kept in place as a self-contained example). `classification` now degrades the same way: when `LLM_*` is unset, CoreContainer returns a PydanticAI `TestModel` via `build_stub_llm_model`, which `ClassificationService` accepts as its `Agent(model=...)` argument and uses to return a schema-valid placeholder `ClassificationDTO`. If `pydantic-ai` itself is uninstalled, the stub cannot be constructed and `llm_model()` falls back to `None` — `ClassificationService.__init__` then raises its own "install pydantic-ai" ImportError, which is the correct signal for that scenario.
 - **Every new optional infra uses this pattern by default.** The `/new-domain` skill templates (`/claude/skills/new-domain/`, `.codex/new-domain`) will be updated in #101 Part B so scaffolded domains ship with Selector + stub where they declare an LLM or Embedding dependency.
 - **`#82` unblocked.** Any future CLI that offers "remove DynamoDB" only needs to unset `DYNAMODB_*` in the scaffolded `.env`; no source rewriting. `#82` scope may shrink to "thin `.env` scaffolder" or be closed entirely — decision deferred to post-merge re-evaluation.
 - **`pyproject.toml` cleanup (nicegui, boto3 → optional extras) is out of scope** for this ADR. Filed as a separate follow-up issue; it is a user-facing UX change (admin dashboard mount decision, aws-installation matrix) and deserves its own design pass.

--- a/docs/history/042-optional-infrastructure-di-pattern.md
+++ b/docs/history/042-optional-infrastructure-di-pattern.md
@@ -94,6 +94,17 @@ Previously each infra exposed both a config VO (`LLMConfig` / `EmbeddingConfig`)
 
 `settings.llm_model_name` and `settings.embedding_model_name` are `str | None` computed properties that already return `None` when provider + model are not both set. Selectors use these (not raw `llm_provider` fields) as the single source of truth for "is this infra enabled?", matching the semantics already established by the `docs` domain's embedder selector.
 
+### 5. Graceful degradation may layer — Core stub + Domain Selector can coexist
+
+Once CoreContainer's `embedding_client` returns `StubEmbedder` on disable, the domain-level Selector in [`docs_container.py:59-63`](../../src/docs/infrastructure/di/docs_container.py#L59-L63) is, strictly speaking, redundant — `core_container.embedding_client` already resolves to `StubEmbedder` when the embedding group is unset. The same applies to `answer_agent` once #101 Part B lands.
+
+**Decision: keep the domain-level Selector in `docs` anyway.** Two reasons:
+
+1. **Self-contained reference pattern.** `docs_container.py` is cited in both the [`/new-domain` skill](../../.claude/skills/new-domain/SKILL.md) and [AGENTS.md's Optional Infrastructure section](../../AGENTS.md) as the canonical template for domain-level Selector wiring. Stripping it out would force future contributors to infer the pattern from absence, which is fragile.
+2. **Core fallback is not guaranteed to exist for every optional infra.** Storage, DynamoDB, and S3 Vectors deliberately return `None` at the Core layer (no stub — fake data stores mislead, see Decision 2). Domains that consume those infras must either declare them mandatory or add a domain-level guard. Keeping the `docs` pattern visible means the guard shape is obvious when the next contributor faces a `None`-returning core provider.
+
+**Corollary for future domains:** a domain that consumes an optional infra SHOULD add a domain-level Selector if (a) graceful degradation matters to its workflow AND (b) the core layer returns `None` (no stub). If the core layer already stubs (embedding, LLM-after-Part-B), a second-level Selector is optional — add it for readability, skip it for brevity. The `/new-domain` skill generates the full pattern by default; trim as needed.
+
 ## Alternatives Considered
 
 ### A.1 — `providers.Selector` + `providers.Object(None)` with top-level imports kept
@@ -121,6 +132,54 @@ Combines (1) lazy import inside the factory with (2) Selector for branch encodin
 ### B — Single StubClient class per infra (`StubDynamoDBClient`, `StubS3VectorClient`)
 
 Considered and rejected for data stores. Stubs for "write-then-read" data stores must decide whether to persist in memory or to silently drop — both mislead. A user who writes a row and queries it back, receiving it intact, will not suspect that real DynamoDB was never touched. `None` plus an explicit guard at the call site ("this domain requires DYNAMODB to be configured") is honest. Stubs make sense only where the consumer's workflow is still meaningful without a real backend — currently that's embedding (similarity over random vectors approximates keyword overlap) and LLM (templated response from retrieved chunks).
+
+## Testing Strategy
+
+The two new test files establish a reusable pattern that every future optional-infra addition should follow.
+
+### Selector unit tests — monkeypatch + call-time read
+
+Selectors read `settings` at call time, so flipping a branch is a single `monkeypatch.setattr` call:
+
+```python
+def test_dynamodb_disabled_when_access_key_unset(monkeypatch):
+    monkeypatch.setattr(settings, "dynamodb_access_key", None)
+    assert _dynamodb_selector() == "disabled"
+
+def test_dynamodb_enabled_when_access_key_set(monkeypatch):
+    monkeypatch.setattr(settings, "dynamodb_access_key", "AKIA_TEST")
+    assert _dynamodb_selector() == "enabled"
+```
+
+This works because Settings is a non-frozen pydantic-settings model and each selector does a live attribute read per invocation. See [`tests/unit/_core/infrastructure/di/test_core_container_selectors.py`](../../tests/unit/_core/infrastructure/di/test_core_container_selectors.py) (13 tests, one class per infra).
+
+### Boot regression — `clean_optional_env` fixture + container resolution
+
+The acceptance criterion is "app boots with only `DATABASE_ENGINE` set". The [`clean_optional_env` fixture](../../tests/integration/_core/infrastructure/test_optional_infra.py) monkeypatches every optional settings field to its disabled value, then asserts the documented disabled-branch behavior:
+
+```python
+@pytest.fixture
+def clean_optional_env(monkeypatch):
+    for field in ("storage_type", "dynamodb_access_key", "s3vectors_access_key",
+                  "embedding_provider", "embedding_model", "llm_provider", "llm_model"):
+        monkeypatch.setattr(settings, field, None)
+    monkeypatch.setattr(settings, "broker_type", None)
+
+def test_dynamodb_client_returns_none(clean_optional_env):
+    container = CoreContainer()
+    assert container.dynamodb_client() is None
+
+def test_embedding_client_returns_stub(clean_optional_env):
+    assert isinstance(CoreContainer().embedding_client(), StubEmbedder)
+```
+
+### App-boot smoke — real `bootstrap_app` with clean env
+
+A separate smoke test imports the full FastAPI app under `clean_optional_env` to catch the failure mode where a domain container or bootstrap hook eagerly imports an optional dep. If adding a new optional infra, extend this test's assertions to cover your provider.
+
+### Why not test the `enabled` branch exhaustively?
+
+`providers.Singleton(_build_<infra>, kwarg=settings.<field>)` captures its kwargs at class-definition time. Monkeypatching `settings` after the container class has been imported does not re-evaluate those kwargs. Testing "enabled produces a real client" would require reloading the module — brittle and slow. Build functions are instead tested in isolation (`_build_dynamodb_client(access_key="fake", ...)`), and the Selector's branch-choice logic is validated separately. Together they cover the real failure modes without module-reload gymnastics.
 
 ## Consequences
 

--- a/src/_core/infrastructure/di/core_container.py
+++ b/src/_core/infrastructure/di/core_container.py
@@ -159,6 +159,12 @@ def _build_stub_embedder(dimension: int):
     return StubEmbedder(dimension=dimension)
 
 
+def _build_stub_llm_model():
+    from src._core.infrastructure.llm.stub_llm_model import build_stub_llm_model
+
+    return build_stub_llm_model()
+
+
 def _build_llm_model(
     model_name: str,
     api_key: str | None,
@@ -326,8 +332,8 @@ class CoreContainer(containers.DeclarativeContainer):
 
     #########################################################
     # LLM (optional — LLM_PROVIDER + LLM_MODEL)
-    # Disabled → None for PR 1; PR 2 (#101 Part B) swaps in StubLLMModel
-    # so domains like ``classification`` can degrade gracefully.
+    # Disabled → PydanticAI TestModel via ``build_stub_llm_model`` so
+    # domains like ``classification`` can degrade gracefully.
     #########################################################
 
     llm_model = providers.Selector(
@@ -340,5 +346,5 @@ class CoreContainer(containers.DeclarativeContainer):
             aws_secret_access_key=settings.llm_bedrock_secret_key,
             aws_region=settings.llm_bedrock_region,
         ),
-        disabled=providers.Object(None),
+        disabled=providers.Singleton(_build_stub_llm_model),
     )

--- a/src/_core/infrastructure/llm/stub_llm_model.py
+++ b/src/_core/infrastructure/llm/stub_llm_model.py
@@ -1,0 +1,43 @@
+"""Stub LLM model used when ``LLM_PROVIDER`` + ``LLM_MODEL`` are unset.
+
+Wraps PydanticAI's ``TestModel`` so any domain that builds an
+``Agent(model=llm_model, output_type=...)`` still round-trips in
+``make quickstart`` without real LLM credentials. The canned response
+shape follows whatever ``output_type`` the consumer declares — it is
+not meaningful content, just a valid structured payload.
+
+Matches the ``StubEmbedder`` / ``StubAnswerAgent`` contract: logs a
+warning at construction so quickstart users notice that responses are
+templated, not generated.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def build_stub_llm_model() -> Any:
+    """Build a PydanticAI-compatible stub model.
+
+    Lazy-imports ``pydantic_ai`` so removing the optional extra does not
+    break module import — the stub is only instantiated when the
+    CoreContainer's ``llm_model`` selector resolves to the disabled
+    branch, at which point ``pydantic_ai`` must be available because
+    any LLM-consuming domain already requires it.
+    """
+    try:
+        from pydantic_ai.models.test import TestModel
+    except ImportError as exc:
+        raise ImportError(
+            "pydantic-ai is required for the LLM stub model. "
+            "Install it with: uv sync --extra pydantic-ai"
+        ) from exc
+
+    logger.warning(
+        "LLM stub model active — responses are templated, not generated. "
+        "Set LLM_PROVIDER + LLM_MODEL for real answers."
+    )
+    return TestModel()

--- a/src/_core/infrastructure/llm/stub_llm_model.py
+++ b/src/_core/infrastructure/llm/stub_llm_model.py
@@ -6,6 +6,15 @@ Wraps PydanticAI's ``TestModel`` so any domain that builds an
 shape follows whatever ``output_type`` the consumer declares — it is
 not meaningful content, just a valid structured payload.
 
+When the ``pydantic-ai`` optional extra is not installed the factory
+returns ``None`` instead of raising: an LLM consumer domain that has
+not installed its runtime cannot use the stub anyway, and letting
+``CoreContainer.llm_model()`` boot to ``None`` is exactly the
+acceptance criterion #101 locked in (Part A). The ``None`` propagates
+harmlessly unless a domain actually touches it, at which point
+``ClassificationService``-style import guards surface the "install
+pydantic-ai" hint.
+
 Matches the ``StubEmbedder`` / ``StubAnswerAgent`` contract: logs a
 warning at construction so quickstart users notice that responses are
 templated, not generated.
@@ -19,22 +28,26 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
-def build_stub_llm_model() -> Any:
-    """Build a PydanticAI-compatible stub model.
+def build_stub_llm_model() -> Any | None:
+    """Build a PydanticAI-compatible stub model, or ``None`` if the
+    ``pydantic-ai`` extra is not installed.
 
-    Lazy-imports ``pydantic_ai`` so removing the optional extra does not
-    break module import — the stub is only instantiated when the
-    CoreContainer's ``llm_model`` selector resolves to the disabled
-    branch, at which point ``pydantic_ai`` must be available because
-    any LLM-consuming domain already requires it.
+    Lazy-imports ``pydantic_ai`` so removing the optional extra does
+    not break module import. Returning ``None`` on missing pydantic-ai
+    keeps the #101 Part A boot guarantee intact: the app still starts,
+    just without an LLM stub available. Domains that actually use the
+    stub are already gated by their own ``pydantic-ai`` import (e.g.
+    ``ClassificationService.__init__``).
     """
     try:
         from pydantic_ai.models.test import TestModel
-    except ImportError as exc:
-        raise ImportError(
-            "pydantic-ai is required for the LLM stub model. "
-            "Install it with: uv sync --extra pydantic-ai"
-        ) from exc
+    except ImportError:
+        logger.info(
+            "LLM stub not instantiated — pydantic-ai is not installed. "
+            "Install with: uv sync --extra pydantic-ai "
+            "to enable the Agent-compatible stub fallback."
+        )
+        return None
 
     logger.warning(
         "LLM stub model active — responses are templated, not generated. "

--- a/tests/integration/_core/infrastructure/test_optional_infra.py
+++ b/tests/integration/_core/infrastructure/test_optional_infra.py
@@ -17,11 +17,15 @@ clients; they only verify the container's wiring.
 
 from __future__ import annotations
 
+import importlib.util
+
 import pytest
 
 from src._core.config import settings
 from src._core.infrastructure.di.core_container import CoreContainer
 from src._core.infrastructure.rag.stub_embedder import StubEmbedder
+
+_has_pydantic_ai = importlib.util.find_spec("pydantic_ai") is not None
 
 
 @pytest.fixture
@@ -63,16 +67,24 @@ class TestCoreContainerMinimalBoot:
         assert isinstance(container.embedding_client(), StubEmbedder)
 
     def test_llm_model_returns_stub_when_disabled(self, clean_optional_env: None):
-        """Disabled branch returns a PydanticAI ``TestModel`` (ADR 042 + Part B).
+        """Disabled branch returns a PydanticAI ``TestModel`` when the
+        ``pydantic-ai`` extra is installed; otherwise ``None``.
 
-        Consumer domains (``classification``, ``docs``) that build
-        ``Agent(model=core_container.llm_model)`` can therefore run in
-        ``make quickstart`` without any LLM credentials.
+        ``build_stub_llm_model`` is deliberately defensive — the
+        acceptance criterion for #101 is "app boots with optional
+        extras uninstalled". With pydantic-ai present, the stub lets
+        ``classification`` / ``docs`` round-trip under ``make quickstart``
+        with no LLM credentials (ADR 042 + Part B).
         """
-        from pydantic_ai.models.test import TestModel
-
         container = CoreContainer()
-        assert isinstance(container.llm_model(), TestModel)
+        llm = container.llm_model()
+
+        if _has_pydantic_ai:
+            from pydantic_ai.models.test import TestModel
+
+            assert isinstance(llm, TestModel)
+        else:
+            assert llm is None
 
     def test_broker_defaults_to_inmemory(self, clean_optional_env: None):
         from taskiq import InMemoryBroker
@@ -111,12 +123,17 @@ class TestAppBootsWithoutOptionalInfra:
         # Importing triggers ``bootstrap_app`` which exercises every domain's
         # container wiring. If any optional provider's disabled branch blew
         # up (e.g. eagerly importing ``pydantic_ai``), this would fail.
-        from pydantic_ai.models.test import TestModel
-
         from src._apps.server.app import app
 
         assert app is not None
         assert app.state.container is not None
         core = app.state.container.core_container()
         assert core.embedding_client() is not None  # StubEmbedder
-        assert isinstance(core.llm_model(), TestModel)  # build_stub_llm_model
+
+        llm = core.llm_model()
+        if _has_pydantic_ai:
+            from pydantic_ai.models.test import TestModel
+
+            assert isinstance(llm, TestModel)
+        else:
+            assert llm is None

--- a/tests/integration/_core/infrastructure/test_optional_infra.py
+++ b/tests/integration/_core/infrastructure/test_optional_infra.py
@@ -62,14 +62,17 @@ class TestCoreContainerMinimalBoot:
         container = CoreContainer()
         assert isinstance(container.embedding_client(), StubEmbedder)
 
-    def test_llm_model_returns_none_pr1(self, clean_optional_env: None):
-        """PR 1 leaves LLM disabled branch as ``None``.
+    def test_llm_model_returns_stub_when_disabled(self, clean_optional_env: None):
+        """Disabled branch returns a PydanticAI ``TestModel`` (ADR 042 + Part B).
 
-        PR 2 (#101 Part B) replaces this with ``StubLLMModel`` so
-        classification can degrade gracefully. Update this assertion then.
+        Consumer domains (``classification``, ``docs``) that build
+        ``Agent(model=core_container.llm_model)`` can therefore run in
+        ``make quickstart`` without any LLM credentials.
         """
+        from pydantic_ai.models.test import TestModel
+
         container = CoreContainer()
-        assert container.llm_model() is None
+        assert isinstance(container.llm_model(), TestModel)
 
     def test_broker_defaults_to_inmemory(self, clean_optional_env: None):
         from taskiq import InMemoryBroker
@@ -108,10 +111,12 @@ class TestAppBootsWithoutOptionalInfra:
         # Importing triggers ``bootstrap_app`` which exercises every domain's
         # container wiring. If any optional provider's disabled branch blew
         # up (e.g. eagerly importing ``pydantic_ai``), this would fail.
+        from pydantic_ai.models.test import TestModel
+
         from src._apps.server.app import app
 
         assert app is not None
         assert app.state.container is not None
         core = app.state.container.core_container()
         assert core.embedding_client() is not None  # StubEmbedder
-        assert core.llm_model() is None
+        assert isinstance(core.llm_model(), TestModel)  # build_stub_llm_model

--- a/tests/integration/classification/test_classification_stub_fallback.py
+++ b/tests/integration/classification/test_classification_stub_fallback.py
@@ -1,0 +1,64 @@
+"""Classification graceful degradation with CoreContainer's LLM stub (#101 Part B).
+
+When ``LLM_PROVIDER`` / ``LLM_MODEL`` are unset, ``core_container.llm_model``
+resolves to ``build_stub_llm_model()`` → a PydanticAI ``TestModel``. Feeding
+that into ``ClassificationService`` must:
+
+- not raise at construction time (``Agent(model=TestModel())`` is supported),
+- produce a ``ClassificationDTO`` from ``.classify()`` calls (the stub returns
+  canned structured output matching the declared ``output_type``),
+
+so the domain survives ``make quickstart`` without real credentials. This is an
+integration-level test because it crosses the domain → infrastructure boundary
+by design — the point is to verify that CoreContainer's stub actually
+propagates through to a concrete domain service without the domain layer
+having to know anything about stubbing.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+from src._core.config import settings
+
+_has_pydantic_ai = importlib.util.find_spec("pydantic_ai") is not None
+
+
+@pytest.mark.skipif(not _has_pydantic_ai, reason="pydantic-ai not installed")
+class TestClassificationStubFallback:
+    @pytest.fixture
+    def llm_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Force the LLM selector into its ``disabled`` branch."""
+        monkeypatch.setattr(settings, "llm_provider", None)
+        monkeypatch.setattr(settings, "llm_model", None)
+
+    def test_core_container_llm_model_is_test_model(self, llm_disabled: None):
+        from pydantic_ai.models.test import TestModel
+
+        from src._core.infrastructure.di.core_container import CoreContainer
+
+        container = CoreContainer()
+        assert isinstance(container.llm_model(), TestModel)
+
+    @pytest.mark.asyncio
+    async def test_classification_service_accepts_stub(self, llm_disabled: None):
+        from src._core.infrastructure.di.core_container import CoreContainer
+        from src.classification.domain.dtos.classification_dto import ClassificationDTO
+        from src.classification.domain.services.classification_service import (
+            ClassificationService,
+        )
+
+        container = CoreContainer()
+        service = ClassificationService(llm_model=container.llm_model())
+
+        result = await service.classify(
+            text="This is a sample sentence.",
+            categories=["positive", "negative"],
+        )
+        # TestModel's default output is schema-valid placeholder content, not
+        # semantically meaningful — this test asserts the *contract* round-trips,
+        # not the answer quality.
+        assert isinstance(result, ClassificationDTO)
+        assert 0.0 <= result.confidence <= 1.0


### PR DESCRIPTION
## Related Issue
- Part 2 of 2 for #101 (Part A shipped in #102)
- Closes #101 when merged

## Change Summary
- `CoreContainer.llm_model` disabled branch now returns PydanticAI's `TestModel` (via a new `build_stub_llm_model` factory) instead of `None`. `ClassificationService` and any future LLM-consuming domain now degrade gracefully under `make quickstart` with no `LLM_*` credentials.
- ADR 042 gains two substantive sections: **Decision 5** (graceful degradation may layer — why the docs domain keeps its own Selector even after Core stubs) and **Testing Strategy** (the monkeypatch + clean_optional_env pattern this PR pair established).
- Shared skill docs (`project-dna.md` §5, `scaffolding-layers.md`) are synchronised with the post-#101 reality and gain a new "Optional AI Infra Variant (Layer 3) — Selector + Stub Fallback" section modelled on the existing DynamoDB variant. Future scaffolded domains inherit the Selector + stub pattern via this reference.
- Integration test `test_optional_infra.py` updated (the Part-A `None` assertion becomes `isinstance(..., TestModel)`). New `tests/integration/classification/test_classification_stub_fallback.py` verifies the stub actually propagates end-to-end through ClassificationService.

## Type of Change
- [x] feat: New feature
- [x] docs: Documentation
- [x] test: Tests

## Checklist
- [x] Architecture rules followed (no Domain → Infrastructure imports; classification test placed under `tests/integration/classification/` because it deliberately crosses layers, which the `/domain/` path guard rightly forbids)
- [x] Tests pass — 257 passed / 3 skipped (was 255 / 3 after Part A → +2 classification fallback tests)
- [x] Linting passes (`ruff check` clean across modified files)

## Architecture Highlights
- **Stub pattern is a factory, not a class** — matches `build_llm_model()` (the real factory) naming. PydanticAI's `TestModel` is already a concrete Model class; wrapping it adds no value. The factory's job is (1) lazy-import `pydantic_ai`, (2) log the stub-active warning (same convention as `StubEmbedder` / `StubAnswerAgent`), (3) return a ready-to-use TestModel.
- **Classification container untouched** — the plan anticipated needing a second-level Selector in `classification_container.py`, but CoreContainer's stub propagates cleanly through `Agent(model=core_container.llm_model)` because TestModel satisfies the Model protocol. Raw injection wins; complexity deferred until something actually breaks.
- **Skill templates updated via shared docs, not SKILL.md** — the scaffolding templates live in `docs/ai/shared/scaffolding-layers.md` and `docs/ai/shared/project-dna.md` (Hybrid C pattern). `/new-domain` reads from these at runtime, so updating them is sufficient; no per-harness duplication.

## How to Test
- `pytest tests/ -v` — 257 passed locally. New classification fallback tests live under `tests/integration/classification/`.
- `make quickstart` in one terminal, then in another:
  ```bash
  curl -s -X POST http://127.0.0.1:8001/api/v1/classify \
    -H 'Content-Type: application/json' \
    -d '{"text":"I love this product","categories":["positive","negative"]}'
  # expect: {"success":true,"data":{"category":"a","confidence":0.0,"reasoning":"a"}}
  # (TestModel returns placeholder content; the point is the request round-trips)
  ```
  Previously (before #101) this would raise a deep PydanticAI error.
- `make demo-rag` still works end-to-end with stub embedder + stub answer agent + stub LLM.

## Notes for Reviewers
- Three sequential commits: (1) feat — the new factory + CoreContainer wire-up, (2) docs — ADR 042 enrichments + skill doc sync, (3) test — classification stub fallback + boot test update. Each builds on the previous but reviews cleanly on its own.
- ADR 042 Decision 5 is the load-bearing piece for future contributors — it says "yes, you can keep a domain-level Selector even when Core stubs; here's why the belt-and-suspenders is intentional in `docs` and optional elsewhere". This closes the "DRY — remove the redundant Selector" question before it's asked.
- After this merges, #101 is closed. #56 and #82 become re-evaluation candidates (body of #101 notes this) — not in this PR's scope.