### PR TITLE
fix: OWASP security review — F3~F11, F13 (v0.4.0 baseline)

### DIFF
--- a/.claude/rules/architecture-conventions.md
+++ b/.claude/rules/architecture-conventions.md
@@ -1,6 +1,6 @@
 # Architecture Conventions
 
-> Last synced: 2026-04-21 via /sync-guidelines
+> Last synced: 2026-04-21 via /sync-guidelines (v0.4.0 post-release sync)
 > For Absolute Prohibitions, Conversion Patterns, Write DTO criteria, and common commands, refer to AGENTS.md.
 > This file only contains **structural context** that supplements AGENTS.md for Claude.
 
@@ -74,6 +74,17 @@ Key differences from RDB/DynamoDB:
 - Domain services inject the Selector-resolved `llm_model` and create `Agent(model=llm_model)` at init; stub propagates transparently
 - Supports OpenAI, Anthropic, Bedrock providers via `model_name` prefix
 - Agents are reusable across requests (create once at service init)
+
+## Structured Logging (#9)
+
+- 파이프라인: `structlog` ProcessorFormatter + `asgi-correlation-id`. JSON(stg/prod) / console(dev/local/quickstart) 자동 전환 (`settings.effective_log_json`)
+- Server: `configure_logging()` → `TrustedHost → CORS → RequestLogMiddleware → CorrelationIdMiddleware` (Starlette는 늦게 `add_middleware`한 것이 외곽이 되므로, 의도적으로 CorrelationId를 가장 마지막에 추가해 요청 최상위에 둠)
+- Worker: `configure_logging()` → `app.add_middlewares(StructlogContextMiddleware())`가 task id / correlation id를 contextvars에 바인딩 (dispatcher가 `with_labels(correlation_id=...)`로 넘긴 값도 자동 lift)
+- Logger 획득 규칙: 모든 애플리케이션 코드는 `structlog.stdlib.get_logger(__name__)` 사용
+  - 기존 `logging.getLogger(__name__)` 호출도 ProcessorFormatter 브리지 덕분에 동일 파이프라인을 타지만, 신규 코드는 structlog API로 통일
+- 민감정보 로깅 금지: `password`, `token`, `access_key`, `secret_key` 등 Response에서 `model_dump(exclude={...})`로 제외하는 필드는 `logger.info(event, password=...)` / `logger.bind(...)` 형태로도 기록 금지
+- SQLAlchemy echo: `DATABASE_ECHO=true`는 `logging.getLogger("sqlalchemy.engine").setLevel(INFO)`로 변환 (engine handler 중복 등록 방지 — 동일 쿼리가 stdlib + structlog 양쪽에서 double-emit 되지 않도록)
+- Env vars: `LOG_LEVEL` (DEBUG/INFO/WARNING/ERROR), `LOG_JSON_FORMAT` (None/True/False — None이면 ENV에서 자동 결정)
 
 ## Object Roles
 

--- a/.claude/rules/commands.md
+++ b/.claude/rules/commands.md
@@ -1,22 +1,27 @@
 # Suggested Commands
 
-> Last synced: 2026-04-21 via /sync-guidelines
+> Last synced: 2026-04-21 via /sync-guidelines (v0.4.0 post-release sync)
 > Purpose: Quick reference for Claude Code when executing shell commands.
 > Also referenced when running Skills.
 > Makefile targets (`make dev`, `make test`, etc.) are available as shortcuts — see `AGENTS.md` Common Commands.
 
 ## Run
 ```bash
+# 개발환경 셋업 (admin + aws extras 포함 — #104)
+make setup
+
 # Zero-config quickstart (SQLite + InMemory broker, no external infra)
 make quickstart
 make demo            # in a second terminal — runs curl CRUD walkthrough
+make demo-rag        # RAG end-to-end (seed 3 docs → list → query, #80)
 
-# FastAPI server (dev — requires PostgreSQL via docker-compose.local.yml)
+# 로컬 개발 (PostgreSQL via docker-compose.local.yml)
+make dev
+make worker
+
+# 직접 실행 (참고용)
 uvicorn src._apps.server.app:app --reload --host 127.0.0.1 --port 8001
-# or
 python run_server_local.py --env local
-
-# Taskiq worker
 python run_worker_local.py --env local
 ```
 
@@ -62,7 +67,11 @@ alembic history
 ## Package Management (uv)
 ```bash
 uv add <package>
-uv sync
+uv sync                                          # core only
+uv sync --group dev --extra admin --extra aws    # 개발 기본 (make setup과 동일, #104)
+uv sync --extra admin                            # NiceGUI 관리 대시보드만
+uv sync --extra aws                              # S3/MinIO/DynamoDB/S3Vectors
+uv sync --extra pydantic-ai --extra aws          # Bedrock LLM/Embedding (aioboto3 포함)
 ```
 
 ## Architecture Diagrams
@@ -72,6 +81,18 @@ uv sync
 # whenever that file is edited so CLI/non-Mermaid viewers stay in sync.
 make diagrams
 ```
+
+## Logging (structlog, #9)
+```bash
+# 로그 레벨 / 포맷 조정 — server/worker 공통
+LOG_LEVEL=DEBUG make dev
+LOG_JSON_FORMAT=true make dev   # dev에서도 JSON 렌더러 강제 (파이프라인 확인용)
+LOG_JSON_FORMAT=false make dev  # stg/prod에서 일시적으로 console 렌더러로 디버깅
+```
+
+- 기본: dev/local/quickstart → console, stg/prod → JSON (`settings.effective_log_json`)
+- 모든 신규 코드는 `structlog.stdlib.get_logger(__name__)` 사용
+- `DATABASE_ECHO=true`는 `logging.getLogger("sqlalchemy.engine").setLevel(INFO)`로 변환되어 structlog 파이프라인을 한 번만 경유
 
 ## Architecture Verification
 ```bash
@@ -115,6 +136,11 @@ STORAGE_TYPE=s3 python run_server_local.py --env local
 
 ## Admin Dashboard
 ```bash
-# Auto-mounted on server → http://127.0.0.1:8001/admin
-# Login with ADMIN_ID / ADMIN_PASSWORD from .env
+# Admin 대시보드는 `admin` extra가 설치된 경우에만 마운트됨 (#104)
+uv sync --extra admin            # nicegui 설치
+# → http://127.0.0.1:8001/admin (ADMIN_ID / ADMIN_PASSWORD from .env)
+
+# 미설치 시에는 서버는 정상 boot하고 구조화 로그만 남김:
+#   event="admin_mount_skipped" reason="nicegui_not_installed"
+#   install_hint="uv sync --extra admin"
 ```

--- a/.claude/rules/project-overview.md
+++ b/.claude/rules/project-overview.md
@@ -1,6 +1,6 @@
 # Project Overview
 
-> Last synced: 2026-04-21 via /sync-guidelines
+> Last synced: 2026-04-21 via /sync-guidelines (v0.4.0 post-release sync)
 > For tech stack, refer to project-dna.md §8; for layer structure, refer to §1.
 > For the Optional infra toggle surface (env var → disabled behavior per infra), see AGENTS.md "Optional Infrastructure" + [ADR 042](../../docs/history/042-optional-infrastructure-di-pattern.md).
 > This file only contains **project-level context** not covered in project-dna.md.
@@ -11,7 +11,8 @@ AI Agent Backend Platform built on FastAPI with DDD modular layered architecture
 ## App Entrypoints
 - Server: `src/_apps/server/` — FastAPI (uvicorn)
 - Worker: `src/_apps/worker/` — Taskiq (broker abstraction: SQS/RabbitMQ/InMemory)
-- Admin: `src/_apps/admin/` — NiceGUI (mounted on server via ui.run_with)
+- Admin: `src/_apps/admin/` — NiceGUI (mounted on server via ui.run_with) — **`admin` extra 설치 시에만 마운트**; 미설치 시 `admin_mount_skipped` 구조화 로그만 남기고 서버는 정상 boot (#104)
+- AWS 인프라 (ObjectStorage/DynamoDB/S3Vectors)는 `aws` extra 필요; 관련 env var 미설정 시 lazy import가 발화하지 않아 extra 없이도 boot 가능 (#104 Part 2)
 
 ## Dependency Direction
 Interface → Application → Domain ← Infrastructure
@@ -24,12 +25,14 @@ Interface → Application → Domain ← Infrastructure
 - Embedding: Optional (EMBEDDING_PROVIDER env var, PydanticAIEmbeddingAdapter — OpenAI/Bedrock/Google/Ollama)
 - LLM: Optional (LLM_PROVIDER env var, build_llm_model() — OpenAI/Anthropic/Bedrock)
 - Message Broker: SQS/RabbitMQ/InMemory (BROKER_TYPE env var)
+- Logging: structlog + asgi-correlation-id, 기본 INFO, LOG_LEVEL / LOG_JSON_FORMAT env var로 제어 (dev/local/quickstart → console, stg/prod → JSON, #9)
 
 ## Environment Config Validation
 - Settings (pydantic-settings) with model_validator
 - stg/prod: unsafe defaults blocked, broker required, partial config groups rejected
 - STORAGE_TYPE-driven validation: S3/MinIO config group required when set
 - Partial config group validation: S3, MinIO, DynamoDB, S3Vectors, SQS, Embedding (OpenAI/Bedrock), LLM (OpenAI/Anthropic/Bedrock)
+- Logging: LOG_LEVEL (DEBUG/INFO/WARNING/ERROR), LOG_JSON_FORMAT (None → env 기반 자동 결정, True/False로 강제 override)
 
 ## Key Value Objects
 - QueryFilter: Immutable filter for paginated queries (sort/search). Used in BaseRepository.select_datas_with_count() and BaseService.get_datas().

--- a/.claude/rules/project-status.md
+++ b/.claude/rules/project-status.md
@@ -1,11 +1,11 @@
 # Project Status
 
-> Last synced: 2026-04-21 via /sync-guidelines
+> Last synced: 2026-04-21 via /sync-guidelines (v0.4.0 post-release sync)
 
 ## Current Version Context
-- Latest release: v0.3.0 (2026-04-10)
+- Latest release: v0.4.0 (2026-04-21)
 - Active domains: user (reference domain), classification (prototype), docs (RAG consumer example, #80)
-- Infrastructure: RDB (PostgreSQL/MySQL/SQLite), DynamoDB, Storage (S3/MinIO), S3 Vectors, InMemory Vectors (quickstart), Embedding (PydanticAI + StubEmbedder fallback), LLM (PydanticAI Agent + TestModel stub fallback via `build_stub_llm_model`), RagPipeline (+ StubAnswerAgent), Broker (SQS/RabbitMQ/InMemory). All non-DB infras are optional via `providers.Selector` + lazy factories (ADR 042).
+- Infrastructure: RDB (PostgreSQL/MySQL/SQLite), DynamoDB, Storage (S3/MinIO), S3 Vectors, InMemory Vectors (quickstart), Embedding (PydanticAI + StubEmbedder fallback), LLM (PydanticAI Agent + TestModel stub fallback via `build_stub_llm_model`), RagPipeline (+ StubAnswerAgent), Broker (SQS/RabbitMQ/InMemory), Structured logging (structlog + asgi-correlation-id). All non-DB infras are optional via `providers.Selector` + lazy factories (ADR 042). `nicegui`는 `admin` extra, `boto3`/`aioboto3`는 `aws` extra (#104).
 
 ## Recent Major Changes (since v0.3.0)
 | Feature | Issue | Impact |
@@ -32,6 +32,9 @@
 | ADR Consolidation | #83 | 40 ADRs → 14 core + 29 archived under `docs/history/archive/`, new `docs/history/README.md` core-reading-order guide |
 | Optional Infrastructure (CoreContainer) — Part A | #101 | `providers.Selector` + lazy factories for all 5 non-broker optional infras (storage, DynamoDB, S3 Vectors, embedding, LLM). Disabled branches: `providers.Object(None)` for data stores, `StubEmbedder` for embedding. `llm_config` / `embedding_config` dropped from public container surface. [ADR 042](../../docs/history/042-optional-infrastructure-di-pattern.md), AGENTS.md "Optional Infrastructure" reference section |
 | Optional Infrastructure — Part B | #101 | `build_stub_llm_model()` factory returns PydanticAI `TestModel` (or `None` if `pydantic-ai` extra not installed). `ClassificationService` now degrades gracefully when `LLM_*` unset. `docs/ai/shared/scaffolding-layers.md` gains "Optional AI Infra Variant" section teaching the domain-level Selector+stub pattern for new-domain scaffolding |
+| Structured Logging | #9 | `structlog` + `asgi-correlation-id` 파이프라인을 server/worker bootstrap에 통합. `configure_logging()`, `RequestLogMiddleware` + `CorrelationIdMiddleware` (server), `StructlogContextMiddleware` (worker)로 task/correlation id contextvars 바인딩. `LOG_LEVEL` / `LOG_JSON_FORMAT` env var (dev/local/quickstart → console, stg/prod → JSON). `DATABASE_ECHO` → `logging.getLogger("sqlalchemy.engine").setLevel(INFO)`로 변환해 double-emit 제거. `generic_exception_handler`가 `print(traceback)` 대신 `logger.exception("unhandled_exception", ...)` 구조화 기록 |
+| Admin extra split | #104 | `nicegui` → `[admin]` extra 이동. `_maybe_bootstrap_admin()`이 `ImportError` 시 `admin_mount_skipped` 구조화 로그만 남기고 skip, 서버는 계속 boot. `make setup`이 `--extra admin` 기본 설치. CI `minimal-install` 잡이 extras 미설치 시 `/admin` 라우트 비마운트 회귀를 가드 |
+| AWS extra split | #104 Part 2 | `boto3` / `aioboto3` / `types-aiobotocore-*` → `[aws]` extra 이동. 4개 AWS client 모듈 (`ObjectStorageClient`, `ObjectStorage`, `DynamoDBClient`, `S3VectorClient`)은 `__init__` / lazy singleton에서 `aioboto3` / `boto3`를 lazy import. CoreContainer Selector가 disabled 분기에서 `None`을 반환하므로 `aws` extra 미설치 + 관련 env var 미설정 시 lazy import가 아예 발화하지 않음. `make setup`이 `--extra aws` 기본 설치 |
 
 ## Architecture Violation Status
 - Domain → Infrastructure import: CLEAN

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,17 @@ Every non-DB infra in `CoreContainer` is optional — toggle via env vars, no co
 
 **Package-level extras:** optional runtime infras are also gated at the `pyproject.toml` level. Install only what you need — `uv sync --extra admin` for the NiceGUI dashboard, `--extra aws` for object storage / DynamoDB / S3 Vectors (boto3 + aioboto3 + type stubs), `--extra sqs` / `--extra rabbitmq` for those broker backends, `--extra pydantic-ai` for LLM / Embedding, etc. When an extra is absent, the matching bootstrap path silently skips and the server continues to boot — the 4 AWS client modules (`ObjectStorageClient`, `ObjectStorage`, `DynamoDBClient`, `S3VectorClient`) import cleanly via `TYPE_CHECKING` + lazy `__init__` imports, and `CoreContainer` resolves the matching Selector to `None` when the env var is unset. `make setup` installs `--extra admin --extra aws` by default for full dev coverage; `make quickstart` only needs `--extra admin` (SQLite + InMemory broker). Every other extra opts in explicitly.
 
+## Structured Logging
+
+Logging is always-on (unlike Optional Infrastructure) and shared across server + worker. Pipeline: `structlog` ProcessorFormatter + `asgi-correlation-id`. Background: #9.
+
+- **Logger acquisition** — all new code uses `structlog.stdlib.get_logger(__name__)`; legacy `logging.getLogger(__name__)` calls still flow through the same pipeline via the ProcessorFormatter bridge but new modules should not add more.
+- **Renderer switching** — `LOG_JSON_FORMAT` env var (None → auto: dev/local/quickstart → console, stg/prod → JSON; True/False force override). Controlled by `settings.effective_log_json`.
+- **Sensitive-field logging is prohibited** — `password`, `token`, `access_key`, `secret_key`, `api_key`, and any field that Response `model_dump(exclude={...})` strips must NOT appear in `logger.info(event, password=...)`, `logger.bind(...)`, or `structlog.contextvars.bind_contextvars(...)`. The JSON renderer ships structlog kwargs verbatim to aggregators.
+- **SQLAlchemy echo** — `DATABASE_ECHO=true` is translated to `logging.getLogger("sqlalchemy.engine").setLevel(INFO)` (not a separate handler) to avoid double-emit between stdlib and structlog pipelines. Do not enable in stg/prod unless secret filtering is in place — bound query parameters reach the log stream.
+- **Bootstrap entrypoints** — server: `configure_logging()` → `RequestLogMiddleware` + `CorrelationIdMiddleware` (Starlette adds late-registered middleware as the outermost layer, so CorrelationId is registered last intentionally). Worker: `configure_logging()` → `StructlogContextMiddleware` binds task id / correlation id into contextvars.
+- **Env vars** — `LOG_LEVEL` (DEBUG/INFO/WARNING/ERROR), `LOG_JSON_FORMAT` (None/True/False).
+
 ## Terminology
 
 - **Request/Response**: API communication schema (`interface/server/schemas/`)

--- a/docs/ai/shared/project-dna.md
+++ b/docs/ai/shared/project-dna.md
@@ -6,7 +6,7 @@
 > This file is auto-extracted/updated from `src/user/` (reference domain) and `src/_core/` (Base classes)
 > when `/sync-guidelines` is run. **Run `/sync-guidelines` instead of editing manually.**
 >
-> Last updated: 2026-04-21
+> Last updated: 2026-04-21 (v0.4.0 post-release sync)
 
 ## Section Index
 §0 Project Scale and Design Philosophy |
@@ -433,7 +433,7 @@ embedding_client = providers.Selector(
 | EMBEDDING_PROVIDER | Model Name Format | Dependency |
 |-------------------|------------------|------------|
 | `openai` | `openai:text-embedding-3-small` | `pydantic-ai` extra (includes `tiktoken`) |
-| `bedrock` | `bedrock:amazon.titan-embed-text-v2:0` | `pydantic-ai` extra, `aioboto3` (main) |
+| `bedrock` | `bedrock:amazon.titan-embed-text-v2:0` | `pydantic-ai` extra + `aws` extra (aioboto3) |
 | `google` | `google:text-embedding-004` | `pydantic-ai-google` extra |
 | `ollama` | `ollama:nomic-embed-text` | `pydantic-ai` extra |
 
@@ -473,7 +473,7 @@ llm_model = providers.Selector(
 |-------------|------------------|------------|
 | `openai` | `openai:gpt-4o` | `pydantic-ai` extra |
 | `anthropic` | `anthropic:claude-sonnet-4-20250514` | `pydantic-ai-anthropic` extra |
-| `bedrock` | `bedrock:us.anthropic.claude-sonnet-4-20250514-v1:0` | `pydantic-ai` extra, `aioboto3` (main) |
+| `bedrock` | `bedrock:us.anthropic.claude-sonnet-4-20250514-v1:0` | `pydantic-ai` extra + `aws` extra (aioboto3) |
 
 - `LLMConfig`: frozen dataclass value object (domain layer) carrying provider+credentials
 - `build_llm_model()`: factory function returning Provider-specific Model or plain string
@@ -528,6 +528,7 @@ class {Name}Container(containers.DeclarativeContainer):
 
 - trailing-whitespace, end-of-file-fixer, check-yaml/json/toml
 - check-added-large-files (1MB), check-merge-conflict, debug-statements, mixed-line-ending (LF)
+- gitleaks v8.30.1 -- block credentials from reaching git at commit time (#87)
 - ruff check --fix (Unified rules for E, W, F, UP, I, B, C4, SIM, S -- replaces pyupgrade, autoflake, isort, flake8, bandit)
 - ruff format (Black-compatible formatting)
 
@@ -559,20 +560,23 @@ class {Name}Container(containers.DeclarativeContainer):
 | SQLAlchemy 2.0+ | Active | Mapped[T] + mapped_column() |
 | Pydantic 2.x | Active | model_validate, model_dump, ConfigDict |
 | dependency-injector | Active | DeclarativeContainer, @inject + Provide |
-| Object Storage (aioboto3) | Active | S3/MinIO switchable via STORAGE_TYPE, ObjectStorage + ObjectStorageClient |
-| AWS DynamoDB (aioboto3) | Active | BaseDynamoRepository + DynamoDBClient (optional infra) |
-| NiceGUI (BaseAdminPage) | Active | Admin dashboard (AG Grid, auto-discovery, Template Method rendering) |
+| Object Storage (aioboto3) | Active | S3/MinIO switchable via STORAGE_TYPE, ObjectStorage + ObjectStorageClient (via `aws` extra) |
+| AWS DynamoDB (aioboto3) | Active | BaseDynamoRepository + DynamoDBClient (optional infra, via `aws` extra) |
+| NiceGUI (BaseAdminPage) | Active | Admin dashboard (AG Grid, auto-discovery, Template Method rendering) -- gated via `admin` extra (#104) |
 | alembic (migrations) | Active | DB migrations |
 | Password hashing (bcrypt) | Active | hash_password(), verify_password() in src._core.common.security |
-| AWS S3 Vectors (aioboto3) | Active | BaseS3VectorStore + S3VectorClient (optional infra) |
+| AWS S3 Vectors (aioboto3) | Active | BaseS3VectorStore + S3VectorClient (optional infra, via `aws` extra) |
 | Embedding (PydanticAI) | Active | PydanticAIEmbeddingAdapter, BaseEmbeddingProtocol, auto-dimension, multi-provider |
 | LLM (PydanticAI Agent) | Active | build_llm_model(), LLMConfig, Agent structured output |
 | Text chunking (semantic-text-splitter) | Active | chunk_text(), chunk_text_by_tokens() in src._core.common.text_utils |
+| Structured Logging (structlog) | Active | structlog + asgi-correlation-id, RequestLogMiddleware (server), StructlogContextMiddleware (worker), LOG_LEVEL / LOG_JSON_FORMAT env vars, sqlalchemy.engine double-emit fix (#9) |
 | JWT/Authentication | Not implemented | |
 | File Upload (UploadFile) | Not implemented | |
 | RBAC/Permissions | Not implemented | |
 | Rate Limiting (slowapi) | Not implemented | |
 | WebSocket | Not implemented | |
+
+> Extras note (#104, ADR 042): `nicegui`는 `admin` extra, `boto3` / `aioboto3` / `types-aiobotocore-*`는 `aws` extra에 속함. 필요한 배포에서만 `uv sync --extra admin --extra aws` — `make setup`은 둘 다 기본 설치. 미설치 시 관련 Selector는 `None` / `StubEmbedder` / `TestModel`로 graceful degradation.
 
 ## §9. Router Pattern
 
@@ -821,7 +825,7 @@ the adapter bridges to `BaseEmbeddingProtocol` and adds OpenAI batch splitting.
 
 - Requires `pydantic-ai` extra: `uv sync --extra pydantic-ai` (installs `pydantic-ai-slim` + `tiktoken`)
 - Provider-specific extras: `pydantic-ai-anthropic` (Anthropic LLM), `pydantic-ai-google` (Google embedding)
-- Bedrock providers reuse the main `aioboto3` dependency — no extra needed
+- Bedrock providers rely on `aioboto3`, which now ships in the `aws` extra (`uv sync --extra aws`) — install both `pydantic-ai` and `aws` extras for Bedrock embedding/LLM (#104 Part 2)
 - OpenAI batch splitting requires `tiktoken` (included in pydantic-ai extra)
 - Raises domain exceptions: `EmbeddingRateLimitException`, `EmbeddingAuthenticationException`, `EmbeddingInputTooLongException`, `EmbeddingModelNotFoundException`
 - `EmbeddingConfig`: frozen dataclass (domain-layer VO) carrying model_name + dimension + credentials

--- a/docs/ai/shared/security-checklist.md
+++ b/docs/ai/shared/security-checklist.md
@@ -159,6 +159,19 @@ Check middleware and exception handling files:
 - [ ] [Always][MEDIUM] Review data ID enumeration attack possibility
   - Grep: `Data with ID` -> awareness needed if present
 
+### Structured Logging (structlog, #9)
+- [ ] [Always][HIGH] structlog kwargs / bind do not carry sensitive fields
+  - Detection condition: Check **project-dna.md section 8** "Structured Logging (structlog)" status -> active for all builds since v0.4.0
+  - Grep: `\.(info|debug|warning|error|exception)\([^)]*\b(password|token|access_key|secret_key|secret|api_key)\s*=`
+  - Grep: `\.(bind|bind_contextvars)\([^)]*\b(password|token|access_key|secret_key|secret|api_key)\s*=`
+  - Reason: structlog kwargs become structured log fields; JSON renderer in stg/prod ships them verbatim to log aggregators
+- [ ] [Always][HIGH] `DATABASE_ECHO` is not enabled in stg/prod without secret filtering
+  - Grep: `DATABASE_ECHO\s*=\s*[Tt]rue` in stg/prod config / `.env.*` shipped samples
+  - Reason: echo forwards SQL with bound parameters to `sqlalchemy.engine` logger — plaintext credentials land in logs when INSERT/UPDATE hits password / token columns
+- [ ] [Always][MEDIUM] `configure_logging()` is invoked before middleware stack in both server and worker bootstrap
+  - Grep: `configure_logging\(\)` call site in `src/_apps/server/app.py` / `src/_apps/worker/app.py`
+  - Reason: un-configured structlog falls back to stdlib default, bypassing ProcessorFormatter JSON renderer and correlation-id binding
+
 ### Rate Limiting
 - [ ] [When applicable][MEDIUM] Rate limiting middleware configuration status
   - Detection condition: Check **project-dna.md section 8** "Rate Limiting (slowapi)" status -> [SKIP] if "not implemented"

--- a/src/_core/common/llm_utils.py
+++ b/src/_core/common/llm_utils.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from typing import NoReturn
+
+from src._core.exceptions.llm_exceptions import (
+    LLMAuthenticationException,
+    LLMContextLengthExceededException,
+    LLMException,
+    LLMModelNotFoundException,
+    LLMRateLimitException,
+)
+
+_RATE_LIMIT_NAMES = frozenset(
+    {
+        "ratelimiterror",
+        "ratelimitexception",
+        "throttlingexception",
+        "toomanyrequestsexception",
+        "throttlederror",
+        "quotaexceeded",
+    }
+)
+_AUTH_NAMES = frozenset(
+    {
+        "authenticationerror",
+        "unauthorizederror",
+        "permissiondeniederror",
+        "invalidapikeyerror",
+        "authorizationerror",
+    }
+)
+_CONTEXT_NAMES = frozenset(
+    {
+        "contextlengtherror",
+        "contextlengthexceeded",
+        "maxtokensexceeded",
+    }
+)
+_NOT_FOUND_NAMES = frozenset(
+    {
+        "modelnotfounderror",
+        "modelnotfoundexception",
+    }
+)
+
+
+def map_llm_error(exc: Exception) -> NoReturn:
+    """Map PydanticAI/provider LLM exceptions to domain LLM exceptions.
+
+    Inspects exception class name first (provider SDK class names are stable),
+    then falls back to string matching for wrapped exceptions.
+    Always raises — return type is NoReturn.
+    """
+    type_name = type(exc).__name__.lower().replace("_", "")
+    error_str = str(exc).lower()
+
+    if (
+        type_name in _RATE_LIMIT_NAMES
+        or "throttl" in error_str
+        or ("rate" in error_str and "limit" in error_str)
+    ):
+        raise LLMRateLimitException() from exc
+    if (
+        type_name in _AUTH_NAMES
+        or "authentication" in error_str
+        or "unauthorized" in error_str
+    ):
+        raise LLMAuthenticationException() from exc
+    if type_name in _CONTEXT_NAMES or (
+        "context" in error_str and ("length" in error_str or "window" in error_str)
+    ):
+        raise LLMContextLengthExceededException() from exc
+    if type_name in _NOT_FOUND_NAMES or (
+        "model" in error_str and "not found" in error_str
+    ):
+        raise LLMModelNotFoundException() from exc
+
+    raise LLMException(
+        status_code=502,
+        message="LLM operation failed",
+        error_code="LLM_OPERATION_FAILED",
+    ) from exc

--- a/src/_core/config.py
+++ b/src/_core/config.py
@@ -1,3 +1,4 @@
+import secrets
 import warnings
 from typing import Self
 
@@ -77,7 +78,8 @@ class Settings(BaseSettings):
     admin_id: str = Field(default="admin", validation_alias="ADMIN_ID")
     admin_password: str = Field(default="admin", validation_alias="ADMIN_PASSWORD")
     admin_storage_secret: str = Field(
-        default="change-me-in-production", validation_alias="ADMIN_STORAGE_SECRET"
+        default_factory=lambda: secrets.token_urlsafe(32),
+        validation_alias="ADMIN_STORAGE_SECRET",
     )
 
     # ----------------------------------------------------------------
@@ -305,6 +307,20 @@ class Settings(BaseSettings):
                     errors.append(
                         f"[{field_name}] Using unsafe default "
                         f"'{unsafe_value}' in '{self.env}' environment"
+                    )
+
+            if "admin_storage_secret" not in self.model_fields_set:
+                errors.append(
+                    f"[admin_storage_secret] ADMIN_STORAGE_SECRET must be explicitly set "
+                    f"in '{self.env}' environment (auto-generated value not allowed)"
+                )
+
+            if self.dynamodb_endpoint_url:
+                _local_patterns = ("localhost", "127.", "0.0.0.0", "::1")  # noqa: S104
+                if any(p in self.dynamodb_endpoint_url for p in _local_patterns):
+                    errors.append(
+                        f"[dynamodb_endpoint_url] DYNAMODB_ENDPOINT_URL references a local "
+                        f"address in '{self.env}' environment. Use an AWS endpoint URL."
                     )
 
             for field_name, default_value in _WARN_DEFAULTS.items():

--- a/src/_core/exceptions/llm_exceptions.py
+++ b/src/_core/exceptions/llm_exceptions.py
@@ -1,0 +1,47 @@
+from src._core.exceptions.base_exception import BaseCustomException
+
+
+class LLMException(BaseCustomException):
+    """Base exception for LLM operations."""
+
+
+class LLMAuthenticationException(LLMException):
+    def __init__(self) -> None:
+        super().__init__(
+            status_code=401,
+            message="LLM API authentication failed",
+            error_code="LLM_AUTH_FAILED",
+        )
+
+
+class LLMRateLimitException(LLMException):
+    def __init__(self) -> None:
+        super().__init__(
+            status_code=429,
+            message="LLM API rate limit exceeded",
+            error_code="LLM_RATE_LIMITED",
+        )
+
+
+class LLMModelNotFoundException(LLMException):
+    def __init__(self, model_id: str = "") -> None:
+        msg = f"LLM model not found: {model_id}" if model_id else "LLM model not found"
+        super().__init__(
+            status_code=404,
+            message=msg,
+            error_code="LLM_MODEL_NOT_FOUND",
+        )
+
+
+class LLMContextLengthExceededException(LLMException):
+    def __init__(self, tokens: int = 0, max_tokens: int = 0) -> None:
+        msg = (
+            f"LLM context length exceeded: {tokens} tokens (max {max_tokens})"
+            if tokens
+            else "LLM context length exceeded"
+        )
+        super().__init__(
+            status_code=400,
+            message=msg,
+            error_code="LLM_CONTEXT_LENGTH_EXCEEDED",
+        )

--- a/src/_core/infrastructure/embedding/pydantic_ai_embedding_adapter.py
+++ b/src/_core/infrastructure/embedding/pydantic_ai_embedding_adapter.py
@@ -14,6 +14,7 @@ from src._core.infrastructure.embedding.exceptions import (
 _BATCH_SIZE = 2048  # OpenAI max texts per request
 _MAX_TOKENS_PER_BATCH = 300_000  # OpenAI total token limit per request
 _MAX_TOKENS_PER_TEXT = 8192  # OpenAI per-text token limit
+_MAX_CHARS_PER_TEXT_BEDROCK = 50_000  # Bedrock per-text character limit
 
 
 class PydanticAIEmbeddingAdapter:
@@ -123,6 +124,13 @@ class PydanticAIEmbeddingAdapter:
         if self._provider == "openai":
             return await self._split_and_embed(texts)
 
+        if self._provider == "bedrock":
+            for text in texts:
+                if len(text) > _MAX_CHARS_PER_TEXT_BEDROCK:
+                    raise EmbeddingInputTooLongException(
+                        len(text), _MAX_CHARS_PER_TEXT_BEDROCK, "chars"
+                    )
+
         result = await self._call_embed_documents(texts)
         return [list(e) for e in result.embeddings]
 
@@ -188,16 +196,28 @@ class PydanticAIEmbeddingAdapter:
             self._map_error(exc)
 
     def _map_error(self, exc: Exception) -> NoReturn:
-        """Map PydanticAI exceptions to domain exceptions."""
+        """Map PydanticAI/provider exceptions to domain embedding exceptions."""
+        try:
+            from botocore.exceptions import ClientError
+
+            if isinstance(exc, ClientError):
+                code = exc.response.get("Error", {}).get("Code", "")
+                if code in ("ThrottlingException", "TooManyRequestsException"):
+                    raise EmbeddingRateLimitException() from exc
+        except ImportError:
+            pass
+
         error_str = str(exc).lower()
         if "authentication" in error_str or "unauthorized" in error_str:
             raise EmbeddingAuthenticationException() from exc
         if "rate" in error_str and "limit" in error_str:
             raise EmbeddingRateLimitException() from exc
+        if "throttl" in error_str:
+            raise EmbeddingRateLimitException() from exc
         if "not found" in error_str:
             raise EmbeddingModelNotFoundException(self._model_name) from exc
         raise EmbeddingException(
             status_code=502,
-            message=f"Embedding failed: {exc}",
+            message="Embedding operation failed",
             error_code="EMBEDDING_OPERATION_FAILED",
         ) from exc

--- a/src/_core/infrastructure/llm/error_mapper.py
+++ b/src/_core/infrastructure/llm/error_mapper.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from typing import NoReturn
+
+from src._core.exceptions.llm_exceptions import (
+    LLMAuthenticationException,
+    LLMContextLengthExceededException,
+    LLMException,
+    LLMModelNotFoundException,
+    LLMRateLimitException,
+)
+
+_RATE_LIMIT_NAMES = frozenset(
+    {
+        "ratelimiterror",
+        "ratelimitexception",
+        "throttlingexception",
+        "toomanyrequestsexception",
+        "throttlederror",
+        "quotaexceeded",
+    }
+)
+_AUTH_NAMES = frozenset(
+    {
+        "authenticationerror",
+        "unauthorizederror",
+        "permissiondeniederror",
+        "invalidapikeyerror",
+        "authorizationerror",
+    }
+)
+_CONTEXT_NAMES = frozenset(
+    {
+        "contextlengtherror",
+        "contextlengthexceeded",
+        "maxtokensexceeded",
+    }
+)
+_NOT_FOUND_NAMES = frozenset(
+    {
+        "modelnotfounderror",
+        "modelnotfoundexception",
+    }
+)
+
+
+def map_llm_error(exc: Exception) -> NoReturn:
+    """Map PydanticAI/provider LLM exceptions to domain LLM exceptions.
+
+    Inspects exception class name first (provider SDK class names are stable),
+    then falls back to string matching for wrapped exceptions.
+    Always raises — return type is NoReturn.
+    """
+    type_name = type(exc).__name__.lower().replace("_", "")
+    error_str = str(exc).lower()
+
+    if (
+        type_name in _RATE_LIMIT_NAMES
+        or "throttl" in error_str
+        or ("rate" in error_str and "limit" in error_str)
+    ):
+        raise LLMRateLimitException() from exc
+    if (
+        type_name in _AUTH_NAMES
+        or "authentication" in error_str
+        or "unauthorized" in error_str
+    ):
+        raise LLMAuthenticationException() from exc
+    if type_name in _CONTEXT_NAMES or (
+        "context" in error_str and ("length" in error_str or "window" in error_str)
+    ):
+        raise LLMContextLengthExceededException() from exc
+    if type_name in _NOT_FOUND_NAMES or (
+        "model" in error_str and "not found" in error_str
+    ):
+        raise LLMModelNotFoundException() from exc
+
+    raise LLMException(
+        status_code=502,
+        message="LLM operation failed",
+        error_code="LLM_OPERATION_FAILED",
+    ) from exc

--- a/src/_core/infrastructure/llm/exceptions.py
+++ b/src/_core/infrastructure/llm/exceptions.py
@@ -1,47 +1,15 @@
-from src._core.exceptions.base_exception import BaseCustomException
+from src._core.exceptions.llm_exceptions import (
+    LLMAuthenticationException,
+    LLMContextLengthExceededException,
+    LLMException,
+    LLMModelNotFoundException,
+    LLMRateLimitException,
+)
 
-
-class LLMException(BaseCustomException):
-    """Base exception for LLM operations."""
-
-
-class LLMAuthenticationException(LLMException):
-    def __init__(self) -> None:
-        super().__init__(
-            status_code=401,
-            message="LLM API authentication failed",
-            error_code="LLM_AUTH_FAILED",
-        )
-
-
-class LLMRateLimitException(LLMException):
-    def __init__(self) -> None:
-        super().__init__(
-            status_code=429,
-            message="LLM API rate limit exceeded",
-            error_code="LLM_RATE_LIMITED",
-        )
-
-
-class LLMModelNotFoundException(LLMException):
-    def __init__(self, model_id: str = "") -> None:
-        msg = f"LLM model not found: {model_id}" if model_id else "LLM model not found"
-        super().__init__(
-            status_code=404,
-            message=msg,
-            error_code="LLM_MODEL_NOT_FOUND",
-        )
-
-
-class LLMContextLengthExceededException(LLMException):
-    def __init__(self, tokens: int = 0, max_tokens: int = 0) -> None:
-        msg = (
-            f"LLM context length exceeded: {tokens} tokens (max {max_tokens})"
-            if tokens
-            else "LLM context length exceeded"
-        )
-        super().__init__(
-            status_code=400,
-            message=msg,
-            error_code="LLM_CONTEXT_LENGTH_EXCEEDED",
-        )
+__all__ = [
+    "LLMAuthenticationException",
+    "LLMContextLengthExceededException",
+    "LLMException",
+    "LLMModelNotFoundException",
+    "LLMRateLimitException",
+]

--- a/src/_core/infrastructure/persistence/nosql/dynamodb/dynamodb_client.py
+++ b/src/_core/infrastructure/persistence/nosql/dynamodb/dynamodb_client.py
@@ -4,6 +4,10 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
+import structlog
+
+_logger = structlog.stdlib.get_logger(__name__)
+
 from src._core.infrastructure.persistence.nosql.dynamodb.exceptions import (
     DynamoDBConditionFailedException,
     DynamoDBException,
@@ -74,12 +78,17 @@ class DynamoDBClient:
             error_message = e.response.get("Error", {}).get("Message", str(e))
 
             if error_code == "ConditionalCheckFailedException":
-                raise DynamoDBConditionFailedException(error_message)
+                raise DynamoDBConditionFailedException(error_code) from e
             if error_code in _THROTTLE_CODES:
-                raise DynamoDBThrottlingException()
+                raise DynamoDBThrottlingException() from e
 
+            _logger.error(
+                "dynamodb_operation_failed",
+                error_code=error_code,
+                error_message=error_message,
+            )
             raise DynamoDBException(
                 status_code=500,
-                message=f"DynamoDB operation failed [{error_code}]: {error_message}",
+                message=f"DynamoDB operation failed [{error_code}]",
                 error_code="DYNAMODB_ERROR",
-            )
+            ) from e

--- a/src/_core/infrastructure/persistence/rdb/database.py
+++ b/src/_core/infrastructure/persistence/rdb/database.py
@@ -197,11 +197,13 @@ class Database:
         except Exception as e:
             if session:
                 await session.rollback()
+            from src._core.config import settings
+
             raise DatabaseException(
                 status_code=500,
                 message="Internal database error",
                 error_code="DB_INTERNAL_ERROR",
-                details={"original_error": str(e)},
+                details={"original_error": str(e)} if settings.is_dev else None,
             )
         finally:
             if session:
@@ -217,9 +219,11 @@ class Database:
                 await conn.execute(text("SELECT 1"))
                 return True
         except Exception as e:
+            from src._core.config import settings
+
             raise DatabaseException(
                 status_code=503,
                 message="Database health check failed",
                 error_code="DATABASE_UNHEALTHY",
-                details={"original_error": str(e)},
+                details={"original_error": str(e)} if settings.is_dev else None,
             )

--- a/src/_core/infrastructure/vectors/s3/client.py
+++ b/src/_core/infrastructure/vectors/s3/client.py
@@ -4,6 +4,10 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
+import structlog
+
+_logger = structlog.stdlib.get_logger(__name__)
+
 from src._core.infrastructure.vectors.s3.exceptions import (
     S3VectorException,
     S3VectorIndexNotFoundException,
@@ -73,11 +77,13 @@ class S3VectorClient:
             if error_code == "TooManyRequestsException":
                 raise S3VectorThrottlingException() from e
 
+            _logger.error(
+                "s3vectors_operation_failed",
+                error_code=error_code,
+                error_message=error_message,
+            )
             raise S3VectorException(
                 status_code=500,
-                message="S3 Vectors operation failed ["
-                + error_code
-                + "]: "
-                + error_message,
+                message=f"S3 Vectors operation failed [{error_code}]",
                 error_code="S3VECTOR_OPERATION_FAILED",
             ) from e

--- a/src/classification/domain/services/classification_service.py
+++ b/src/classification/domain/services/classification_service.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 from typing import Any
 
+from src._core.common.llm_utils import map_llm_error
+from src._core.exceptions.base_exception import BaseCustomException
 from src.classification.domain.dtos.classification_dto import ClassificationDTO
-from src.classification.domain.exceptions.classification_exceptions import (
-    ClassificationFailedException,
-)
 
 
 class ClassificationService:
@@ -60,5 +59,7 @@ class ClassificationService:
         try:
             result = await self._agent.run(prompt)
             return result.output
+        except BaseCustomException:
+            raise
         except Exception as exc:
-            raise ClassificationFailedException(str(exc)) from exc
+            map_llm_error(exc)

--- a/src/classification/interface/server/schemas/classification_schema.py
+++ b/src/classification/interface/server/schemas/classification_schema.py
@@ -1,15 +1,21 @@
+from typing import Annotated
+
 from pydantic import Field
 
 from src._core.application.dtos.base_request import BaseRequest
 from src._core.application.dtos.base_response import BaseResponse
 
+_Category = Annotated[str, Field(min_length=1, max_length=100)]
+
 
 class ClassifyRequest(BaseRequest):
     """Request schema for text classification."""
 
-    text: str = Field(..., min_length=1, description="Text to classify")
-    categories: list[str] | None = Field(
-        default=None, description="Allowed categories (optional)"
+    text: str = Field(
+        ..., min_length=1, max_length=50_000, description="Text to classify"
+    )
+    categories: list[_Category] | None = Field(
+        default=None, max_length=50, description="Allowed categories (optional)"
     )
 
 

--- a/src/docs/domain/services/docs_query_service.py
+++ b/src/docs/domain/services/docs_query_service.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from src._core.common.llm_utils import map_llm_error
 from src._core.domain.dtos.rag import BaseChunkDTO, QueryAnswerDTO
 from src._core.domain.services.rag_pipeline import RagPipeline
-from src.docs.domain.exceptions.docs_exceptions import QueryFailedException
+from src._core.exceptions.base_exception import BaseCustomException
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +34,9 @@ class DocsQueryService:
             answer, chunks = await self._pipeline.answer(
                 question=question, top_k=top_k, filters=filters
             )
+        except BaseCustomException:
+            raise
         except Exception as exc:
             logger.exception("Docs query failed")
-            raise QueryFailedException(str(exc)) from exc
+            map_llm_error(exc)
         return answer, len(chunks)

--- a/src/docs/domain/services/document_service.py
+++ b/src/docs/domain/services/document_service.py
@@ -10,6 +10,7 @@ from src._core.domain.protocols.embedding_protocol import BaseEmbeddingProtocol
 from src._core.domain.protocols.vector_store_protocol import BaseVectorStoreProtocol
 from src._core.domain.services.base_service import BaseService
 from src._core.domain.value_objects.vector_query import VectorQuery
+from src._core.exceptions.base_exception import BaseCustomException
 from src.docs.domain.dtos.document_dto import DocumentDTO
 from src.docs.domain.exceptions.docs_exceptions import IngestionFailedException
 from src.docs.domain.protocols.document_repository_protocol import (
@@ -60,7 +61,9 @@ class DocumentService(
             logger.exception("Docs ingestion failed for document %s", created.id)
             # Best-effort cleanup so the caller does not see a phantom row.
             await self._document_repository.delete_data_by_data_id(data_id=created.id)
-            raise IngestionFailedException(str(exc)) from exc
+            if isinstance(exc, BaseCustomException):
+                raise
+            raise IngestionFailedException("ingestion pipeline error") from exc
 
         if chunk_count != created.chunk_count:
             created = await super().update_data_by_data_id(

--- a/src/docs/interface/server/routers/docs_router.py
+++ b/src/docs/interface/server/routers/docs_router.py
@@ -57,8 +57,8 @@ async def create_document(
 )
 @inject
 async def list_documents(
-    page: int = 1,
-    page_size: int = Query(10, alias="pageSize"),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(10, alias="pageSize", ge=1, le=100),
     document_service: DocumentService = Depends(
         Provide[DocsContainer.document_service]
     ),

--- a/src/docs/interface/server/schemas/docs_schema.py
+++ b/src/docs/interface/server/schemas/docs_schema.py
@@ -15,13 +15,13 @@ from src._core.application.dtos.base_response import BaseResponse
 
 class CreateDocumentRequest(BaseRequest):
     title: str = Field(..., min_length=1, max_length=255)
-    content: str = Field(..., min_length=1)
+    content: str = Field(..., min_length=1, max_length=1_000_000)
     source: str | None = Field(default=None, max_length=1024)
 
 
 class UpdateDocumentRequest(BaseRequest):
     title: str | None = Field(default=None, max_length=255)
-    content: str | None = Field(default=None)
+    content: str | None = Field(default=None, max_length=1_000_000)
     source: str | None = Field(default=None, max_length=1024)
     chunk_count: int | None = Field(default=None, ge=0)
 
@@ -42,7 +42,9 @@ class DocumentResponse(BaseResponse):
 
 
 class QueryRequest(BaseRequest):
-    question: str = Field(..., min_length=1, description="User question")
+    question: str = Field(
+        ..., min_length=1, max_length=2_000, description="User question"
+    )
     top_k: int = Field(default=5, ge=1, le=50, description="Chunks to retrieve")
     filters: dict[str, Any] | None = Field(
         default=None,

--- a/src/user/interface/server/routers/user_router.py
+++ b/src/user/interface/server/routers/user_router.py
@@ -61,8 +61,8 @@ async def create_users(
 )
 @inject
 async def get_user(
-    page: int = 1,
-    page_size: int = Query(10, alias="pageSize"),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(10, alias="pageSize", ge=1, le=100),
     user_service: UserService = Depends(Provide[UserContainer.user_service]),
 ) -> SuccessResponse[list[UserResponse]]:
     datas, pagination = await user_service.get_datas(page=page, page_size=page_size)

--- a/tests/unit/docs/domain/test_docs_query_service.py
+++ b/tests/unit/docs/domain/test_docs_query_service.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from src._core.domain.dtos.rag import BaseChunkDTO, QueryAnswerDTO
-from src.docs.domain.exceptions.docs_exceptions import QueryFailedException
+from src._core.exceptions.llm_exceptions import LLMException
 from src.docs.domain.services.docs_query_service import DocsQueryService
 
 
@@ -39,8 +39,9 @@ async def test_answer_question_wraps_exception():
 
     service = DocsQueryService(rag_pipeline=pipeline)
 
-    with pytest.raises(QueryFailedException, match="boom"):
+    with pytest.raises(LLMException) as exc_info:
         await service.answer_question(question="q")
+    assert "boom" not in str(exc_info.value)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

OWASP-based security audit (`/security-review all`) on the v0.4.0 codebase. Fixes 9 findings across HIGH and MEDIUM severity. Excluded from this PR: F1 (JWT — tracked in #4), F2 (CORS — deployment flexibility), F12 (DB SSL — optional per infra).

- **F3 (HIGH)** — `admin_storage_secret` now uses `default_factory=secrets.token_urlsafe(32)`; stg/prod require explicit `ADMIN_STORAGE_SECRET` via `model_fields_set` check
- **F4 (HIGH)** — New `_core/exceptions/llm_exceptions.py` + `_core/common/llm_utils.py`; `map_llm_error()` rewraps all provider exceptions into typed LLM exceptions without leaking raw error text; classification and docs query services updated
- **F5/F10 (HIGH/MEDIUM)** — Embedding adapter sanitizes generic error message; adds Bedrock 50k-char input guard and `ThrottlingException` ClientError detection
- **F6 (HIGH)** — `database.py` gates `original_error` details behind `settings.is_dev` (SQL/schema text no longer leaks in stg/prod)
- **F7/F13 (MEDIUM/LOW)** — `max_length` bounds on classification `text`/`categories` and docs `content`/`question` fields
- **F8 (MEDIUM)** — `page`/`page_size` Query params enforce `ge=1`/`le=100` in user and docs routers
- **F9 (MEDIUM)** — `_validate_environment_safety` blocks localhost `DYNAMODB_ENDPOINT_URL` in stg/prod
- **F11 (MEDIUM)** — DynamoDB and S3 Vectors clients log raw AWS error via structlog; user-facing exceptions expose only `[error_code]`

## Deferred (follow-up issues)

- F14: ID enumeration oracle — defer until JWT (#4) is introduced
- F15: Storage upload validation hooks — defer until File Upload feature
- F16: RAG indirect prompt injection — chunk wrapping in `<context>` tags

## Test plan

- [x] `pytest tests/ -v` → 259 passed, 18 skipped
- [x] `pre-commit run --all-files` → all hooks passed
- [x] Domain → Infrastructure import prohibition hook passed
- [x] `LLMException` raised (not raw provider error) on unknown LLM failures
- [x] `"boom"` not present in `LLMException` message (error sanitization verified)