### PR TITLE
docs: sync guidelines after #101 merge

### DIFF
--- a/.claude/rules/architecture-conventions.md
+++ b/.claude/rules/architecture-conventions.md
@@ -1,6 +1,6 @@
 # Architecture Conventions
 
-> Last synced: 2026-04-20 via /sync-guidelines
+> Last synced: 2026-04-21 via /sync-guidelines
 > For Absolute Prohibitions, Conversion Patterns, Write DTO criteria, and common commands, refer to AGENTS.md.
 > This file only contains **structural context** that supplements AGENTS.md for Claude.
 
@@ -61,16 +61,17 @@ Key differences from RDB/DynamoDB:
 
 ## Embedding (PydanticAI Adapter)
 - Single `PydanticAIEmbeddingAdapter` replaces per-provider clients (ADR 039)
-- No `providers.Selector` — PydanticAI handles provider abstraction internally
-- `EmbeddingConfig` (frozen dataclass VO) carries model_name + dimension + credentials via DI
-- Provider determined by `model_name` prefix format (e.g., `openai:text-embedding-3-small`)
+- No provider-level Selector — PydanticAI handles provider abstraction internally via `model_name` prefix
+- `CoreContainer.embedding_client` wraps the adapter in `providers.Selector`: enabled → real adapter; disabled → `StubEmbedder` for graceful degradation (ADR 042)
+- `EmbeddingConfig` (frozen dataclass VO) is constructed inside the lazy factory — not a standalone container provider
 - Implements `BaseEmbeddingProtocol` (embed_text, embed_batch, dimension)
 - Dimension auto-derived from model name — `settings.embedding_dimension` is single source of truth
 
 ## LLM (PydanticAI Agent)
 - `build_llm_model()` factory returns PydanticAI Model object from `LLMConfig`
-- `LLMConfig` (frozen dataclass VO) carries model_name + credentials via DI
-- Domain services inject pre-built `llm_model` and create `Agent(model=llm_model)` at init
+- `CoreContainer.llm_model` wraps the factory in `providers.Selector`: enabled → real model; disabled → PydanticAI `TestModel` via `build_stub_llm_model` (or `None` when the `pydantic-ai` extra is uninstalled) (ADR 042)
+- `LLMConfig` (frozen dataclass VO) is constructed inside the lazy factory — not a standalone container provider
+- Domain services inject the Selector-resolved `llm_model` and create `Agent(model=llm_model)` at init; stub propagates transparently
 - Supports OpenAI, Anthropic, Bedrock providers via `model_name` prefix
 - Agents are reusable across requests (create once at service init)
 

--- a/.claude/rules/commands.md
+++ b/.claude/rules/commands.md
@@ -1,6 +1,6 @@
 # Suggested Commands
 
-> Last synced: 2026-04-20 via /sync-guidelines
+> Last synced: 2026-04-21 via /sync-guidelines
 > Purpose: Quick reference for Claude Code when executing shell commands.
 > Also referenced when running Skills.
 > Makefile targets (`make dev`, `make test`, etc.) are available as shortcuts — see `AGENTS.md` Common Commands.

--- a/.claude/rules/project-overview.md
+++ b/.claude/rules/project-overview.md
@@ -1,7 +1,8 @@
 # Project Overview
 
-> Last synced: 2026-04-20 via /sync-guidelines
+> Last synced: 2026-04-21 via /sync-guidelines
 > For tech stack, refer to project-dna.md §8; for layer structure, refer to §1.
+> For the Optional infra toggle surface (env var → disabled behavior per infra), see AGENTS.md "Optional Infrastructure" + [ADR 042](../../docs/history/042-optional-infrastructure-di-pattern.md).
 > This file only contains **project-level context** not covered in project-dna.md.
 
 ## Purpose

--- a/.claude/rules/project-status.md
+++ b/.claude/rules/project-status.md
@@ -1,11 +1,11 @@
 # Project Status
 
-> Last synced: 2026-04-20 via /sync-guidelines
+> Last synced: 2026-04-21 via /sync-guidelines
 
 ## Current Version Context
 - Latest release: v0.3.0 (2026-04-10)
 - Active domains: user (reference domain), classification (prototype), docs (RAG consumer example, #80)
-- Infrastructure: RDB (PostgreSQL/MySQL/SQLite), DynamoDB, Storage (S3/MinIO), S3 Vectors, InMemory Vectors (quickstart), Embedding (PydanticAI + Stub), LLM (PydanticAI Agent), RagPipeline (+ Stub answer agent), Broker (SQS/RabbitMQ/InMemory)
+- Infrastructure: RDB (PostgreSQL/MySQL/SQLite), DynamoDB, Storage (S3/MinIO), S3 Vectors, InMemory Vectors (quickstart), Embedding (PydanticAI + StubEmbedder fallback), LLM (PydanticAI Agent + TestModel stub fallback via `build_stub_llm_model`), RagPipeline (+ StubAnswerAgent), Broker (SQS/RabbitMQ/InMemory). All non-DB infras are optional via `providers.Selector` + lazy factories (ADR 042).
 
 ## Recent Major Changes (since v0.3.0)
 | Feature | Issue | Impact |
@@ -28,7 +28,10 @@
 | PydanticAI Embedder Transition | ADR 039 | PydanticAIEmbeddingAdapter replaces per-provider clients, EmbeddingConfig VO |
 | Bedrock Credential Support | #15 | LLMConfig with per-service AWS credential injection, model_factory |
 | Zero-config Quickstart | #78 | `make quickstart` + `make demo`, ENV=quickstart with SQLite + InMemory broker + auto create_all, Settings defaults for zero-infra boot |
-| RAG Pattern + docs Domain | #80 | `_core/domain/services/rag_pipeline.py` (Generic[TChunk] orchestrator), `_core/domain/value_objects/rag/` (BaseChunkDTO, CitationDTO, QueryAnswer), `_core/domain/protocols/answer_agent_protocol.py`, `_core/infrastructure/rag/` (StubEmbedder, StubAnswerAgent, PydanticAIAnswerAgent), `_core/infrastructure/vectors/` (BaseInMemoryVectorStore), `src/docs/` consumer (document CRUD + query), `make demo-rag`, VECTOR_STORE_TYPE env var, [ADR 040](../../docs/history/040-rag-as-reusable-pattern.md) |
+| RAG Pattern + docs Domain | #80 | `_core/domain/services/rag_pipeline.py` (Generic[TChunk] orchestrator), `_core/domain/dtos/rag.py` (BaseChunkDTO, CitationDTO, QueryAnswerDTO), `_core/domain/protocols/answer_agent_protocol.py`, `_core/infrastructure/rag/` (StubEmbedder, StubAnswerAgent, PydanticAIAnswerAgent), `_core/infrastructure/vectors/` (BaseInMemoryVectorStore), `src/docs/` consumer (document CRUD + query), `make demo-rag`, VECTOR_STORE_TYPE env var, [ADR 040](../../docs/history/040-rag-as-reusable-pattern.md) |
+| ADR Consolidation | #83 | 40 ADRs → 14 core + 29 archived under `docs/history/archive/`, new `docs/history/README.md` core-reading-order guide |
+| Optional Infrastructure (CoreContainer) — Part A | #101 | `providers.Selector` + lazy factories for all 5 non-broker optional infras (storage, DynamoDB, S3 Vectors, embedding, LLM). Disabled branches: `providers.Object(None)` for data stores, `StubEmbedder` for embedding. `llm_config` / `embedding_config` dropped from public container surface. [ADR 042](../../docs/history/042-optional-infrastructure-di-pattern.md), AGENTS.md "Optional Infrastructure" reference section |
+| Optional Infrastructure — Part B | #101 | `build_stub_llm_model()` factory returns PydanticAI `TestModel` (or `None` if `pydantic-ai` extra not installed). `ClassificationService` now degrades gracefully when `LLM_*` unset. `docs/ai/shared/scaffolding-layers.md` gains "Optional AI Infra Variant" section teaching the domain-level Selector+stub pattern for new-domain scaffolding |
 
 ## Architecture Violation Status
 - Domain → Infrastructure import: CLEAN

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Zero-config quickstart (`make quickstart` / `make demo` / `ENV=quickstart` with SQLite + InMemory broker + auto create_all) so the blueprint can boot in under 60 seconds with no external infra ([#78](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/78))
+- End-to-end RAG example as a reusable `_core` pattern (`RagPipeline`, `BaseChunkDTO` / `CitationDTO` / `QueryAnswerDTO`, `AnswerAgentProtocol`, `StubEmbedder` / `StubAnswerAgent` / `PydanticAIAnswerAgent`, `BaseInMemoryVectorStore`) with `src/docs/` consumer domain, `make demo-rag`, and `VECTOR_STORE_TYPE` env var ([#80](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/80))
+- Optional Infrastructure pattern in CoreContainer — `providers.Selector` + lazy factories for all 5 non-broker optional infras (storage, DynamoDB, S3 Vectors, embedding, LLM); disabled branches return `providers.Object(None)` for data stores or `StubEmbedder` / PydanticAI `TestModel` for AI infras so apps boot with only `DATABASE_ENGINE=sqlite` set and optional extras uninstalled ([#101](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/101))
+- `build_stub_llm_model()` factory — returns PydanticAI `TestModel` when `pydantic-ai` is installed, `None` otherwise, so `ClassificationService` and future LLM-consuming domains degrade gracefully when `LLM_*` env vars are unset ([#101](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/101))
+- AGENTS.md "Optional Infrastructure" reference section and `docs/ai/shared/scaffolding-layers.md` "Optional AI Infra Variant" section for `/new-domain` scaffolding ([#101](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/101))
+- README restructure (633 → 260 lines), `docs/reference.md`, and `docs/README.ko.md` Korean mirror ([#79](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/79))
+- Visual architecture diagrams (Mermaid + SVG exports) with canonical `docs/ai/shared/architecture-diagrams.md` and `make diagrams` target ([#81](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/81), [#89](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/89))
+- "Your first domain in 10 minutes" tutorial ([#84](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/84))
+- Contributor funnel — good-first-issues audit, `examples/` seed, five seed issues for contributors ([#85](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/85))
+- Secret hygiene — gitleaks pre-commit hook, history scan, `SECURITY.md` expansion ([#87](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/87))
+- ADR 040 (RAG as reusable `_core` pattern), ADR 041 (Multi-backend infrastructure layout — persistence umbrella + vector backend subfolders), ADR 042 (Optional Infrastructure — Selector + lazy factory)
+
+### Changed
+
+- ADR curation — 40 ADRs consolidated down to 14 core + 29 archived under `docs/history/archive/`, with `docs/history/README.md` providing a core-reading-order guide for onboarding ([#83](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/83))
+- `CoreContainer.llm_config` and `CoreContainer.embedding_config` are no longer public providers — both VOs are now constructed inside the lazy factory functions, reducing the container's surface area without changing the VO classes themselves ([#101](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/101))
+- `src/_core/infrastructure/` reorganised under the `persistence/` umbrella (RDB at `persistence/rdb/`, DynamoDB at `persistence/nosql/dynamodb/`) with vector backends split into `vectors/s3/` and `vectors/in_memory/` sharing a root `vector_model.py` ([#80](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/80), ADR 041)
+- RAG DTOs relocated from `_core/domain/value_objects/rag/` to `_core/domain/dtos/rag.py` and renamed `QueryAnswer` → `QueryAnswerDTO` for consistency with the ADR 004 DTO suffix convention ([#80](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/80))
+
 ## [0.3.0] - 2026-04-09
 
 ### Added

--- a/docs/ai/shared/project-dna.md
+++ b/docs/ai/shared/project-dna.md
@@ -6,7 +6,7 @@
 > This file is auto-extracted/updated from `src/user/` (reference domain) and `src/_core/` (Base classes)
 > when `/sync-guidelines` is run. **Run `/sync-guidelines` instead of editing manually.**
 >
-> Last updated: 2026-04-20
+> Last updated: 2026-04-21
 
 ## Section Index
 §0 Project Scale and Design Philosophy |
@@ -352,12 +352,9 @@ class {Name}Container(containers.DeclarativeContainer):
 | App Container (Server/Worker) | `containers.DynamicContainer` (factory function) |
 | Domain auto-discovery | `src._core.infrastructure.discovery.discover_domains()` |
 | Dynamic Container loading | `src._core.infrastructure.discovery.load_domain_container()` |
-| S3VectorClient | `providers.Singleton` | S3 Vectors API wrapper |
-| EmbeddingConfig | `providers.Singleton` | Immutable config VO for PydanticAI Embedder |
-| PydanticAIEmbeddingAdapter | `providers.Singleton` | Single adapter, multi-provider |
-| LLMConfig | `providers.Singleton` | Immutable config VO for PydanticAI Agent |
-| llm_model | `providers.Singleton` | Pre-built model via `build_llm_model()` |
-| Broker (multi-backend) | `providers.Selector` | Selects SQS/RabbitMQ/InMemory by config |
+| Broker (multi-backend) | `providers.Selector` | Selects SQS/RabbitMQ/InMemory by config (ADR 029) |
+| Optional infra (storage / DynamoDB / S3 Vectors / embedding / LLM) | `providers.Selector` + lazy factory | Enabled branch constructs the real client; disabled branch returns `providers.Object(None)` for data stores or a stub (`StubEmbedder` / `TestModel`) for AI infras (ADR 042) |
+| `EmbeddingConfig` / `LLMConfig` | Constructed inside lazy factories | Frozen dataclass VOs (domain layer) — **not** standalone container providers post-ADR 042; consumers receive the built `embedding_client` / `llm_model` instead |
 
 ### App-level Container (Auto-discovery)
 


### PR DESCRIPTION
## Related Issue
- Sync follow-up after #101 (Part A + Part B) and #83 (ADR consolidation) landed. Not tied to a single issue.

## Change Summary
- `.claude/rules/project-status.md` — added #83, #101 Part A, #101 Part B to Recent Major Changes; fixed stale #80 RAG path reference (`value_objects/rag/` → `dtos/rag.py`); updated infrastructure bullet with Selector + Stub LLM wording; bumped Last synced.
- `.claude/rules/architecture-conventions.md` — Embedding and LLM sections rewritten to reflect the CoreContainer `providers.Selector` shape + `StubEmbedder` / `build_stub_llm_model` fallbacks; noted that `LLMConfig` / `EmbeddingConfig` are constructed inside the lazy factory, not standalone container providers.
- `.claude/rules/project-overview.md` — added cross-reference pointer to AGENTS.md Optional Infrastructure + ADR 042.
- `.claude/rules/commands.md` — date bump only (no new commands added by #101).
- `docs/ai/shared/project-dna.md` §5 DI Pattern table — removed stale `EmbeddingConfig` / `LLMConfig` / `llm_model` Singleton rows; consolidated into a single "Optional infra (Selector + lazy factory)" row citing ADR 042; updated the broker row with the ADR 029 cross-reference.
- `CHANGELOG.md` — populated the `[Unreleased]` section (was empty) with entries for this sprint: #78 quickstart, #79 README restructure, #80 RAG, #81/#89 diagrams, #83 ADR consolidation, #84 tutorial, #85 examples, #87 secret hygiene, #101 Optional infra, and ADRs 040/041/042.

## Type of Change
- [x] docs: Documentation

## Checklist
- [x] Architecture rules followed (no code changes)
- [x] Tests pass (no test changes — pure docs)
- [x] Linting passes (no code changes)

## How to Test
- Visual review: open each changed file side-by-side with actual code references cited in this PR and confirm they now match.
- `grep -rn "2026-04-20" .claude/rules/ docs/ai/shared/` should return 0 hits (all Last-synced dates bumped to 2026-04-21).
- Verify `CHANGELOG.md`'s `[Unreleased]` section reflects everything shipped since v0.3.0.

## Notes for Reviewers
- Drift audit was run via an Explore agent before applying fixes — conclusions (with line numbers and quoted stale text) are in the local plan file but not in this PR. The fixes here are the concrete outcome of that audit.
- Research on PEP 621 extras conventions (for #104) and OSS issue-lifecycle conventions (for the #56 / #82 closures) was conducted during this sync but is not part of this PR.