### PR TITLE
chore+docs(examples): align todo with src/user + codify examples profile

### DIFF
--- a/docs/ai/shared/skills/review-architecture.md
+++ b/docs/ai/shared/skills/review-architecture.md
@@ -30,6 +30,26 @@ Every result must include:
 
 - `all` -> audit all domains under `src/`, excluding `_core` and `_apps`
 - `{domain}` -> audit only `src/{domain}/`
+- `examples/{name}` -> audit `examples/{name}/` against the **examples
+  profile** described below
+
+### Examples Profile (vs production)
+
+`examples/` are reference code, not production domains. Two checklist
+categories apply differently:
+
+- **§5 Test Coverage**: examples require only the unit test declared in
+  `examples/README.md` Contributing, not the full
+  `docs/ai/shared/test-files.md` baseline (3 baseline + applicable
+  conditional). Missing factories / integration / e2e tests are not
+  findings in the examples profile.
+- **§2 Auth (security-checklist)**: examples may omit auth dependencies
+  on `@router.post|put|delete`. The omission is intentional reference
+  simplicity, not a finding, unless the example's stated pattern claims
+  to demonstrate auth.
+
+All other categories (layer dependency, conversion, DI, bootstrap,
+naming) apply identically to examples and production domains.
 
 ## Category Coverage
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -53,15 +53,29 @@ An example PR should include:
    layout (Domain, Infrastructure, Interface) exactly — see the
    [tutorial](../docs/tutorial/first-domain.md#step-3--describe-an-order)
    for the canonical structure.
+   - **Path params** should use `{<domain>_id}` (e.g.
+     `/user/{user_id}`, `/todo/{todo_id}`) to avoid shadowing the
+     Python builtin `id`. The handler parameter name (`user_id: int`,
+     `todo_id: int`) must match the path placeholder.
+   - **Handler function names** follow `src/{domain}/` only when the
+     domain has multiple lookup variants needing disambiguation (e.g.
+     `get_user_by_user_id` vs `get_user_by_ids`). Single-lookup
+     examples may keep short names (`get_todo`, `update_todo`,
+     `delete_todo`).
 2. **A README** in `examples/{name}/README.md` covering:
    - What pattern the example teaches (2–3 sentences).
    - `curl` requests a reader can paste to exercise the endpoints.
    - Relevant production-domain reference (e.g. "compare with
      [`src/user/`](../src/user/) for password hashing").
-3. **A unit test** under `examples/{name}/tests/` (or at least a
-   protocol-based mock test pattern like the
-   [tutorial unit test](../docs/tutorial/first-domain.md#step-5--add-a-unit-test))
-   so a contributor can verify locally before pasting into `src/`.
+3. **A unit test** under `tests/unit/{name}/` (matching the production
+   test layout so CI auto-discovery runs it without extra wiring; see
+   the [tutorial unit test](../docs/tutorial/first-domain.md#step-5--add-a-unit-test)
+   for a protocol-based mock pattern). Examples are **not** required
+   to provide the full production test baseline (factories /
+   integration / e2e under `tests/{layer}/{name}/`) — a single unit
+   test is sufficient. This is the **examples profile**; see
+   [`docs/ai/shared/skills/review-architecture.md`](../docs/ai/shared/skills/review-architecture.md#examples-profile-vs-production)
+   for the audit-side counterpart.
 4. **No new dependencies** unless explicitly called for by the issue.
    If your example needs a library not already in `pyproject.toml`,
    open a discussion on the issue first.

--- a/examples/todo/README.md
+++ b/examples/todo/README.md
@@ -1,14 +1,14 @@
 # Todo Example
 
-A minimal CRUD example mirroring the `src/user/` layout.
+A minimal CRUD example mirroring the [`src/user/`](../../src/user/) layout.
 > **Note:** Reference code only. Not auto-wired. To run it, copy into `src/todo/` or add a manual bootstrap call.
 ## Endpoints
 
 - `POST /v1/todo` — Create a todo
 - `GET /v1/todos` — List all todos
-- `GET /v1/todo/{id}` — Get a todo by ID
-- `PUT /v1/todo/{id}` — Update a todo
-- `DELETE /v1/todo/{id}` — Delete a todo
+- `GET /v1/todo/{todo_id}` — Get a todo by ID
+- `PUT /v1/todo/{todo_id}` — Update a todo
+- `DELETE /v1/todo/{todo_id}` — Delete a todo
 
 ## Quick Start
 
@@ -19,5 +19,5 @@ curl -X POST http://localhost:8000/v1/todo \
 
 curl http://localhost:8000/v1/todos
 
-curl -X DELETE http://localhost:8000/v1/todo/{id}
+curl -X DELETE http://localhost:8000/v1/todo/{todo_id}
 ```

--- a/examples/todo/interface/server/bootstrap/todo_bootstrap.py
+++ b/examples/todo/interface/server/bootstrap/todo_bootstrap.py
@@ -10,7 +10,7 @@ def create_todo_container(todo_container: TodoContainer) -> None:
     todo_container.wire(packages=["examples.todo.interface.server.routers"])
 
 
-def setup_todo_routes(app: FastAPI):
+def setup_todo_routes(app: FastAPI) -> None:
     """Register todo domain routes"""
     app.include_router(router=todo_router.router, prefix="/v1", tags=["Todo"])
 

--- a/examples/todo/interface/server/routers/todo_router.py
+++ b/examples/todo/interface/server/routers/todo_router.py
@@ -47,44 +47,46 @@ async def list_todos(
 
 
 @router.get(
-    "/todo/{id}",
+    "/todo/{todo_id}",
     summary="Get todo",
     response_model=SuccessResponse[TodoResponse],
     response_model_exclude={"pagination"},
 )
 @inject
 async def get_todo(
-    id: int, todo_service: TodoService = Depends(Provide[TodoContainer.todo_service])
+    todo_id: int,
+    todo_service: TodoService = Depends(Provide[TodoContainer.todo_service]),
 ) -> SuccessResponse[TodoResponse]:
-    data = await todo_service.get_data_by_data_id(data_id=id)
+    data = await todo_service.get_data_by_data_id(data_id=todo_id)
     return SuccessResponse(data=TodoResponse(**data.model_dump()))
 
 
 @router.put(
-    "/todo/{id}",
+    "/todo/{todo_id}",
     summary="Update todo",
     response_model=SuccessResponse[TodoResponse],
     response_model_exclude={"pagination"},
 )
 @inject
 async def update_todo(
-    id: int,
+    todo_id: int,
     item: UpdateTodoRequest,
     todo_service: TodoService = Depends(Provide[TodoContainer.todo_service]),
 ) -> SuccessResponse[TodoResponse]:
-    data = await todo_service.update_data_by_data_id(data_id=id, entity=item)
+    data = await todo_service.update_data_by_data_id(data_id=todo_id, entity=item)
     return SuccessResponse(data=TodoResponse(**data.model_dump()))
 
 
 @router.delete(
-    "/todo/{id}",
+    "/todo/{todo_id}",
     summary="Delete todo",
     response_model=SuccessResponse,
     response_model_exclude={"data", "pagination"},
 )
 @inject
 async def delete_todo(
-    id: int, todo_service: TodoService = Depends(Provide[TodoContainer.todo_service])
+    todo_id: int,
+    todo_service: TodoService = Depends(Provide[TodoContainer.todo_service]),
 ) -> SuccessResponse:
-    success = await todo_service.delete_data_by_data_id(data_id=id)
+    success = await todo_service.delete_data_by_data_id(data_id=todo_id)
     return SuccessResponse(success=success)


### PR DESCRIPTION
## Related Issue
- Follow-up polish to #112 (no separate issue)

## Change Summary

### chore — examples/todo code alignment (commit `e8195d0`)
- **router** ([examples/todo/interface/server/routers/todo_router.py](examples/todo/interface/server/routers/todo_router.py)): path param `{id}` → `{todo_id}` to avoid shadowing the Python builtin; matching parameter rename (`id: int` → `todo_id: int`) and `data_id=` call sites updated in 3 handlers (`get_todo`, `update_todo`, `delete_todo`).
- **bootstrap** ([examples/todo/interface/server/bootstrap/todo_bootstrap.py](examples/todo/interface/server/bootstrap/todo_bootstrap.py)): add `-> None` return type to `setup_todo_routes` for consistency with sibling `create_todo_container` / `bootstrap_todo_domain` (both already annotated, mirrors `src/user/.../user_bootstrap.py`).
- **README** ([examples/todo/README.md](examples/todo/README.md)): convert ``mirroring the `src/user/` layout`` from inline code to a clickable markdown link, per the `examples/README.md` Contributing guideline; sync endpoint table and curl example with the new `{todo_id}` path param.

### docs — codify examples profile (commit `4e0f0c6`, from `/sync-guidelines`)
- **shared skill procedure** ([docs/ai/shared/skills/review-architecture.md](docs/ai/shared/skills/review-architecture.md)): extend Audit Target with an `examples/{name}` branch + a new "Examples Profile" subsection that explicitly relaxes §5 Test Coverage (single unit test is sufficient) and §2 Auth (omission of auth deps is intentional reference simplicity, not a finding) for the `examples/` subtree.
- **Contributing guide** ([examples/README.md](examples/README.md)): add path-param naming convention (`{<domain>_id}` to avoid shadowing Python builtin `id`) and a note on handler-name length following `src/` only when the domain has multiple lookup variants. Test location guideline now points to `tests/unit/{name}/` (matching the layout established in commit `21515e9` to keep CI auto-discovery wiring-free) and links the audit-side examples-profile section.

### Decision notes
- **Handler function names** (`get_todo`, `update_todo`, `delete_todo`) intentionally kept short. The longer `_by_user_id` suffix in `src/user/` exists to disambiguate against `get_user_by_ids`; todo has a single lookup endpoint, so the suffix would add no information. This rule is now codified in `examples/README.md` Contributing.
- **Test location** (`tests/unit/{name}/` vs `examples/{name}/tests/`): the actual location was set in commit `21515e9` for CI auto-discovery; the Contributing guide is now aligned with code reality.

## Type of Change
- [ ] feat: New feature
- [ ] fix: Bug fix
- [ ] refactor: Code restructuring
- [x] docs: Documentation
- [x] chore: Build/tooling
- [ ] test: Tests
- [ ] ci: CI/CD
- [ ] perf: Performance
- [ ] style: Code style

## Checklist
- [x] Architecture rules followed (no Domain -> Infrastructure imports)
- [x] Tests pass
- [x] Linting passes (`ruff check src/`)

## How to Test
- Unit tests:
  ```bash
  pytest tests/unit/todo/ -v
  ```
- Optional end-to-end verification (Swagger + curl):
  ```bash
  cp -r examples/todo src/todo
  rm -f ./quickstart.db
  make quickstart                          # in another terminal
  curl http://127.0.0.1:8001/v1/todo/1     # verify {todo_id} path resolves
  open http://127.0.0.1:8001/docs-swagger  # verify Swagger renders {todo_id}
  rm -rf src/todo && rm -f ./quickstart.db
  ```

## Notes for Reviewer
- **Security surface**: none touched (path-param identifier rename, return-type annotation, README link, contributing-guide wording). `/security-review` SKIP rationale: the changes do not interact with auth, logging, storage, input validation beyond identifier renames, or any other security boundary.
- **Quality gate trail**:
  - `/review-architecture examples/todo` → architecture clean (5 OK / 3 SKIP / 1 §5 finding deferred to examples profile).
  - `/review-pr 119` → no OPEN findings; CI 5/5 pass at `e8195d0`.
  - `/sync-guidelines` → 4 input drift candidates closed (3 AUTO-FIX + 1 REVIEW codified). 1 inherited drift remaining (`.agents` wrapper step count vs shared procedure phase headings — pre-existing pattern across multiple Hybrid C wrappers, out of scope for this PR; recommended for a separate sync pass).