### PR TITLE
docs: restructure quality gate skills as unified review flow

### DIFF
--- a/.agents/skills/review-architecture/SKILL.md
+++ b/.agents/skills/review-architecture/SKILL.md
@@ -8,8 +8,8 @@ metadata:
 # Review Architecture
 
 1. Read `AGENTS.md` and `docs/ai/shared/skills/review-architecture.md` for the full procedure.
-2. Read `docs/ai/shared/architecture-review-checklist.md` for the detailed checklist.
-3. Decide whether to scan one domain or all domains.
-4. Apply the checklist category by category (8 categories, 28+ items).
-5. Report findings with severity and actionable fixes.
-6. When no findings exist, say so explicitly.
+2. Read `docs/ai/shared/architecture-review-checklist.md` and `docs/ai/shared/project-dna.md` as the shared architecture rule sources.
+3. Resolve the audit target and load the shared rule sources (Phase 0).
+4. Audit the target against the 9 architecture checklist categories (Phase 1).
+5. Determine `Drift Candidates` and whether `Sync Required` is `true` or `false` (Phase 2).
+6. Report using the shared review contract: `Scope`, `Sources Loaded`, `Findings`, `Drift Candidates`, `Next Actions`, `Completion State`, `Sync Required` (Phase 3).

--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -8,8 +8,9 @@ metadata:
 # Review PR
 
 1. Read `AGENTS.md` and `docs/ai/shared/skills/review-pr.md` for the full procedure.
-2. Read `docs/ai/shared/architecture-review-checklist.md` and `docs/ai/shared/security-checklist.md`.
-3. Resolve the review target (PR number, URL, or current branch diff).
-4. Limit the review to changed files, inspecting surrounding context when needed.
-5. Prioritize: blocking bugs > architecture violations > security risks > missing tests.
-6. Output findings with file/line references, then summarize.
+2. Read `docs/ai/shared/architecture-review-checklist.md`, `docs/ai/shared/security-checklist.md`, and `docs/ai/shared/project-dna.md` as shared rule sources.
+3. Resolve the review target and load the shared rule sources (Phase 0).
+4. Review changed files against the shared architecture and security rules (Phase 1).
+5. Determine `Drift Candidates` and whether `Sync Required` is `true` or `false` (Phase 2).
+6. Report using the shared review contract: `Scope`, `Sources Loaded`, `Findings`, `Drift Candidates`, `Next Actions`, `Completion State`, `Sync Required` (Phase 3).
+7. Optionally post the final review after user confirmation (Phase 4).

--- a/.agents/skills/security-review/SKILL.md
+++ b/.agents/skills/security-review/SKILL.md
@@ -8,7 +8,8 @@ metadata:
 # Security Review
 
 1. Read `AGENTS.md` and `docs/ai/shared/skills/security-review.md` for the full procedure.
-2. Read `docs/ai/shared/security-checklist.md` for the detailed checklist.
-3. Choose the scope: file, domain, or all.
-4. Run the checklist with conditional checks only when the related feature is in use.
-5. Report file/line references, severity, and concrete mitigations.
+2. Read `docs/ai/shared/security-checklist.md` and `docs/ai/shared/project-dna.md` as the shared security rule sources.
+3. Resolve the audit scope and run the feature-detection / reference-freshness preflight (Phase 0).
+4. Audit the target against the 12 security checklist categories using the shared applicability rules (Phase 1).
+5. Determine stale-reference drift, other `Drift Candidates`, and whether `Sync Required` is `true` or `false` (Phase 2).
+6. Report using the shared review contract: `Scope`, `Sources Loaded`, `Findings`, `Drift Candidates`, `Next Actions`, `Completion State`, `Sync Required` (Phase 3).

--- a/.agents/skills/sync-guidelines/SKILL.md
+++ b/.agents/skills/sync-guidelines/SKILL.md
@@ -7,20 +7,9 @@ metadata:
 
 # Sync Guidelines
 
-## Procedure Overview
-1. Reference code analysis — read `src/user/` for current patterns
-2. Code ↔ Documentation consistency check — `AGENTS.md`, shared refs, harness docs, skills, `.claude/rules/` (Phase 1-3)
-3. `project-dna.md` regeneration — extract from code and update when drift exists (Phase 4)
-4. References drift inspection — report both `AUTO-FIX` and `REVIEW` targets (Phase 5)
-
-Read `AGENTS.md` and `docs/ai/shared/skills/sync-guidelines.md` for the full procedure.
-Also refer to `docs/ai/shared/drift-checklist.md` for detailed inspection items.
-
-## Completion Contract
-`$sync-guidelines` is not complete until the result explicitly reports all of:
-- `project-dna` — regenerated or confirmed unchanged
-- `AUTO-FIX` — automatic drift targets and whether they were applied
-- `REVIEW` — human-review targets and why they need review, or `none`
-- `Remaining` — unresolved drift items, or `none`
-
-If any `REVIEW` item exists, do not close with “nothing to change” or equivalent wording.
+1. Read `AGENTS.md` and `docs/ai/shared/skills/sync-guidelines.md` for the full procedure.
+   Also refer to `docs/ai/shared/drift-checklist.md` for detailed inspection items.
+2. Determine the sync mode, gather incoming `Drift Candidates`, and load the governing sources (Phase 0).
+3. Reconcile drift candidates with code, shared references, harness docs, and wrappers (Phase 1).
+4. Refresh `project-dna` and dependent shared references as needed (Phase 2).
+5. Verify Hybrid C parity for both Claude and Codex wrappers, then close with the sync contract (Phase 3).

--- a/.claude/skills/review-architecture/SKILL.md
+++ b/.claude/skills/review-architecture/SKILL.md
@@ -12,9 +12,10 @@ description: |
 Target: $ARGUMENTS (domain name or "all")
 
 ## Procedure Overview
-1. Identify audit target — single domain or all domains
-2. Run 8-category checklist — layer deps, conversions, DTO integrity, DI, tests, worker, admin, bootstrap
-3. Report — PASS/FAIL per item with recommended actions
+1. Resolve the audit target and load the shared rule sources (Phase 0)
+2. Audit the target against the 9 architecture checklist categories (Phase 1)
+3. Determine `Drift Candidates` and whether `Sync Required` is `true` or `false` (Phase 2)
+4. Report using the shared review contract (Phase 3)
 
 Read `docs/ai/shared/skills/review-architecture.md` for detailed steps and output format.
 Also refer to `docs/ai/shared/architecture-review-checklist.md` for the full checklist.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -12,12 +12,15 @@ description: |
 Target: $ARGUMENTS (PR number, GitHub URL, or empty for current branch)
 
 ## Procedure Overview
-1. Resolve PR & collect rules — load architecture/security checklists (Phase 0)
-2. Apply rules to PR diff — check per layer, assign severity (Phase 1)
-3. Report — BLOCKING/SUGGESTION/PASS findings (Phase 2)
-4. Post to GitHub — optional, after user confirmation (Phase 3)
+1. Resolve PR and load shared rule sources (Phase 0)
+2. Review changed files against shared architecture and security rules (Phase 1)
+3. Determine `Drift Candidates` and whether `Sync Required` is `true` or `false` (Phase 2)
+4. Report using the shared review contract (Phase 3)
+5. Post to GitHub only after user confirmation (Phase 4)
 
 Read `docs/ai/shared/skills/review-pr.md` for detailed steps and output format.
 
 ## Claude-Specific: Rule Sources
-Also load `.claude/rules/architecture-conventions.md` for additional DO/DON'T context.
+You may cross-check the final wording against `.claude/rules/architecture-conventions.md`,
+but do not create findings that are not already backed by the shared rule
+sources loaded in `docs/ai/shared/skills/review-pr.md`.

--- a/.claude/skills/security-review/SKILL.md
+++ b/.claude/skills/security-review/SKILL.md
@@ -12,10 +12,10 @@ description: |
 Target: $ARGUMENTS (domain name, file path, or "all")
 
 ## Procedure Overview
-1. Identify audit scope — file, domain, or all
-2. Run 8-category security checklist — injection, auth, data protection, input validation, config, errors, worker, S3
-3. Apply conditional checks — [Always] items run unconditionally, [When applicable] items check feature usage first
-4. Report — severity-rated findings with file/line references and mitigations
+1. Resolve the audit scope and run the feature-detection / reference-freshness preflight (Phase 0)
+2. Audit the target against the 12 security checklist categories (Phase 1)
+3. Determine stale-reference drift, other `Drift Candidates`, and whether `Sync Required` is `true` or `false` (Phase 2)
+4. Report using the shared review contract (Phase 3)
 
 Read `docs/ai/shared/skills/security-review.md` for detailed steps and output format.
 Also refer to `docs/ai/shared/security-checklist.md` for the full checklist.

--- a/.claude/skills/sync-guidelines/SKILL.md
+++ b/.claude/skills/sync-guidelines/SKILL.md
@@ -11,17 +11,21 @@ description: |
 # Guideline Synchronization Inspection
 
 ## Procedure Overview
-1. Reference code analysis — read `src/user/` for current patterns
-2. Code ↔ Documentation consistency check — AGENTS.md, shared refs, harness docs, skills, `.claude/rules/` (Phase 1-3)
-3. project-dna.md regeneration — extract from code and update (Phase 4)
-4. References drift inspection — AUTO-FIX and REVIEW targets (Phase 5)
+1. Determine the sync mode, gather incoming `Drift Candidates`, and load the governing sources (Phase 0)
+2. Reconcile drift candidates with code, shared references, harness docs, and wrappers (Phase 1)
+3. Refresh `project-dna` and dependent shared references as needed (Phase 2)
+4. Verify Hybrid C parity for both Claude and Codex wrappers, then close with the sync contract (Phase 3)
 
 Read `docs/ai/shared/skills/sync-guidelines.md` for detailed steps.
 Also refer to `docs/ai/shared/drift-checklist.md` for inspection items.
 
-Closing summary must include: `project-dna`, `AUTO-FIX`, `REVIEW`, `Remaining` — see "Sync Completion Contract" in shared procedure.
+Closing summary must include: `Mode`, `Input Drift Candidates`, `project-dna`, `AUTO-FIX`, `REVIEW`, `Remaining`, `Next Actions` - see "Sync Contract" in the shared procedure.
 
 ## Claude-Specific Post-Steps
+
+> This is a Claude-harness post-step.
+> Codex may not have an equivalent post-step unless Codex-specific harness assets also require synchronization.
+
 After completing the shared procedure:
 1. Update `.claude/rules/architecture-conventions.md`
    (data flow, object roles, generic signatures changes)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,13 +25,23 @@ This file intentionally keeps only Claude-specific setup and workflow guidance.
 - `/add-admin-page {domain}` — Add NiceGUI admin page to existing domain
 - `/add-cross-domain from:{a} to:{b}` — Wire cross-domain dependency
 - `/review-architecture {domain|all}` — Architecture compliance audit
-- `/security-review {domain|file|all}` — OWASP-based code security audit
+- `/security-review {domain|file|all}` — Security quality-gate audit with feature-freshness preflight
 - `/test-domain {domain} [generate|run]` — Generate or run tests
 - `/fix-bug {description}` — Structured bug-fix workflow
-- `/review-pr {number|URL}` — Architecture-aware PR review (existing rules applied to PR diff)
-- `/sync-guidelines` — Synchronize guidelines after design changes + regenerate project-dna.md
+- `/review-pr {number|URL}` — PR quality-gate review with drift-candidate detection
+- `/sync-guidelines` — Close the quality gate after design changes or review-detected drift
 - `/migrate-domain {generate|upgrade|downgrade|status}` — Alembic migration management
 - `/onboard` — Interactive onboarding for new members (project structure → rules → workflow)
+
+## Quality Gate Flow
+- Start with `/review-pr` for change-scoped review or `/review-architecture` for domain/full-repo structure audits.
+- Run `/security-review` when the change touches security-sensitive surfaces — see `docs/ai/shared/skills/security-review.md` §"When to Use" for the canonical trigger list.
+- If any review reports `Drift Candidates` or `Sync Required: true`, close the work with `/sync-guidelines` before treating the review as complete.
+- `/sync-guidelines` is the closure step for shared docs, `project-dna.md`, skill wrappers, and Claude-specific rules that depend on shared references.
+
+> Review output contract: `/review-pr`, `/review-architecture`, `/security-review` each emit
+> `Scope / Sources Loaded / Findings / Drift Candidates / Next Actions / Completion State / Sync Required`.
+> `/sync-guidelines` uses a separate terminal contract: `Mode / Input Drift Candidates / project-dna / AUTO-FIX / REVIEW / Remaining / Next Actions`.
 
 ## Domain Auto-discovery
 - `discover_domains()` in `src/_core/infrastructure/discovery.py` auto-detects domains

--- a/docs/ai/shared/architecture-review-checklist.md
+++ b/docs/ai/shared/architecture-review-checklist.md
@@ -1,6 +1,9 @@
 # Architecture Audit Checklist Details
 
 > Refer to `docs/ai/shared/project-dna.md` for detailed definitions of expected patterns.
+> This checklist covers code-auditable architecture rules. The shared-rule-source
+> cross-reference rule stays in `AGENTS.md` and harness docs because it is a
+> process safeguard, not a code grep target.
 
 ## 1. Layer Dependency Rules
 Grep-check Python files in each domain:
@@ -16,6 +19,7 @@ Check across all domain files:
 
 - [ ] No `class.*Mapper` class definitions
 - [ ] No Entity pattern remnants (`to_entity(`, `from_entity(`, `Entity` class definitions)
+- [ ] Persistence models (`Model`, `DynamoModel`, `VectorModel`) are not imported or exposed outside Repository / VectorStore layers
 - [ ] Repository method return values are DTO types (no Model object exposure)
 - [ ] Model -> DTO conversion uses `model_validate(..., from_attributes=True)`
 - [ ] Service classes use 3 TypeVars: `BaseService[Create{Name}Request, Update{Name}Request, {Name}DTO]` (not `BaseService[{Name}DTO]`)

--- a/docs/ai/shared/architecture-review-checklist.md
+++ b/docs/ai/shared/architecture-review-checklist.md
@@ -1,93 +1,107 @@
 # Architecture Audit Checklist Details
 
-> Refer to `docs/ai/shared/project-dna.md` for detailed definitions of expected patterns.
-> This checklist covers code-auditable architecture rules. The shared-rule-source
-> cross-reference rule stays in `AGENTS.md` and harness docs because it is a
-> process safeguard, not a code grep target.
+> Refer to `docs/ai/shared/project-dna.md` for expected patterns.
+> This checklist defines architecture findings for `/review-architecture` and
+> `/review-pr`.
+>
+> Taxonomy:
+> - Rule type: every item below is a `code-auditable rule`
+> - Review state is assigned by the review procedure: `OPEN`, `OK`, `SKIP`
+> - Severity is declared here: `BLOCKING`, `HIGH`, `MEDIUM`, `LOW`, `NOTE`
+>
+> The shared-rule-source cross-reference safeguard remains in `AGENTS.md` and
+> harness docs because it is a process rule, not a code-grep rule.
 
 ## 1. Layer Dependency Rules
-Grep-check Python files in each domain:
 
-- [ ] No `from src.{name}.infrastructure` imports in `src/{name}/domain/` files
-- [ ] No `from src.{name}.interface` imports in `src/{name}/domain/` files — **except** `schemas/` (Request types are passed directly when fields match, per AGENTS.md Write DTO criteria)
-- [ ] No `from src.{name}.infrastructure` imports in `src/{name}/application/` files (excluding DI)
-- [ ] No `from sqlalchemy` imports in `src/{name}/domain/` files
-- [ ] No `from dependency_injector` imports in `src/{name}/domain/` files
+Grep-check Python files in each domain.
+
+- [ ] [BLOCKING] No `from src.{name}.infrastructure` imports in `src/{name}/domain/` files
+- [ ] [BLOCKING] No `from src.{name}.interface` imports in `src/{name}/domain/` files, except `schemas/`
+- [ ] [BLOCKING] No `from src.{name}.infrastructure` imports in `src/{name}/application/` files, excluding DI-only wiring
+- [ ] [BLOCKING] No `from sqlalchemy` imports in `src/{name}/domain/` files
+- [ ] [HIGH] No `from dependency_injector` imports in `src/{name}/domain/` files
 
 ## 2. Conversion Patterns Compliance
-Check across all domain files:
 
-- [ ] No `class.*Mapper` class definitions
-- [ ] No Entity pattern remnants (`to_entity(`, `from_entity(`, `Entity` class definitions)
-- [ ] Persistence models (`Model`, `DynamoModel`, `VectorModel`) are not imported or exposed outside Repository / VectorStore layers
-- [ ] Repository method return values are DTO types (no Model object exposure)
-- [ ] Model -> DTO conversion uses `model_validate(..., from_attributes=True)`
-- [ ] Service classes use 3 TypeVars: `BaseService[Create{Name}Request, Update{Name}Request, {Name}DTO]` (not `BaseService[{Name}DTO]`)
-- [ ] Service method overrides match parent signature types (no LSP-violating parameter narrowing)
+Check across all domain files.
 
-## 3. DTO/Response Integrity
-Check interface/server/schemas/ files:
+- [ ] [BLOCKING] No `class.*Mapper` class definitions
+- [ ] [BLOCKING] No Entity pattern remnants (`to_entity(`, `from_entity(`, `Entity` class definitions)
+- [ ] [BLOCKING] Persistence models (`Model`, `DynamoModel`, `VectorModel`) are not imported or exposed outside Repository / VectorStore layers
+- [ ] [BLOCKING] Repository method return values are DTO types, not Model objects
+- [ ] [HIGH] Model -> DTO conversion uses `model_validate(..., from_attributes=True)`
+- [ ] [HIGH] Service classes use 3 TypeVars: `BaseService[Create{Name}Request, Update{Name}Request, {Name}DTO]`
+- [ ] [HIGH] Service method overrides match parent signature types and do not narrow parameters
 
-- [ ] Response classes inherit only from `BaseResponse` (no multiple inheritance)
-- [ ] Request classes inherit only from `BaseRequest` (no multiple inheritance)
-- [ ] Sensitive fields (password, etc.) not included in Response
-- [ ] Router uses `model_dump(exclude={...})` to exclude sensitive fields
+## 3. DTO / Response Integrity
+
+Check `interface/server/schemas/` files.
+
+- [ ] [HIGH] Response classes inherit only from `BaseResponse`
+- [ ] [HIGH] Request classes inherit only from `BaseRequest`
+- [ ] [BLOCKING] Sensitive fields are not included in Response classes
+- [ ] [HIGH] Routers use `model_dump(exclude={...})` when a DTO contains sensitive data
 
 ## 4. DI Container Correctness
-Check infrastructure/di/ files (expected pattern: refer to **project-dna.md section 5**):
 
-- [ ] Container inherits from `containers.DeclarativeContainer`
-- [ ] `core_container = providers.DependenciesContainer()` declared
-- [ ] Repository uses `providers.Singleton`
-- [ ] Service uses `providers.Factory`
-- [ ] UseCase uses `providers.Factory`
+Check `infrastructure/di/` files and compare with `project-dna` section 5.
+
+- [ ] [HIGH] Container inherits from `containers.DeclarativeContainer`
+- [ ] [HIGH] `core_container = providers.DependenciesContainer()` is declared
+- [ ] [HIGH] Repository providers use `providers.Singleton`
+- [ ] [HIGH] Service providers use `providers.Factory`
+- [ ] [MEDIUM] UseCase providers use `providers.Factory`
 
 ## 5. Test Coverage
-Check tests/ directory:
 
-- [ ] `tests/factories/{name}_factory.py` exists
-- [ ] `tests/unit/{name}/domain/test_{name}_service.py` exists
-- [ ] `tests/unit/{name}/application/test_{name}_use_case.py` exists **(only when UseCase exists)**
-- [ ] `tests/integration/{name}/infrastructure/test_{name}_repository.py` exists
+Check required test paths for the audited domain.
+See `docs/ai/shared/test-files.md` for the canonical baseline and conditional file definitions.
+
+- [ ] [MEDIUM] All baseline test files exist (factories, domain service unit, repository integration)
+- [ ] [MEDIUM] Applicable conditional test files exist (use_case unit when UseCase present, e2e router when API present, admin_config when admin present)
 
 ## 6. Worker Payload Compliance
-Check interface/worker/ files:
 
-- [ ] Worker tasks validate `**kwargs` via a Payload class (not directly via domain DTO)
-- [ ] Payload classes inherit from `BasePayload` (not `BaseModel` or `BaseRequest`)
-- [ ] Payload files live in `interface/worker/payloads/` (not in domain layer)
-- [ ] When fields match: Payload passed directly to Service (same as Request pattern)
-- [ ] When fields differ: explicit DTO conversion in task
+Check `interface/worker/` files.
+
+- [ ] [HIGH] Worker tasks validate `**kwargs` via a Payload class, not directly via a domain DTO
+- [ ] [HIGH] Payload classes inherit from `BasePayload`, not `BaseModel` or `BaseRequest`
+- [ ] [MEDIUM] Payload files live in `interface/worker/payloads/`, not the domain layer
+- [ ] [LOW] When fields match, the Payload is passed directly to the Service
+- [ ] [MEDIUM] When fields differ, the task performs explicit DTO conversion
 
 ## 7. Admin Page Compliance
-Check interface/admin/ files (expected pattern: refer to **project-dna.md section 11**):
 
-- [ ] Config file exists: `src/{name}/interface/admin/configs/{name}_admin_config.py`
-- [ ] Config variable named `{name}_admin_page` (discovery convention)
-- [ ] Page file exists: `src/{name}/interface/admin/pages/{name}_page.py`
-- [ ] Page file imports config from the configs module (not defined inline)
-- [ ] No direct Service import in page file (service resolved via BaseAdminPage internally)
-  - Grep: No `from src.{name}.domain.services` in `interface/admin/pages/` files
-- [ ] `page_configs: list[BaseAdminPage] = []` declared at module level in page file
-- [ ] `require_auth()` called at the top of every `@ui.page` function
-- [ ] Sensitive fields use `masked=True` in ColumnConfig (password, secret, token)
+Check `interface/admin/` files and compare with `project-dna` section 11.
+
+- [ ] [MEDIUM] Config file exists at `src/{name}/interface/admin/configs/{name}_admin_config.py`
+- [ ] [MEDIUM] Config variable is named `{name}_admin_page`
+- [ ] [MEDIUM] Page file exists at `src/{name}/interface/admin/pages/{name}_page.py`
+- [ ] [MEDIUM] Page file imports config from the configs module instead of defining it inline
+- [ ] [HIGH] Page files do not import domain services directly
+- [ ] [MEDIUM] `page_configs: list[BaseAdminPage] = []` is declared at module level
+- [ ] Admin endpoint access restriction enforced — see security-checklist.md §2 for canonical rule and severity
+- [ ] [HIGH] Sensitive fields use `masked=True` in `ColumnConfig`
 
 ## 8. Bootstrap Wiring
-Check app-level files and auto-discovery mechanism:
 
-- [ ] `src/{name}/interface/server/bootstrap/{name}_bootstrap.py` exists
-- [ ] `src/{name}/infrastructure/di/{name}_container.py` exists (auto-discovery condition)
-- [ ] `src/{name}/__init__.py` exists (auto-discovery condition)
-- [ ] `wire(packages=[...])` call targets the correct packages
-- [ ] **Note**: `discover_domains()` handles auto-detection, so manual registration in App-level `container.py`/`bootstrap.py` is not needed (project-dna.md section 5)
+Check app-level files and auto-discovery wiring.
+
+- [ ] [MEDIUM] `src/{name}/interface/server/bootstrap/{name}_bootstrap.py` exists
+- [ ] [MEDIUM] `src/{name}/infrastructure/di/{name}_container.py` exists
+- [ ] [MEDIUM] `src/{name}/__init__.py` exists
+- [ ] [HIGH] `wire(packages=[...])` targets the correct packages
+- [ ] [NOTE] Domain discovery is automatic; manual app-level registration should not be added unless the pattern itself changes
 
 ## 9. DynamoDB Domain Compliance
-Check only when a domain uses DynamoDB (has `infrastructure/dynamodb/` directory):
 
-- [ ] DynamoDB models stored in `infrastructure/dynamodb/models/` (not `infrastructure/database/`)
-- [ ] Model inherits from `DynamoModel` (not SQLAlchemy `Base`)
-- [ ] Repository inherits from `BaseDynamoRepository[{Name}DTO]` (not `BaseRepository`)
-- [ ] Service inherits from `BaseDynamoService[Create{Name}Request, Update{Name}Request, {Name}DTO]` (not `BaseService`)
-- [ ] DI Container uses `dynamodb_client=core_container.dynamodb_client` (not `database=core_container.database`)
-- [ ] No `from sqlalchemy` imports in DynamoDB domain files
-- [ ] Protocol inherits from `BaseDynamoRepositoryProtocol[{Name}DTO]` (not `BaseRepositoryProtocol`)
+Check only when a domain uses DynamoDB (`infrastructure/dynamodb/` exists).
+
+- [ ] [HIGH] DynamoDB models live in `infrastructure/dynamodb/models/`
+- [ ] [HIGH] DynamoDB models inherit from `DynamoModel`, not SQLAlchemy `Base`
+- [ ] [HIGH] Repository inherits from `BaseDynamoRepository[{Name}DTO]`, not `BaseRepository`
+- [ ] [HIGH] Service inherits from `BaseDynamoService[Create{Name}Request, Update{Name}Request, {Name}DTO]`, not `BaseService`
+- [ ] [HIGH] DI container uses `dynamodb_client=core_container.dynamodb_client`, not `database=core_container.database`
+- [ ] [BLOCKING] No `from sqlalchemy` imports remain in DynamoDB domain files
+- [ ] [HIGH] Protocol inherits from `BaseDynamoRepositoryProtocol[{Name}DTO]`, not `BaseRepositoryProtocol`

--- a/docs/ai/shared/drift-checklist.md
+++ b/docs/ai/shared/drift-checklist.md
@@ -1,5 +1,13 @@
 # Guideline Synchronization Inspection Items (Detailed)
 
+> This checklist defines drift work for `/sync-guidelines`.
+>
+> Taxonomy:
+> - `AUTO-FIX` = auto-fixable drift that can be updated mechanically
+> - `REVIEW` = policy-review drift that needs human judgment
+> - `DRIFT` = unresolved mismatch discovered during inspection
+> - `OK` = verified and aligned
+
 ## 1. AGENTS.md ↔ Code Consistency Check
 
 Read AGENTS.md and compare each section against the actual code:
@@ -150,8 +158,8 @@ Inspect whether `docs/ai/shared/` documents match the current code.
 
 - [ ] **Phase count consistency**:
   - Count Phase/Step headings in `docs/ai/shared/skills/{name}.md`
-  - Count Phase/Step overview items in `.claude/skills/{name}/SKILL.md` wrapper
-  - On mismatch: flag as [DRIFT] — shared procedure may have been updated without updating the wrapper overview
+  - Count Phase/Step overview items in both `.claude/skills/{name}/SKILL.md` and `.agents/skills/{name}/SKILL.md`
+  - On mismatch: flag as [DRIFT] — shared procedure may have been updated without updating one or both wrappers
 
 - [ ] **No tool-specific instructions in shared procedure**:
   - Grep `docs/ai/shared/skills/*.md` for `.claude/rules/`, `.claude/skills/`, `.agents/skills/`
@@ -167,6 +175,15 @@ Inspect whether `docs/ai/shared/` documents match the current code.
 
 - [ ] **`security-review` security checklist** (`docs/ai/shared/security-checklist.md`):
   - Extract the "active" feature list from `docs/ai/shared/project-dna.md` §8
-  - Extract the feature list from items marked `[when applicable]` in `docs/ai/shared/security-checklist.md`
-  - Check whether security inspection items exist for newly activated features
+  - Extract the feature list from items marked `[When applicable]` in `docs/ai/shared/security-checklist.md`
+  - Check whether security inspection items exist for newly activated features and whether the live code differs from `project-dna`
   - On uncovered features: confirm with the user whether security inspection items need to be added for those features
+
+## 6. Quality Gate Scenarios
+
+Use these scenario checks when validating the redesigned workflow:
+
+- [ ] Architecture-changing PR -> `/review-pr` should produce findings and/or drift candidates, and `/sync-guidelines` should be required before closure
+- [ ] Security feature active in code but stale in `project-dna` -> `/security-review` should continue auditing and report stale-reference drift instead of ending in `SKIP`
+- [ ] Shared procedure changed without wrapper updates -> `/sync-guidelines` should detect Hybrid C drift for both Claude and Codex wrappers
+- [ ] Docs-only checklist meaning change -> `/sync-guidelines` should classify it as `REVIEW`, not a silent `AUTO-FIX`

--- a/docs/ai/shared/drift-checklist.md
+++ b/docs/ai/shared/drift-checklist.md
@@ -161,8 +161,9 @@ Inspect whether `docs/ai/shared/` documents match the current code.
 ### Manual Inspection (Change-history-based — [REVIEW] targets)
 
 - [ ] **`review-architecture` checklist** (`docs/ai/shared/architecture-review-checklist.md`):
-  - Count the items in AGENTS.md's "Absolute Prohibitions" section (expected: 5) and compare against the number of related inspection items in `docs/ai/shared/architecture-review-checklist.md`
-  - On mismatch: confirm with the user whether Grep patterns need to be added for new rules
+  - Compare the **code-auditable** Absolute Prohibitions in AGENTS.md against the related inspection items in `docs/ai/shared/architecture-review-checklist.md`
+  - Exclude the "No modifying or deleting shared rule sources without cross-reference verification" rule from this count; it remains in AGENTS.md / harness docs because it is process-oriented rather than a code-audit grep target
+  - On mismatch: confirm with the user whether checklist coverage should be expanded for any newly code-auditable rule
 
 - [ ] **`security-review` security checklist** (`docs/ai/shared/security-checklist.md`):
   - Extract the "active" feature list from `docs/ai/shared/project-dna.md` §8

--- a/docs/ai/shared/planning-checklists.md
+++ b/docs/ai/shared/planning-checklists.md
@@ -83,16 +83,16 @@
 | Async task | `/add-worker-task` | `{domain} {task_name}` | Add UseCase method first if needed |
 | Admin page addition | `/add-admin-page` | `{domain}` | Auto-discovers, no bootstrap changes needed |
 | Cross-domain connection | `/add-cross-domain` | `from:{consumer} to:{provider}` | Protocol-based DIP |
-| Test generation | `/test-domain` | `{domain} generate` | 5 required test files |
+| Test generation | `/test-domain` | `{domain} generate` | baseline + conditional test files (see `docs/ai/shared/test-files.md`) |
 | Test execution | `/test-domain` | `{domain} run` | unit + integration + e2e |
-| Architecture verification | `/review-architecture` | `{domain}` or `all` | 20+ item inspection |
-| Security audit | `/security-review` | `{domain}`, `{file}`, or `all` | OWASP 8 categories, 32+ items |
-| Guideline sync | `/sync-guidelines` | (none) | Run after design changes |
+| Architecture verification | `/review-architecture` | `{domain}` or `all` | 9 categories, severity-tagged architecture audit |
+| Security audit | `/security-review` | `{domain}`, `{file}`, or `all` | 12 categories, feature-freshness preflight, stale-drift detection |
+| Guideline sync | `/sync-guidelines` | (none) | Close the quality gate after design changes or review drift |
 | Bug fix | `/fix-bug` | `"{description}"` | Reproduce -> Trace -> Fix -> Verify |
 | DB migration | `/migrate-domain` | `generate\|upgrade\|downgrade\|status` | Manual review required after autogenerate |
 | New member onboarding | `/onboard` | (none) | Experience-level adaptive (Beginner/Intermediate/Advanced) |
 | Sub-feature design | `/plan-feature` | `"{description}"` | Recursive use when splitting large features |
-| PR review | `/review-pr` | `{number\|URL}` | Architecture-aware review against project rules |
+| PR review | `/review-pr` | `{number\|URL}` | Diff review + drift candidates + explicit sync-required decision |
 | DynamoDB migration | `python -m migrations.dynamodb.cli --env {env}` | — | DynamoDB table/GSI creation (manual CLI) |
 | **Unmappable** items | Manual implementation | — | External API integrations, middleware, etc. |
 

--- a/docs/ai/shared/planning-checklists.md
+++ b/docs/ai/shared/planning-checklists.md
@@ -83,7 +83,7 @@
 | Async task | `/add-worker-task` | `{domain} {task_name}` | Add UseCase method first if needed |
 | Admin page addition | `/add-admin-page` | `{domain}` | Auto-discovers, no bootstrap changes needed |
 | Cross-domain connection | `/add-cross-domain` | `from:{consumer} to:{provider}` | Protocol-based DIP |
-| Test generation | `/test-domain` | `{domain} generate` | 4 required test files |
+| Test generation | `/test-domain` | `{domain} generate` | 5 required test files |
 | Test execution | `/test-domain` | `{domain} run` | unit + integration + e2e |
 | Architecture verification | `/review-architecture` | `{domain}` or `all` | 20+ item inspection |
 | Security audit | `/security-review` | `{domain}`, `{file}`, or `all` | OWASP 8 categories, 32+ items |

--- a/docs/ai/shared/scaffolding-layers.md
+++ b/docs/ai/shared/scaffolding-layers.md
@@ -291,3 +291,5 @@ Use domain-local Protocol + Adapter when the output DTO is domain-specific (not 
 20. `tests/unit/{name}/application/test_{name}_use_case.py` — **only when UseCase exists** MockService + tests
 21. `tests/integration/{name}/infrastructure/test_{name}_repository.py` — uses test_db fixture
 22. `tests/e2e/{name}/test_{name}_router.py` — TestClient HTTP 요청 테스트
+
+> For canonical required test file definitions (baseline vs. conditional), see `docs/ai/shared/test-files.md`.

--- a/docs/ai/shared/security-checklist.md
+++ b/docs/ai/shared/security-checklist.md
@@ -1,19 +1,31 @@
 # Security Audit Checklist Details
 
-> **Classification**: `[Always]` = always check | `[When applicable]` = check only when the feature is in use (output [SKIP] when not in use)
+> This checklist defines security findings for `/security-review` and
+> `/review-pr`.
 >
-> **Automatic conditional check determination**: Whether `[When applicable]` items are active is
-> pre-determined using the "Active Features" table in `docs/ai/shared/project-dna.md` section 8.
-> `[When applicable]` items for features marked "not implemented" in section 8 are immediately [SKIP]ped without Grep.
+> Taxonomy:
+> - Rule type: every item is a `code-auditable rule` unless the item explicitly
+>   says `Manual review` or `Policy review`
+> - Review state is assigned by the review procedure: `OPEN`, `OK`, `SKIP`
+> - Severity is declared here: `BLOCKING`, `HIGH`, `MEDIUM`, `LOW`, `NOTE`
+> - Applicability uses `Always` or `When applicable`
+>
+> Applicability decision is a 2-step check:
+> 1. preflight expectation from `docs/ai/shared/project-dna.md` section 8
+> 2. live code re-detection before the review decides `SKIP`
+>
+> If live code and `project-dna` disagree, audit the feature as active when the
+> code says it is active and report the stale shared reference as a drift
+> candidate.
 
 ## 1. Injection Prevention
 
 Grep-check each target Python file:
 
 ### SQL Injection
-- [ ] [Always][CRITICAL] No `f"SELECT ` / `f"INSERT ` / `f"UPDATE ` / `f"DELETE ` patterns
+- [ ] [Always][BLOCKING] No `f"SELECT ` / `f"INSERT ` / `f"UPDATE ` / `f"DELETE ` patterns
   - Grep: `f["'].*\b(SELECT|INSERT|UPDATE|DELETE|DROP)\b`
-- [ ] [Always][CRITICAL] No `.format()` + SQL keyword combinations
+- [ ] [Always][BLOCKING] No `.format()` + SQL keyword combinations
   - Grep: `\.format\(.*\).*(SELECT|INSERT|UPDATE|DELETE)`
 - [ ] [Always][HIGH] When using `text()`, parameter binding applied (no f-string + text() combination)
   - Grep: `text\(f["']`
@@ -21,9 +33,9 @@ Grep-check each target Python file:
   - Grep: `\bexec\s*\(|\beval\s*\(`
 
 ### Command Injection
-- [ ] [Always][CRITICAL] No `subprocess.*(shell=True)` usage
+- [ ] [Always][BLOCKING] No `subprocess.*(shell=True)` usage
   - Grep: `subprocess\.\w+\(.*shell\s*=\s*True`
-- [ ] [Always][CRITICAL] No `os.system(` usage
+- [ ] [Always][BLOCKING] No `os.system(` usage
   - Grep: `os\.system\s*\(`
 - [ ] [Always][HIGH] No `os.popen(` usage
   - Grep: `os\.popen\s*\(`
@@ -38,11 +50,11 @@ Grep-check each target Python file:
 Check router files and configuration files:
 
 ### Endpoint Protection
-- [ ] [Always][CRITICAL] POST/PUT/DELETE endpoints have authentication dependency
+- [ ] [Always][BLOCKING] POST/PUT/DELETE endpoints have authentication dependency
   - Grep: `@router\.(post|put|delete|patch)` -> verify `Depends(.*auth|.*current_user|.*token)` in the function
-  - When not implemented: [FAIL] + "Authentication not implemented — must be implemented before production deployment" warning
+  - When not implemented: treat as `[OPEN][BLOCKING]` and require production-safe auth before release
 ### Admin Dashboard Security
-- [ ] [Always][HIGH] Admin endpoint access restriction verified
+- [ ] [Always][BLOCKING] Admin endpoint access restriction verified
   - Grep: Every `@ui.page("/admin/` function calls `require_auth()` before any rendering
 - [ ] [Always][HIGH] Admin authentication uses timing-safe comparison
   - Grep: Verify `hmac.compare_digest` in `src/_core/infrastructure/admin/auth.py` (not `==` for password comparison)
@@ -56,7 +68,7 @@ Check router files and configuration files:
   - Grep: No `from src.*.domain.services` in `interface/admin/pages/` files
 
 ### Credential Management
-- [ ] [Always][CRITICAL] No hardcoded password/secret/api_key/token
+- [ ] [Always][BLOCKING] No hardcoded password/secret/api_key/token
   - Grep: `(password|secret|api_key|token)\s*=\s*["'][^"']{3,}["']`
   - Exclude: Field(), os.environ, settings., getenv, test files
 - [ ] [When applicable][HIGH] JWT configuration verified
@@ -74,7 +86,7 @@ Check router files and configuration files:
 Check DTO, Response, and log files:
 
 ### PII Exposure Prevention
-- [ ] [Always][CRITICAL] Response DTO does not contain password field
+- [ ] [Always][BLOCKING] Response DTO does not contain password field
   - Grep: No password field in `class.*Response` block
   - Or: Verify `model_dump(exclude=.*password)` usage
 - [ ] [Always][HIGH] Response DTO does not contain sensitive fields
@@ -86,7 +98,7 @@ Check DTO, Response, and log files:
 - [ ] [When applicable][MEDIUM] Password hashing in use (bcrypt, argon2, etc.)
   - Detection condition: Check when password field + DB storage logic exist
   - Grep: Verify `(bcrypt|argon2|pbkdf2|hashlib)` presence
-  - When hashing library not detected: [FAIL] + "Password hashing not applied — bcrypt/argon2 adoption required before production deployment"
+  - When hashing library not detected: treat as `[OPEN][HIGH]` and require bcrypt/argon2 before production deployment
 - [ ] [When applicable][LOW] DB connection SSL configuration verified
   - Detection condition: Check when production environment settings exist
   - Verify `sslmode` in config.py
@@ -113,7 +125,7 @@ Check Request DTO and router files:
   - Grep: Verify `content_type` or `filename` validation
 
 ### Path Traversal
-- [ ] [Always][CRITICAL] User input not used directly in file paths
+- [ ] [Always][BLOCKING] User input not used directly in file paths
   - Grep: `open\(.*\+|Path\(.*\+|os\.path\.join\(.*request`
 
 ## 5. Dependencies & Configuration
@@ -125,7 +137,7 @@ Check configuration files and pyproject.toml:
   - Execute: `uv pip audit 2>/dev/null || pip audit 2>/dev/null || echo "audit tool not installed"`
 
 ### Debug Mode
-- [ ] [Always][CRITICAL] debug=True disabled in production
+- [ ] [Always][BLOCKING] debug=True disabled in production
   - Grep: `debug\s*=\s*True` (when set directly without conditional)
 - [ ] [Always][HIGH] docs/swagger disabled in production
   - Verify `docs_url` in config.py uses `is_dev` condition
@@ -136,7 +148,7 @@ Check configuration files and pyproject.toml:
 - [ ] [Always][MEDIUM] Review scope of `allow_methods=["*"]`, `allow_headers=["*"]`
 
 ### Secret Management
-- [ ] [Always][CRITICAL] `.env` file included in `.gitignore`
+- [ ] [Always][BLOCKING] `.env` file included in `.gitignore`
   - Verify `\.env` pattern exists in .gitignore
 - [ ] [Always][HIGH] Configuration values loaded from environment variables (not hardcoded)
   - Verify Settings class uses `validation_alias`
@@ -148,7 +160,7 @@ Check configuration files and pyproject.toml:
 Check middleware and exception handling files:
 
 ### Stack Trace Exposure
-- [ ] [Always][CRITICAL] Traceback not exposed in production
+- [ ] [Always][BLOCKING] Traceback not exposed in production
   - Verify `is_dev` condition in `generic_exception_handler` (exception_handlers.py)
 - [ ] [Always][HIGH] Error responses do not expose internal implementation details
   - Grep: `traceback|stack_trace|__traceback__` return presence
@@ -176,7 +188,7 @@ Check middleware and exception handling files:
 - [ ] [When applicable][MEDIUM] Rate limiting middleware configuration status
   - Detection condition: Check **project-dna.md section 8** "Rate Limiting (slowapi)" status -> [SKIP] if "not implemented"
   - Grep: `RateLimitMiddleware|slowapi|throttle|rate_limit`
-  - When not configured: [SKIP] + "Recommend adopting slowapi when expanding endpoints"
+  - When not configured: keep `[SKIP]` and recommend adopting slowapi as the endpoint surface expands
 
 ### Request Size Limit
 - [ ] [When applicable][MEDIUM] Request body size limit configuration status
@@ -273,7 +285,7 @@ Check S3 Vectors client, store, and configuration files:
 Check Embedding client and configuration files:
 
 ### API Key Management
-- [ ] [When applicable][CRITICAL] Embedding API keys (OpenAI/Bedrock) managed via environment variables (not hardcoded)
+- [ ] [When applicable][BLOCKING] Embedding API keys (OpenAI/Bedrock) managed via environment variables (not hardcoded)
   - Detection condition: Check **project-dna.md section 8** "Embedding (PydanticAI)" status -> [SKIP] if "not implemented"
   - Grep: `embedding_openai_api_key|embedding_bedrock_access_key|embedding_bedrock_secret_key` loaded from `Settings`
   - Verify no API key hardcoded in client constructors
@@ -309,7 +321,7 @@ Check Embedding client and configuration files:
 Check LLM model factory, configuration, and Agent-using services:
 
 ### API Key / Credential Management
-- [ ] [When applicable][CRITICAL] LLM API keys / AWS credentials managed via environment variables (not hardcoded)
+- [ ] [When applicable][BLOCKING] LLM API keys / AWS credentials managed via environment variables (not hardcoded)
   - Detection condition: Check **project-dna.md section 8** "LLM (PydanticAI Agent)" status -> [SKIP] if "not implemented"
   - Grep: `llm_api_key|llm_bedrock_access_key|llm_bedrock_secret_key` loaded from `Settings`
   - Verify `LLMConfig` is constructed only via DI (`core_container.llm_config`), not instantiated with literal credentials

--- a/docs/ai/shared/skills/review-architecture.md
+++ b/docs/ai/shared/skills/review-architecture.md
@@ -1,39 +1,126 @@
-# Architecture Compliance Audit — Detailed Procedure
+# Architecture Compliance Audit
+
+## Purpose
+
+Use this skill to audit one domain or the full repository against the project's
+shared architecture rules, then decide whether the audit also requires
+`/sync-guidelines` follow-up.
+
+## Review Contract
+
+Every result must include:
+
+- `Scope` - audit target, audited domains, important exclusions
+- `Sources Loaded` - exact shared rule sources used for the audit
+- `Findings` - only open issues; each item includes `severity`, `rule source`,
+  `file:line`, `impact`, and `recommended fix`
+- `Drift Candidates` - shared docs, checklists, wrappers, or `project-dna`
+  targets that may need sync; each item includes `target`, `reason`,
+  `auto-fix`, and `sync-required`
+- `Next Actions` - implementation follow-up, verification, sync path
+- `Completion State` - concise closure status for the audit
+- `Sync Required` - explicit `true` or `false`
+
+### Severity Taxonomy
+
+- Review state: `OPEN`, `OK`, `SKIP`
+- Severity: `BLOCKING`, `HIGH`, `MEDIUM`, `LOW`, `NOTE`
 
 ## Audit Target
-When "all", audit all domain directories under `src/` (excluding `_core`, `_apps`).
-When a specific domain name, audit only `src/{name}/`.
 
-## Current Domain List
-Identify domains using Glob pattern `src/*/` and exclude `_core`, `_apps` prefixes
+- `all` -> audit all domains under `src/`, excluding `_core` and `_apps`
+- `{domain}` -> audit only `src/{domain}/`
 
-## Audit Procedure
+## Category Coverage
 
-Inspect 8 categories with 28+ items using Grep-based checks.
-Refer to `docs/ai/shared/architecture-review-checklist.md` for the detailed checklist.
+Inspect the 9 architecture checklist categories defined in
+`docs/ai/shared/architecture-review-checklist.md`.
 
-**Category Summary**:
-1. **Layer Dependency Rules** — domain -> infrastructure/interface import violations
-2. **Conversion Patterns Compliance** — Mapper class, Entity pattern remnants
-3. **DTO/Response Integrity** — sensitive field exposure
-4. **DI Container Correctness** — Singleton/Factory distinction
-5. **Test Coverage** — required test file existence
-6. **Worker Payload Compliance** — Payload class usage and location
-7. **Admin Page Compliance** — config/page separation, naming conventions, auth guard, field masking
-8. **Bootstrap Wiring** — app-level registration status
+1. Layer Dependency Rules
+2. Conversion Patterns Compliance
+3. DTO / Response Integrity
+4. DI Container Correctness
+5. Test Coverage
+6. Worker Payload Compliance
+7. Admin Page Compliance
+8. Bootstrap Wiring
+9. DynamoDB Domain Compliance
 
-## Output Format
+## Phase 0: Resolve Scope and Load Rule Sources
 
+1. Resolve the audit target and enumerate the domains included in the run.
+2. Load:
+   - `AGENTS.md`
+   - `docs/ai/shared/project-dna.md`
+   - `docs/ai/shared/architecture-review-checklist.md`
+3. Use `docs/ai/shared/security-checklist.md` only when an architecture issue
+   overlaps with a security boundary such as auth, logging, or storage.
+
+## Phase 1: Audit Against Severity-Tagged Rules
+
+Apply the checklist category by category.
+
+- use grep-style checks for code-auditable rules first
+- read surrounding files when a rule depends on wiring or conversion flow
+- mark optional categories such as DynamoDB only when the domain actually uses
+  that variant
+
+Do not collapse missing tests, dependency violations, and DTO exposure into a
+single issue. Each broken rule gets its own finding.
+
+## Phase 2: Determine Drift Candidates and Sync Requirement
+
+The audit must explicitly decide whether the shared references are still
+accurate.
+
+Mark `Sync Required: true` when:
+- the audited changes touch shared rule sources, shared skill procedures, or
+  wrappers
+- the audit reveals that `project-dna`, checklists, or wrapper summaries no
+  longer describe the implemented architecture
+- the audit reveals a new documented pattern that should be added to the shared
+  references
+
+If the code is already correct but the docs are behind, report that as a
+`Drift Candidates` item instead of forcing a fake code finding.
+
+## Phase 3: Report Using the Review Contract
+
+Example:
+
+```text
+Scope
+- Target: docs
+- Audited domains: docs
+
+Sources Loaded
+- AGENTS.md
+- docs/ai/shared/project-dna.md
+- docs/ai/shared/architecture-review-checklist.md
+
+Findings
+- [OPEN][BLOCKING] Architecture checklist - src/docs/domain/services/docs_service.py:12
+  Impact: domain layer imports infrastructure directly, breaking the layering rule.
+  Recommended fix: introduce a Protocol in the domain layer and invert the dependency.
+- [OK][MEDIUM] Architecture checklist §4 - DI container: providers.DeclarativeContainer and providers.Factory used correctly
+- [SKIP] Architecture checklist §9 - DynamoDB domain compliance: no infrastructure/dynamodb/ directory found in docs domain
+
+Drift Candidates
+- target: docs/ai/shared/project-dna.md
+  reason: the current admin page pattern differs from the documented layout.
+  auto-fix: yes
+  sync-required: true
+
+Next Actions
+- Refactor the direct import.
+- Run `/sync-guidelines` after the admin page pattern reference is updated.
+
+Completion State
+- complete with findings
+
+Sync Required
+- true
 ```
-[PASS] Layer dependency: no domain -> infrastructure imports found
-[FAIL] Test coverage: tests/unit/{name}/domain/test_{name}_service.py missing
-       -> Recommended: generate with `/test-domain {name} generate`
-```
 
-Final summary: `Passed: XX/28 | Failed: XX/28`
-
-## Recommended Actions on Failure
-- Layer dependency violation -> Refactor to Protocol-based approach
-- Conversion Patterns violation -> Replace with inline conversion (model_dump, model_validate)
-- Missing tests -> Run `/test-domain {name} generate`
-- Bootstrap not registered -> Refer to Layer 5 in `/new-domain` reference
+When the audit is clean, still emit `Findings: none`, `Drift Candidates: none`,
+and `Sync Required: false`.

--- a/docs/ai/shared/skills/review-pr.md
+++ b/docs/ai/shared/skills/review-pr.md
@@ -1,81 +1,144 @@
-# Pull Request Architecture Review — Detailed Procedure
+# Pull Request Quality Gate Review
 
-## Core Principle: No custom rules — reference existing rule sources only
+## Core Principle
 
-This skill does NOT define its own review criteria.
-It applies existing rules from the project's rule sources to the PR diff scope.
+This skill does not define custom review rules.
+It applies the project's shared rule sources to the PR diff and decides whether
+the quality gate can close or must continue into `/sync-guidelines`.
 
-Rule sources to load:
-- `docs/ai/shared/architecture-review-checklist.md` — 20+ architecture checklist items
-- `docs/ai/shared/security-checklist.md` — OWASP security items
-- `docs/ai/shared/project-dna.md` — conversion patterns, DI rules, base classes
-- `AGENTS.md` — shared absolute prohibitions and DTO rules
+Only shared rule sources may create findings:
+- `AGENTS.md`
+- `docs/ai/shared/project-dna.md`
+- `docs/ai/shared/architecture-review-checklist.md`
+- `docs/ai/shared/security-checklist.md`
+
+Tool-specific files such as `.claude/rules/*` may help wording or navigation,
+but they must not introduce findings that are not already backed by the shared
+rule sources above.
+
+## Review Contract
+
+Every result must include the sections below.
+
+- `Scope` - PR number/title, base/head refs, affected domains, changed file count
+- `Sources Loaded` - exact shared rule sources used for the review
+- `Findings` - only open issues; each item includes `severity`, `rule source`,
+  `file:line`, `impact`, and `recommended fix`
+- `Drift Candidates` - shared docs, checklists, wrappers, or `project-dna`
+  targets that may need sync; each item includes `target`, `reason`,
+  `auto-fix`, and `sync-required`
+- `Next Actions` - code fixes, follow-up review, sync request, optional GitHub
+  posting
+- `Completion State` - concise closure status for the review
+- `Sync Required` - explicit `true` or `false`
+
+### Severity Taxonomy
+
+Use a separate review state and severity. Do not mix them.
+
+- Review state: `OPEN`, `OK`, `SKIP`
+- Severity: `BLOCKING`, `HIGH`, `MEDIUM`, `LOW`, `NOTE`
 
 ## Difference from `/review-architecture`
-```
-/review-architecture  →  Audit an entire domain offline (full scan)
-/review-pr            →  Same rules, applied only to PR diff (change-scoped)
-```
 
-## Phase 0: Resolve PR & Collect Rules
-
-1. Resolve the target PR:
-   - If a number or URL is given: `gh pr view $ARGUMENTS --json number,title,body,baseRefName,headRefName`
-   - If empty: `gh pr view --json number,title,body,baseRefName,headRefName` (current branch)
-   - If no PR exists for the current branch → abort with instructions to create one first
-
-2. Fetch PR context:
-   ```bash
-   gh pr diff {number}
-   gh pr view {number} --json files --jq '.files[].path'
-   ```
-
-3. Identify affected domains: extract domain names from paths matching `src/{name}/`
-
-4. Load all rule sources listed above. These are the ONLY review criteria.
-
-## Phase 1: Apply Rules to PR Diff
-
-- Walk through each checklist item from the loaded rule sources
-- For each changed file, check only the applicable rules based on its layer:
-  - `domain/` files → Layer Dependency, Conversion Patterns, DTO Integrity
-  - `infrastructure/` files → DI Container, Repository patterns
-  - `interface/` files → Response field exposure, Router patterns
-  - `application/` files → UseCase patterns
-  - `migrations/` files → upgrade/downgrade existence
-- When surrounding context is needed, examine related code
-  (e.g., cross-reference DTO fields with Response exclude set)
-- Assign severity from the checklist source's own categorization
-
-## Phase 2: Report
-
-```
-=== PR #{number}: {title} ===
-Affected domains: {domain_list}
-Changed files: {count}
-
---- Findings ---
-[FAIL][BLOCKING] {checklist item name} — {file:line}
-  → {what's wrong + how to fix}
-
-[NOTE][SUGGESTION] {checklist item name} — {file:line}
-  → {recommendation}
-
-=== Summary ===
-BLOCKING: {count} | SUGGESTION: {count} | PASS: {count}
+```text
+/review-pr            -> review only changed files, then decide whether sync is required
+/review-architecture  -> audit a domain or the full repo structure outside PR scope
 ```
 
-If no violations found:
+## Phase 0: Resolve Target and Collect Evidence
+
+1. Resolve the review target.
+   - If a PR number or URL is given: inspect that PR
+   - If omitted: inspect the current branch diff or current branch PR
+   - If no review target exists, stop with instructions to create or identify one
+2. Collect the diff, changed filenames, affected domains, and surrounding code
+   when a changed file alone is not enough to judge the rule.
+3. Load the shared rule sources listed above before forming findings.
+
+## Phase 1: Review Changed Files Against Shared Rules
+
+Walk through changed files and apply only the relevant checklist categories.
+
+- `domain/` -> layer dependency, conversion patterns, DTO integrity
+- `application/` -> orchestration, dependency boundaries
+- `infrastructure/` -> DI, repository, provider, storage, worker, logging rules
+- `interface/` -> router, response exposure, admin, auth, validation rules
+- `migrations/` -> upgrade/downgrade completeness and compatibility concerns
+- shared docs / skill wrappers -> drift risk, source-of-truth alignment, quality
+  gate follow-up
+
+Use surrounding context whenever a rule depends on code outside the diff.
+
+## Phase 2: Determine Drift Candidates and Sync Requirement
+
+After findings are collected, determine whether the PR also created or exposed
+reference drift.
+
+Mark `Sync Required: true` when at least one of the following is true:
+- the diff touches `AGENTS.md`, `docs/ai/shared/`, `project-dna`, checklist
+  files, skill procedures, or tool wrappers
+- the diff touches shared/base architecture files whose patterns are documented
+- the review discovers a mismatch between code and shared references
+- the review discovers stale feature detection assumptions that should update
+  `project-dna` or a checklist
+
+When a drift exists, create a `Drift Candidates` entry even if the code change
+itself is otherwise acceptable.
+
+## Phase 3: Report Using the Review Contract
+
+Use the contract sections exactly and keep the result action-oriented.
+
+Example:
+
+```text
+Scope
+- PR #128: Add DynamoDB-backed docs query path
+- Affected domains: docs, _core
+- Changed files: 7
+
+Sources Loaded
+- AGENTS.md
+- docs/ai/shared/project-dna.md
+- docs/ai/shared/architecture-review-checklist.md
+- docs/ai/shared/security-checklist.md
+
+Findings
+- [OPEN][HIGH] Architecture checklist - src/docs/infrastructure/di/docs_container.py:18
+  Impact: container wiring uses the wrong dependency source for DynamoDB mode.
+  Recommended fix: switch to `core_container.dynamodb_client` and keep RDB wiring out.
+- [OK][MEDIUM] Architecture checklist §5 - Test coverage: all 3 baseline test files present for docs domain
+- [SKIP] Security checklist §4.2 - File Upload input validation: project-dna §8 and live code both confirm feature inactive
+
+Drift Candidates
+- target: docs/ai/shared/architecture-review-checklist.md
+  reason: PR introduces DynamoDB-specific guidance that the shared checklist does not mention consistently.
+  auto-fix: no
+  sync-required: true
+
+Next Actions
+- Fix the container wiring issue.
+- Run `/sync-guidelines` after the DynamoDB guidance is updated.
+- Post the review to GitHub only after the findings are addressed.
+
+Completion State
+- complete with findings
+
+Sync Required
+- true
 ```
-=== PR #{number}: {title} ===
-All architecture checks passed. No violations in changed files.
-```
 
-## Phase 3: Post to GitHub (optional)
+If no issues are found, still emit all sections and explicitly state
+`Findings: none`, `Drift Candidates: none`, and `Sync Required: false`.
 
-Ask the user: "Post this review to the PR?"
+## Phase 4: Post to GitHub (Optional)
 
-If yes:
-- BLOCKING items present → `gh pr review {number} --request-changes --body "{review}"`
-- SUGGESTION only → `gh pr review {number} --comment --body "{review}"`
-- All PASS → `gh pr review {number} --approve --body "Architecture review: all checks passed"`
+Ask before posting.
+
+- `BLOCKING` findings present -> request changes
+- only `HIGH` / `MEDIUM` / `LOW` / `NOTE` findings -> comment
+- no findings and `Sync Required: false` -> approve or leave a clean comment
+
+If `Sync Required: true`, do not treat the review as fully closed until the
+follow-up sync path is acknowledged.

--- a/docs/ai/shared/skills/review-pr.md
+++ b/docs/ai/shared/skills/review-pr.md
@@ -12,9 +12,9 @@ Only shared rule sources may create findings:
 - `docs/ai/shared/architecture-review-checklist.md`
 - `docs/ai/shared/security-checklist.md`
 
-Tool-specific files such as `.claude/rules/*` may help wording or navigation,
-but they must not introduce findings that are not already backed by the shared
-rule sources above.
+Tool-specific convention files, if available, may help with wording or
+navigation, but they must not introduce findings that are not already backed by
+the shared rule sources above.
 
 ## Review Contract
 

--- a/docs/ai/shared/skills/security-review.md
+++ b/docs/ai/shared/skills/security-review.md
@@ -1,83 +1,156 @@
-# OWASP-Based Code Security Audit — Detailed Procedure
+# Security Quality Gate Audit
+
+## Purpose
+
+Use this skill to audit a file, domain, or the full repository for security
+issues, while also checking whether shared references such as `project-dna` and
+the security checklist are stale.
+
+## When to Use
+
+Run this skill whenever a change touches one or more of the following surfaces:
+
+- Authentication, authorization, or session management
+- Secrets, API keys, or credential handling
+- Logging, structured log fields, or error responses
+- Object storage (S3/MinIO), DynamoDB, or S3 Vectors
+- AI providers (LLM, Embedding)
+- Async workers or task payloads
+- Any other security-sensitive surface
+
+Also run when the user explicitly asks for a security audit.
+
+## Review Contract
+
+Every result must include:
+
+- `Scope` - audit target, audited domains/files, important exclusions
+- `Sources Loaded` - exact shared rule sources used for the audit
+- `Findings` - only open issues; each item includes `severity`, `rule source`,
+  `file:line`, `impact`, and `recommended fix`
+- `Drift Candidates` - shared docs, checklists, wrappers, or `project-dna`
+  targets that may need sync; each item includes `target`, `reason`,
+  `auto-fix`, and `sync-required`
+- `Next Actions` - remediation, verification, sync path
+- `Completion State` - concise closure status for the audit
+- `Sync Required` - explicit `true` or `false`
+
+### Severity Taxonomy
+
+- Review state: `OPEN`, `OK`, `SKIP`
+- Severity: `BLOCKING`, `HIGH`, `MEDIUM`, `LOW`, `NOTE`
 
 ## Audit Target
-- When "all", audit all directories under `src/` (including `_core`, `_apps`).
-- When a specific domain name, audit only `src/{name}/`.
-- When a file path, audit only that file.
 
-## Current Domain List
-Identify domains using Glob pattern `src/*/` (include all directories)
+- `all` -> audit all directories under `src/`, including `_core` and `_apps`
+- `{domain}` -> audit only `src/{domain}/`
+- `{file}` -> audit only that file
 
-## Audit Procedure
+## Category Coverage
 
-Inspect 8 security categories with 32+ items using Grep-based checks.
-Refer to `docs/ai/shared/security-checklist.md` for the detailed checklist.
+Inspect the 12 security checklist categories defined in
+`docs/ai/shared/security-checklist.md`.
 
-**Category Summary**:
-1. **Injection Prevention** — SQL, Command, Template injection patterns
-2. **Authentication & Authorization** — endpoint protection, credential management, JWT, RBAC
-3. **Data Protection** — PII exposure, sensitive data in logs, encryption
-4. **Input Validation** — Pydantic validation, file uploads, Path Traversal
-5. **Dependencies & Configuration** — vulnerable packages, debug mode, CORS, secret management
-6. **Error Handling & Logging** — stack trace exposure, Rate Limiting
-7. **Async Worker Security (Taskiq)** — payload validation, message security, idempotency
-8. **Object Storage Security (AWS S3)** — access control, upload validation, encryption
+1. Injection Prevention
+2. Authentication & Authorization
+3. Data Protection
+4. Input Validation
+5. Dependencies & Configuration
+6. Error Handling and Logging
+7. Async Worker Security
+8. Object Storage Security (AWS S3)
+9. DynamoDB Security
+10. S3 Vectors Security
+11. Embedding API Security
+12. LLM API Security
 
-## Audit Execution Method
+## Phase 0: Feature Detection and Reference Freshness Preflight
 
-Each checklist item is classified as `[Always]` or `[When applicable]`:
+Before the main audit, compare shared references against live code.
 
-### Conditional Check Procedure
-1. `[Always]` items: Execute Grep check unconditionally
-2. `[When applicable]` items: First verify detection conditions (import/usage of the feature) via Grep
-   - Feature not in use -> Output `[SKIP]` and skip
-   - Feature in use -> Proceed with detailed check
-3. False positive filtering — exclude test code, comments, config examples
-4. Include specific file/line information for discovered issues
-5. Severity indicators: [CRITICAL], [HIGH], [MEDIUM], [LOW]
+1. Load:
+   - `AGENTS.md`
+   - `docs/ai/shared/project-dna.md`
+   - `docs/ai/shared/security-checklist.md`
+2. Build a feature snapshot from `project-dna` section 8.
+3. Re-detect the same features directly from code imports and wiring.
+4. If the live code disagrees with `project-dna`, or `project-dna` is stale for
+   the current security surface, continue the audit but add a
+   `stale reference risk` drift candidate with `sync-required: true`.
 
-## Output Format
+Live code is authoritative. `project-dna` is a cached shared reference, not the
+final source of truth.
 
+## Phase 1: Run the 12-Category Audit
+
+Each checklist item is either `Always` or `When applicable`.
+
+Use a two-step applicability decision:
+1. preflight expectation from `project-dna`
+2. live code re-detection before deciding `SKIP`
+
+Rules:
+- if both sources say inactive -> `SKIP`
+- if code says active -> audit as active, even if `project-dna` says inactive
+- if code says inactive but `project-dna` says active -> note the drift and use
+  judgment on whether the feature was removed or merely hard to detect
+
+Include file and line references for every open issue and filter out false
+positives from tests, comments, or config examples.
+
+## Phase 2: Determine Drift Candidates and Sync Requirement
+
+Mark `Sync Required: true` when:
+- preflight detects stale or conflicting feature status
+- the audit exposes a new active feature without matching checklist coverage
+- the audited changes touch shared references, checklist files, or wrappers
+- the audit finds code that is secure but no longer described correctly in
+  `project-dna` or the checklist
+
+Security review does not stop at `SKIP`. A stale shared reference is itself a
+quality gate issue and must be reported.
+
+## Phase 3: Report Using the Review Contract
+
+Example:
+
+```text
+Scope
+- Target: all
+- Audited domains: docs, user, _core
+
+Sources Loaded
+- AGENTS.md
+- docs/ai/shared/project-dna.md
+- docs/ai/shared/security-checklist.md
+
+Findings
+- [OPEN][BLOCKING] Security checklist - src/user/interface/server/routers/user_router.py:19
+  Impact: write endpoint has no authentication dependency and is exposed to unauthenticated callers.
+  Recommended fix: add the project's auth dependency before allowing create/update/delete actions.
+- [OK][BLOCKING] Security checklist §2 - Admin dashboard: require_auth() present in all @ui.page handlers
+- [SKIP] Security checklist §4.2 - File Upload input validation: project-dna §8 and live code both confirm feature inactive
+
+Drift Candidates
+- target: docs/ai/shared/project-dna.md
+  reason: code uses UploadFile validation paths, but section 8 still reports file upload as not implemented.
+  auto-fix: yes
+  sync-required: true
+- target: docs/ai/shared/security-checklist.md
+  reason: active LLM usage exists but the applicable checklist wording is stale.
+  auto-fix: no
+  sync-required: true
+
+Next Actions
+- Fix the endpoint authentication gap.
+- Run `/sync-guidelines` to refresh feature status and checklist wording.
+
+Completion State
+- complete with findings
+
+Sync Required
+- true
 ```
-=== OWASP Code Security Audit Results ===
 
---- 1. Injection Prevention ---
-[PASS] SQL injection: no f-string SQL patterns found
-[FAIL][HIGH] Command injection: subprocess.call(shell=True) detected
-     -> File: src/example/infrastructure/services/export_service.py:42
-     -> Recommended: use subprocess.run(shell=False) + shlex.split()
-
---- 2. Authentication & Authorization ---
-[PASS] No hardcoded credentials found
-[FAIL][CRITICAL] Missing endpoint authentication: POST /user has no auth dependency
-     -> File: src/user/interface/server/routers/user_router.py:19
-     -> Recommended: add Depends(get_current_user)
-
-...
-
-=== Summary ===
-Passed: XX/24 | Failed: XX/24 | Skipped: XX/24
-  - CRITICAL: X issues
-  - HIGH: X issues
-  - MEDIUM: X issues
-  - LOW: X issues
-  - SKIP: X items (feature not in use)
-```
-
-## External Tool Integration (Optional)
-Run additionally if the tool is installed:
-```bash
-# Python security static analysis
-bandit -r src/{name}/ -f json 2>/dev/null || echo "bandit not installed"
-
-# Dependency vulnerability scan
-pip audit 2>/dev/null || uv pip audit 2>/dev/null || echo "audit tool not installed"
-```
-
-## Recommended Actions on Failure
-- Injection -> parameterized query, shell=False, Jinja2 autoescape
-- Missing authentication -> add Depends(get_current_user) or RBAC middleware
-- PII exposure -> apply model_dump(exclude={'password', ...})
-- Hardcoded secrets -> migrate to Settings class (environment variables)
-- CORS wildcard -> restrict to specific origins in production
-- Stack trace exposure -> verify is_dev condition (generic_exception_handler in exception_handlers.py)
+When there are no security findings, still emit all sections. In particular, do
+not omit `Drift Candidates` or `Sync Required`.

--- a/docs/ai/shared/skills/security-review.md
+++ b/docs/ai/shared/skills/security-review.md
@@ -56,8 +56,8 @@ Inspect the 12 security checklist categories defined in
 3. Data Protection
 4. Input Validation
 5. Dependencies & Configuration
-6. Error Handling and Logging
-7. Async Worker Security
+6. Error Handling & Logging
+7. Async Worker Security (Taskiq)
 8. Object Storage Security (AWS S3)
 9. DynamoDB Security
 10. S3 Vectors Security

--- a/docs/ai/shared/skills/sync-guidelines.md
+++ b/docs/ai/shared/skills/sync-guidelines.md
@@ -86,8 +86,9 @@ Items that can be mechanically extracted from code. When drift is found, generat
 Policy/standard-based content. Only detect whether related sources have changed and request user review.
 
 4. **Architecture Checklist** (`docs/ai/shared/architecture-review-checklist.md`)
-   - Compare the number of Absolute Prohibitions in AGENTS.md vs. the number of check items in `docs/ai/shared/architecture-review-checklist.md`
-   - On mismatch, request confirmation on whether to add Grep patterns for the new rules
+   - Compare the **code-auditable** Absolute Prohibitions in AGENTS.md against the related check items in `docs/ai/shared/architecture-review-checklist.md`
+   - Exclude the shared-rule-source cross-reference rule from this comparison; keep that safeguard in AGENTS.md / harness docs
+   - On mismatch, request confirmation on whether to expand checklist coverage for the newly code-auditable rule
 
 5. **Security Checklist** (`docs/ai/shared/security-checklist.md`)
    - Compare `docs/ai/shared/project-dna.md` section 8 active feature status with `[when applicable]` items

--- a/docs/ai/shared/skills/sync-guidelines.md
+++ b/docs/ai/shared/skills/sync-guidelines.md
@@ -1,158 +1,129 @@
-# Guideline Synchronization — Detailed Procedure
+# Guideline Synchronization Quality Gate
 
-After design changes, inspect whether `AGENTS.md`, `CLAUDE.md`, shared workflow references, Codex workflow assets, Claude skills, and `.claude/rules/` are consistent with the actual code.
+Use this skill to close the documentation and workflow side of the quality gate
+after architecture, security, or workflow changes.
 
-## Reference Code Analysis
-Read `src/user/` as the reference domain to identify current actual patterns:
-- Base class import paths
-- Class inheritance structure
-- Conversion Patterns (Model->DTO, DTO->Response)
-- DI patterns (Singleton/Factory)
-- File structure
+## Operating Modes
 
-## Phase 1-3: Code ↔ Documentation Consistency
+`/sync-guidelines` supports two modes:
 
-### Inspection Targets (5 Categories)
-1. **AGENTS.md <-> Code** -- Absolute Prohibitions, Conversion Patterns, Write DTO criteria
-2. **Shared references <-> Code** -- `docs/ai/shared/` content and the current implementation
-3. **Harness docs <-> Workflow layers** -- `CLAUDE.md`, `.codex/config.toml`, `.codex/hooks.json`, `.agents/skills/`
-4. **Skills <-> Code** -- Whether each skill's `SKILL.md` matches the current state (references are checked separately in Phase 5)
-5. **`.claude/rules/` <-> Code** -- architecture-conventions, project-status, project-overview
+- standalone inspection mode - discover drift directly from the repo state
+- review follow-up mode - consume incoming drift candidates from
+  `/review-pr`, `/review-architecture`, or `/security-review`, then verify and
+  close them
 
-Refer to `docs/ai/shared/drift-checklist.md` for detailed inspection items.
+## Input Contract
 
-### Output Format
+If a previous review already produced `Drift Candidates`, consume them first.
+Each candidate should preserve:
 
-```
-=== Guideline Synchronization Inspection Results ===
+- `target`
+- `reason`
+- `auto-fix`
+- `sync-required`
 
-[OK] AGENTS.md: Absolute Prohibitions -- No violations found
-[DRIFT] /new-domain: Base class import -- Path change detected
-  -> Previous: src._core.infrastructure.persistence.rdb.base_repository
-  -> Actual: src._core.database.base_repository
-  -> Action: Update `docs/ai/shared/scaffolding-layers.md` and any dependent skill entry points
+If no candidates are provided, derive them from the repo diff and code/reference
+inspection.
 
-Sync required: X items / Total: Y items
-```
+## Gate Triggers
 
-### Actions When DRIFT Is Found
-1. Show the list of discovered mismatches to the user
-2. Suggest a fix for each mismatch
-3. Update the relevant files after user approval
-4. Re-run the inspection after updates to confirm all items are [OK]
+Treat sync as required when at least one of the following changed or drifted:
 
-## Phase 4: project-dna.md Regeneration
+- `AGENTS.md`
+- `docs/ai/shared/`
+- `docs/ai/shared/project-dna.md`
+- shared checklists
+- shared skill procedures or tool wrappers
+- harness docs (`CLAUDE.md`, `.claude/rules/`, `.codex/`)
+- base classes, shared architecture wiring, or other documented reference
+  patterns
 
-Regenerate `docs/ai/shared/project-dna.md` when DRIFT is found or the user requests it.
+## Sync Contract
 
-### Regeneration Procedure
-1. Scan `src/user/` as the reference domain using Glob/Read
-2. Extract `src/_core/` Base class signatures:
-   - Import paths (actual file locations of all Base classes)
-   - Generic parameters (TypeVar bounds, class definitions)
-   - `__init__` signatures (BaseRepository, etc.)
-   - Method list (BaseRepositoryProtocol)
-3. Extract DI patterns: check `providers.Singleton` / `providers.Factory` mappings in each Container
-4. Scan security tools: extract active tool list from `pyproject.toml` and `.pre-commit-config.yaml`
-5. Scan active features: check whether `jwt`, `UploadFile`, `RBAC`, `slowapi`, `websocket` imports exist in the codebase
-6. Regenerate `docs/ai/shared/project-dna.md` with the latest information (update date)
-7. Compare each Skill's references with `docs/ai/shared/project-dna.md` -> report mismatches
+The result is not complete until it includes all of:
 
-### Post-Regeneration Verification
-- Verify all import paths in project-dna.md match actual files using `Grep`
-- Compare generated Generic signatures against source code definitions
+- `Mode` - standalone or review follow-up
+- `Input Drift Candidates` - consumed list, or `none`
+- `project-dna` - updated or unchanged
+- `AUTO-FIX` - applied mechanical fixes, or `none`
+- `REVIEW` - policy or judgment items that still require human review, or `none`
+- `Remaining` - unresolved drift that still exists, or `none`
+- `Next Actions` - follow-up expected from the caller
 
-## Phase 5: References Drift Inspection
+If any `REVIEW` item exists, do not close with "nothing to change" or similar
+language.
 
-After project-dna.md regeneration is complete, inspect whether `docs/ai/shared/` documents are consistent with the current code.
-Follow the "5. References <-> Code" section in `docs/ai/shared/drift-checklist.md` for detailed inspection items.
+## Phase 0: Intake and Reference Scan
 
-### Automated Verification ([AUTO-FIX] Targets)
-Items that can be mechanically extracted from code. When drift is found, generate a fix diff and present it to the user.
+1. Determine the operating mode.
+2. Collect incoming `Drift Candidates` if they already exist.
+3. Read the reference domain (`src/user/`) and shared/base modules to anchor the
+   current implementation shape.
+4. Load the governing sources:
+   - `AGENTS.md`
+   - `docs/ai/shared/project-dna.md`
+   - `docs/ai/shared/drift-checklist.md`
+   - the affected shared procedures, checklists, wrappers, and harness docs
 
-1. **File List** (`docs/ai/shared/scaffolding-layers.md`)
-   - Compare `Glob src/user/**/*.py` results with the file list (items 1-26) in `docs/ai/shared/scaffolding-layers.md`
-   - Detect missing/deleted files
+## Phase 1: Reconcile Drift Candidates with Code and References
 
-2. **Factory Pattern** (`docs/ai/shared/test-patterns.md`)
-   - Read `tests/factories/user_factory.py` and compare with code blocks in `docs/ai/shared/test-patterns.md`
-   - Detect function signature and import path changes
+Process incoming drift first.
 
-3. **Skill Mapping** (`docs/ai/shared/planning-checklists.md`)
-   - Collect `name:` fields from `.claude/skills/*/SKILL.md` and `.agents/skills/*/SKILL.md`
-   - Compare with the Skill column in the "Skill Mapping Table" of `docs/ai/shared/planning-checklists.md`
+- verify whether each candidate is still real
+- promote still-valid candidates into `AUTO-FIX` or `REVIEW`
+- mark resolved candidates as closed instead of re-reporting them blindly
 
-### Manual Check ([REVIEW] Targets)
-Policy/standard-based content. Only detect whether related sources have changed and request user review.
+If no incoming candidates exist, run the full drift inspection from
+`docs/ai/shared/drift-checklist.md`.
 
-4. **Architecture Checklist** (`docs/ai/shared/architecture-review-checklist.md`)
-   - Compare the **code-auditable** Absolute Prohibitions in AGENTS.md against the related check items in `docs/ai/shared/architecture-review-checklist.md`
-   - Exclude the shared-rule-source cross-reference rule from this comparison; keep that safeguard in AGENTS.md / harness docs
-   - On mismatch, request confirmation on whether to expand checklist coverage for the newly code-auditable rule
+## Phase 2: Refresh `project-dna` and Shared References
 
-5. **Security Checklist** (`docs/ai/shared/security-checklist.md`)
-   - Compare `docs/ai/shared/project-dna.md` section 8 active feature status with `[when applicable]` items
-   - Request confirmation on whether security check items exist for newly activated features
+Update or confirm `project-dna` based on actual code.
 
-### Hybrid C Skill Structure Verification
+- regenerate when drift exists or the caller explicitly requests it
+- re-check shared references that depend on `project-dna`
+- keep mechanical updates separate from policy-review updates
 
-For skills that have been migrated to Hybrid C:
-- [ ] `docs/ai/shared/skills/{name}.md` exists and is non-empty
-- [ ] Claude wrapper references `docs/ai/shared/skills/{name}.md`
-- [ ] Codex wrapper references `docs/ai/shared/skills/{name}.md`
-- [ ] Phase count in shared procedure matches Phase overview in Claude wrapper
-- [ ] No tool-specific instructions leaked into shared procedure (grep for `.claude/rules/`, `.claude/skills/`, `.agents/skills/`)
+When a shared reference depends on product or policy judgment, report it under
+`REVIEW` even if the code facts are clear.
 
-### Phase 5 Output Format
+## Phase 3: Verify Hybrid C and Close the Gate
 
-```
---- References Drift Inspection ---
+Before closing:
 
-[AUTO-FIX] scaffolding-layers.md: File list
-  -> Missing file detected: src/{name}/domain/value_objects/__init__.py
-  -> Fix suggestion generated -- Would you like to apply it?
+- verify shared procedure existence for migrated skills
+- verify both Claude and Codex wrappers reference the same shared procedure
+- verify both wrappers keep the same Phase/Step overview count as the shared
+  procedure
+- verify shared procedures do not contain tool-specific instructions
 
-[OK] test-patterns.md: Factory pattern -- No changes
-[OK] planning-checklists.md: Skill mapping -- No changes
-[OK] Hybrid C: sync-guidelines -- Structure verified
+Emit the full sync contract and clearly state whether the quality gate is closed
+or waiting on review follow-up.
 
-[REVIEW] security-checklist.md: Active feature change detected
-  -> "JWT/Authentication" toggled to active in project-dna.md section 8
-  -> Please verify whether JWT-related security checks need to be added to [when applicable] items
+## Quality Gate Scenarios
 
-References: AUTO-FIX X items | REVIEW X items | OK X items
-```
+Use these scenarios as regression examples for the workflow.
 
-## Sync Completion Contract
+1. Architecture-changing PR
+   - `/review-pr` should produce code findings and/or drift candidates
+   - `/sync-guidelines` should refresh references before the gate closes
+2. Security feature activation not reflected in `project-dna`
+   - `/security-review` should not end in `SKIP`
+   - it should raise a stale-reference drift candidate and require sync
+3. Shared procedure changed but wrapper did not
+   - `/sync-guidelines` should detect Hybrid C drift for both Claude and Codex
+     wrappers
+4. Docs-only change that alters checklist meaning
+   - `/sync-guidelines` should classify it under `REVIEW`, not a silent auto-fix
 
-Do not treat the sync as complete until the closing summary includes all four sections below.
+## Completion Example
 
 ```text
-project-dna: updated | unchanged
-AUTO-FIX: ...
-REVIEW: ...
-Remaining: ...
-```
-
-- **project-dna**: Whether `docs/ai/shared/project-dna.md` was regenerated, updated, or confirmed unchanged.
-- **AUTO-FIX**: Mechanically fixable drift targets and whether each fix was applied. If none: `AUTO-FIX: none`.
-- **REVIEW**: Human-review targets — explain why policy or product judgment is needed. If none: `REVIEW: none`.
-- **Remaining**: Unresolved drift that still remains after updates. If none: `Remaining: none`.
-
-If one or more `REVIEW` items exist, the sync result must not conclude with "nothing to change" or equivalent wording.
-
-Example:
-
-```text
-project-dna: updated (new Base class paths synced)
-AUTO-FIX: 2 items applied (scaffolding-layers, planning-checklists)
-REVIEW: 1 item (security-checklist lacks checks for newly active "Embedding")
+Mode: review follow-up
+Input Drift Candidates: 2 consumed
+project-dna: updated (feature status refreshed)
+AUTO-FIX: 2 items applied (planning-checklists, skill wrappers)
+REVIEW: 1 item (security checklist wording changed and needs human approval)
 Remaining: none
+Next Actions: rerun the originating review or acknowledge the open review item
 ```
-
-## When to Run
-- After architecture refactoring
-- After changes to Base classes or shared modules
-- After introducing new patterns or conventions
-- When project-dna.md was last updated more than 2 weeks ago
-- Periodic inspection (recommended once every 2 weeks)

--- a/docs/ai/shared/skills/test-domain.md
+++ b/docs/ai/shared/skills/test-domain.md
@@ -4,12 +4,9 @@ If the argument contains "generate", generate missing test files.
 If the argument contains "run", execute existing tests.
 If neither is present, ask the user which mode they want.
 
-## Required Test Files (5)
-- `tests/factories/{name}_factory.py`
-- `tests/unit/{name}/domain/test_{name}_service.py`
-- `tests/unit/{name}/application/test_{name}_use_case.py`
-- `tests/integration/{name}/infrastructure/test_{name}_repository.py`
-- `tests/unit/{name}/interface/admin/test_{name}_admin_config.py` **(only when admin exists)**
+## Required Test Files
+
+See `docs/ai/shared/test-files.md` for the canonical baseline and conditional file definitions.
 
 Refer to `docs/ai/shared/test-patterns.md` for detailed test patterns and Factory code examples.
 

--- a/docs/ai/shared/test-files.md
+++ b/docs/ai/shared/test-files.md
@@ -1,0 +1,27 @@
+# Required Test Files
+
+> Canonical definition of test files required per domain.
+> Consumed by `/test-domain`, `/review-architecture`, `/new-domain`, and planning references.
+> All other documents referencing required test files must point here rather than maintaining their own list.
+
+## Baseline (always required)
+
+These three files are required for every domain, regardless of shape:
+
+- `tests/factories/{name}_factory.py`
+- `tests/unit/{name}/domain/test_{name}_service.py`
+- `tests/integration/{name}/infrastructure/test_{name}_repository.py`
+
+## Conditional (required when the feature exists)
+
+| File | Condition |
+|---|---|
+| `tests/unit/{name}/application/test_{name}_use_case.py` | UseCase exists in the domain |
+| `tests/e2e/{name}/test_{name}_router.py` | Server router / API exists |
+| `tests/unit/{name}/interface/admin/test_{name}_admin_config.py` | Admin interface exists |
+
+## Usage by Skill
+
+- `/test-domain generate` — generates all missing baseline files plus applicable conditionals
+- `/review-architecture §5` — checks for baseline files; conditionals checked when the corresponding feature exists
+- `/new-domain` scaffolding — creates baseline + applicable conditionals at domain creation time


### PR DESCRIPTION
## Related Issue
- N/A (docs-only quality gate restructure)

## Change Summary
- Restructure `/review-pr`, `/review-architecture`, `/security-review`, `/sync-guidelines` as a unified quality gate flow
- Formalize the 7-field review contract (`Scope / Sources Loaded / Findings / Drift Candidates / Next Actions / Completion State / Sync Required`) in all three review shared procedures
- Formalize the separate `sync-guidelines` terminal contract (`Mode / Input Drift Candidates / project-dna / AUTO-FIX / REVIEW / Remaining / Next Actions`)
- Introduce `docs/ai/shared/test-files.md` — replaces the inconsistent "5 required files" framing with a baseline (3) + conditional (3) model
- Canonicalize `require_auth` severity: security-checklist owns `[BLOCKING]`; architecture-checklist keeps a cross-ref only
- Move security-review trigger heuristics to `docs/ai/shared/skills/security-review.md §"When to Use"` as the canonical home; CLAUDE.md keeps a pointer
- Add `[OK]` / `[SKIP]` worked examples to all three review shared procedures
- Add harness docs (`CLAUDE.md`, `.claude/rules/`, `.codex/`) to sync-guidelines Gate Triggers
- Codex sync-guidelines wrapper: hoist `Read` line to step 1, remove duplicate contract section
- Claude sync-guidelines wrapper: add meta-note clarifying Claude-harness post-step ownership
- Add review contract + sync contract summary to CLAUDE.md Quality Gate Flow section

## Type of Change
- [x] docs: Documentation

## Checklist
- [x] Architecture rules followed (no Domain -> Infrastructure imports)
- [x] Tests pass
- [x] Linting passes (`ruff check src/`)

## How to Test
- Run `/review-pr` and verify output follows the 7-field contract format
- Run `/security-review` and verify Phase 0 preflight and `[OK]`/`[SKIP]` branching
- Run `/sync-guidelines` and verify output follows the separate terminal contract format
- Open `docs/ai/shared/test-files.md` and confirm baseline/conditional definitions