### PR TITLE
Hybrid Harness Phase 2: UserPromptSubmit exception-token parser

### DIFF
--- a/.claude/hooks/user-prompt-submit.sh
+++ b/.claude/hooks/user-prompt-submit.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# UserPromptSubmit Hook: Exception-token parser (Phase 2 of #117 / #121)
+# Informational only — exit 0 in all cases, never blocks prompt submission.
+
+INPUT=$(cat)
+echo "$INPUT" | python3 "$(dirname "$0")/user_prompt_submit.py"

--- a/.claude/hooks/user_prompt_submit.py
+++ b/.claude/hooks/user_prompt_submit.py
@@ -1,0 +1,98 @@
+"""UserPromptSubmit Hook: Exception-token parser (Phase 2 of #117 / #121)
+
+Parses the leading exception token (`[trivial]` / `[hotfix]` / `[exploration]`
+/ `[자명]` / `[긴급]` / `[탐색]`) from the first line of a user prompt, after
+NFKC normalisation. Writes a per-session marker file under `.claude/state/`
+when matched. Output is informational only — never blocks prompt submission.
+
+Contract — payload schema shared with Codex side:
+    {"matched": bool, "token": str | None, "rationale_required": bool}
+
+Invariant: this hook never overrides safety / sandbox / Absolute Prohibitions
+(IC-1). It only writes a marker file after a token is detected.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import time
+import unicodedata
+import uuid
+from pathlib import Path
+
+TOKEN_REGEX = re.compile(
+    r"^\s*\[(trivial|hotfix|exploration|자명|긴급|탐색)\](?:\s|$)",
+    re.IGNORECASE,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+STATE_DIR = REPO_ROOT / ".claude" / "state"
+
+
+def parse_exception_token(prompt: str) -> dict:
+    """Return canonical decision payload per IC-3.
+
+    Always returns the same shape regardless of input. Token name is lowercased
+    for English variants; Korean tokens pass through unchanged (NFKC-normalised).
+    """
+    if not prompt:
+        return {"matched": False, "token": None, "rationale_required": False}
+
+    normalised = unicodedata.normalize("NFKC", prompt)
+    match = TOKEN_REGEX.match(normalised)
+    if not match:
+        return {"matched": False, "token": None, "rationale_required": False}
+
+    token = match.group(1)
+    if token.isascii():
+        token = token.lower()
+    return {"matched": True, "token": token, "rationale_required": True}
+
+
+def write_marker(payload: dict) -> Path | None:
+    """Write the token decision payload to a per-session marker file.
+
+    Marker schema: {matched, token, rationale_required, ts (ISO 8601)}.
+    Returns the marker path on write, or None when not matched.
+    """
+    if not payload.get("matched"):
+        return None
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    ts = time.strftime("%Y%m%dT%H%M%S", time.gmtime())
+    marker = STATE_DIR / f"exception-token-{ts}-{uuid.uuid4().hex[:12]}.json"
+    record = dict(payload)
+    record["ts"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    marker.write_text(json.dumps(record, ensure_ascii=False), encoding="utf-8")
+    return marker
+
+
+def read_prompt() -> str:
+    """Read prompt text from Claude UserPromptSubmit stdin payload.
+
+    Claude Code SDK delivers a JSON object with a `prompt` field. Empty stdin
+    or invalid JSON degrades to empty prompt — informational hook never crashes.
+    """
+    raw = sys.stdin.read()
+    if not raw.strip():
+        return ""
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return ""
+    if isinstance(payload, dict):
+        return str(payload.get("prompt", "") or "")
+    return ""
+
+
+def main() -> int:
+    prompt = read_prompt()
+    payload = parse_exception_token(prompt)
+    write_marker(payload)
+    print(json.dumps(payload, ensure_ascii=False), file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,6 +16,16 @@
         ]
       }
     ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/user-prompt-submit.sh"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Edit|Write|Bash",

--- a/.codex/hooks/user-prompt-submit.py
+++ b/.codex/hooks/user-prompt-submit.py
@@ -1,8 +1,29 @@
+"""UserPromptSubmit Hook (Codex side).
+
+Behaviour-preserving extension under Phase 2 of #117 / #121. The pre-existing
+safety check (rule-bypass / destructive git / destructive shell) runs first;
+when it emits ``decision: block`` the hook exits **without** parsing the
+exception-token vocabulary — i.e. dangerous prompts never produce a marker
+file even if they happen to start with `[trivial]`. Only after safety has
+passed the prompt does the parser run; its output is informational only and
+mirrors the Claude-side payload schema (IC-3).
+
+Decision payload (shared with `.claude/hooks/user_prompt_submit.py`):
+    {"matched": bool, "token": str | None, "rationale_required": bool}
+
+Marker file (when matched) carries the decision payload plus an ISO 8601 ``ts``
+timestamp.
+"""
+
 from __future__ import annotations
 
 import json
 import re
 import sys
+import time
+import unicodedata
+import uuid
+from pathlib import Path
 
 PROMPT_RULES: list[tuple[re.Pattern[str], str, str]] = [
     (
@@ -25,22 +46,78 @@ PROMPT_RULES: list[tuple[re.Pattern[str], str, str]] = [
     ),
 ]
 
+TOKEN_REGEX = re.compile(
+    r"^\s*\[(trivial|hotfix|exploration|자명|긴급|탐색)\](?:\s|$)",
+    re.IGNORECASE,
+)
 
-payload = json.load(sys.stdin)
-prompt = payload.get("prompt", "")
+REPO_ROOT = Path(__file__).resolve().parents[2]
+STATE_DIR = REPO_ROOT / ".codex" / "state"
 
-for pattern, reason, extra in PROMPT_RULES:
-    if pattern.search(prompt):
-        print(
-            json.dumps(
-                {
-                    "decision": "block",
-                    "reason": reason,
-                    "hookSpecificOutput": {
-                        "hookEventName": "UserPromptSubmit",
-                        "additionalContext": extra,
-                    },
-                }
+
+def parse_exception_token(prompt: str) -> dict:
+    """Return canonical decision payload per IC-3 (mirrors Claude side)."""
+    if not prompt:
+        return {"matched": False, "token": None, "rationale_required": False}
+    normalised = unicodedata.normalize("NFKC", prompt)
+    match = TOKEN_REGEX.match(normalised)
+    if not match:
+        return {"matched": False, "token": None, "rationale_required": False}
+    token = match.group(1)
+    if token.isascii():
+        token = token.lower()
+    return {"matched": True, "token": token, "rationale_required": True}
+
+
+def write_marker(payload: dict) -> Path | None:
+    if not payload.get("matched"):
+        return None
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    ts = time.strftime("%Y%m%dT%H%M%S", time.gmtime())
+    marker = STATE_DIR / f"exception-token-{ts}-{uuid.uuid4().hex[:12]}.json"
+    record = dict(payload)
+    record["ts"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    marker.write_text(json.dumps(record, ensure_ascii=False), encoding="utf-8")
+    return marker
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        # Empty stdin → informational, fail-open (parity with Claude side).
+        return 0
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        # Malformed payload → fail-open. The pre-Phase-2 hook crashed here;
+        # Phase 2 prefers symmetry with Claude side and Non-Goal "false-positive
+        # blocking" (issue #117) over preserving the crash behaviour.
+        return 0
+    if not isinstance(payload, dict):
+        return 0
+    prompt = payload.get("prompt", "") or ""
+
+    for pattern, reason, extra in PROMPT_RULES:
+        if pattern.search(prompt):
+            print(
+                json.dumps(
+                    {
+                        "decision": "block",
+                        "reason": reason,
+                        "hookSpecificOutput": {
+                            "hookEventName": "UserPromptSubmit",
+                            "additionalContext": extra,
+                        },
+                    }
+                )
             )
-        )
-        raise SystemExit(0)
+            return 0
+
+    decision = parse_exception_token(prompt)
+    write_marker(decision)
+    print(json.dumps(decision, ensure_ascii=False), file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,7 @@ quickstart.db
 
 # Claude Code per-user local overrides
 .claude/settings.local.json
+
+# Per-session governor state (exception-token markers, etc.) — Phase 2 #121
+.claude/state/
+.codex/state/

--- a/docs/ai/shared/governor-review-log/README.md
+++ b/docs/ai/shared/governor-review-log/README.md
@@ -88,3 +88,4 @@ The prompt is a starting point; phase-specific reviews (Phase 2 token parser, Ph
 | PR | Title | Issue | Entry |
 |---|---|---|---|
 | #125 | hybrid harness target architecture + Phase 1 | #117 | [pr-125-hybrid-harness-target-architecture.md](pr-125-hybrid-harness-target-architecture.md) |
+| #126 | Phase 2: UserPromptSubmit exception-token parser | #121 | [pr-126-userpromptsubmit-token-parser.md](pr-126-userpromptsubmit-token-parser.md) |

--- a/docs/ai/shared/governor-review-log/pr-126-userpromptsubmit-token-parser.md
+++ b/docs/ai/shared/governor-review-log/pr-126-userpromptsubmit-token-parser.md
@@ -1,0 +1,212 @@
+# PR #126 — Hybrid Harness Phase 2: UserPromptSubmit exception-token parser
+
+- GitHub PR: <https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/126>
+- Closes: #121
+- Branch: `feat/121-userpromptsubmit-token-parser` → `main`
+- Date range: 2026-04-26
+- Cross-tool reviewer: `codex exec -m gpt-5.5 --sandbox read-only` (Round 0 + Round 1); **Round 2 performed by Claude as self-administered stand-in (Codex API credit exhausted mid-flight)**.
+
+## Summary
+
+Implements Phase 2 of [ADR 045](../../history/045-hybrid-harness-target-architecture.md): the exception-token vocabulary defined in PR #125 becomes machine-readable on both tool surfaces.
+
+- New Claude `UserPromptSubmit` hook surface — `.claude/hooks/user-prompt-submit.sh` + `.claude/hooks/user_prompt_submit.py` + `.claude/settings.json` entry. Mirrors the existing `pre-tool-security.sh` + `pre_tool_security.py` sh-wrapper / py-helper pair.
+- Codex `.codex/hooks/user-prompt-submit.py` extended (behaviour-preserving) — pre-existing safety check runs first; on `decision: block`, hook returns immediately without parsing or writing a marker. Empty / invalid stdin now fail-open (parity with Claude side; pre-Phase-2 path crashed). The fail-open transition is the only behaviour change beyond the parser block; safety logic itself is preserved verbatim.
+- Recognised tokens (NFKC, leading-bracketed, case-insensitive) per IC-3 canonical regex `^\s*\[(trivial|hotfix|exploration|자명|긴급|탐색)\](?:\s|$)`. Decision payload `{matched, token, rationale_required}` shared across tools; marker file adds `ts` (ISO 8601) and uses `uuid.uuid4().hex[:12]` filename suffix to make collisions effectively impossible.
+- Tests: `tests/unit/agents_shared/test_token_parser.py` (34 cases). Parity assertions across Claude/Codex parser via `importlib.util.spec_from_file_location` (Codex hook filename has hyphens). Marker schema validation. HC-1 safety-preservation smokes via subprocess. Fail-open subprocess smokes for both sides.
+- Docs: `harness-asset-matrix.md` Tier 3 (count 11→13, intro sentence rewrite, Codex hook role updated, two new Claude rows, Bucket Distribution Summary 56→58 with bucket-share ~86% / ~14% retained at one decimal); `repo-facts.md` adds `.claude/state/` + `.codex/state/` row.
+- Multi-commit on the branch (per PR #125 convention): `feat(claude)` + `feat(codex)` + `test` + `docs(matrix+repo-facts)` + `docs(governor-review-log)` (this entry, follow-up commit). Final file count is read from `git diff --stat main..HEAD` at merge time.
+
+## Review Rounds
+
+### Round 0 — Plan Review (plan stage)
+
+- **Target**: `/Users/doo/.claude/plans/117-playful-dongarra.md` (Phase 2 plan, inherited filename from #117 plan).
+- **Reviewer**: `codex exec -m gpt-5.5 --sandbox read-only`.
+- **Final Verdict**: `still needs reinforcement` → all 11 R-points reflected back into the plan before any implementation file was touched.
+- **R-points** (full text inlined in plan §"Round 0 — captured (Codex)" so a fresh session can recover the rationale; not re-duplicated here):
+  - R0.1 (merge-blocking): Codex existing safety block preservation missing → HC-1 added; Codex side spec rewritten; verification checks safety preservation explicitly.
+  - R0.2: hyphen filename forces `importlib.util.spec_from_file_location`; CLI smoke for end-to-end safety-preservation.
+  - R0.3: SDK hook stdin schema must be confirmed before implementation.
+  - R0.4: regex fixture corrections — `[trivial]hello` no-match, CRLF behaviour, leading-newline acceptance, decomposed jamo as out-of-spec.
+  - R0.5: PR-number ↔ log-filename ordering (HC-3) — scratch first, rename after `gh pr create`.
+  - R0.6 (merge-blocking): self-application proof skill mismatch — `/review-architecture` + `/sync-guidelines` are the proof; `/review-pr` is gate-on-gate.
+  - R0.7: verification expanded (marker schema, state dir auto-create, empty stdin, invalid JSON).
+  - R0.8: "additive only" → "behaviour-preserving extension" (Codex side semantics).
+  - R0.9: cold-start reads expanded to 15 items.
+  - R0.10: new-session start prompt added at plan top.
+  - R0.11: stale plan filename `117-playful-dongarra.md` clarified.
+
+### Round 1 — Implementation Review
+
+- **Target**: 4-commit working tree before push (`.claude/hooks/user_prompt_submit.py`, `.claude/hooks/user-prompt-submit.sh`, `.codex/hooks/user-prompt-submit.py` extension, `tests/unit/agents_shared/test_token_parser.py`, `.claude/settings.json`, `.gitignore`). Pytest 30/30 PASSED at submission time.
+- **Reviewer**: `codex exec -m gpt-5.5 --sandbox read-only`.
+- **Final Verdict**: `minor fixes recommended` (no merge blockers). 5 review angles flagged 보완 필요; 4 actionable + 1 deferred to Phase 4.
+- **R-points** (all addressed or explicitly deferred):
+  - **R1.1** (Top 1) `harness-asset-matrix.md` Tier 3 not yet reflecting the new Claude hooks and the Codex role change. → **Applied**: Tier 3 11→13, Codex hook role updated, Bucket Distribution Summary 56→58, Counting note + Update Log refreshed (commit 4 `docs(governor): register Phase 2 hooks in matrix + repo-facts`).
+  - **R1.2** (Top 2) marker filename uses `int(time.time() * 1000) % 1_000_000` — millisecond modulo collisions possible if two hook invocations land in the same UTC-second. → **Applied**: both sides switched to `uuid.uuid4().hex[:12]` suffix (48-bit random).
+  - **R1.3** (Top 3) marker lifecycle ill-defined — Phase 4 must commit to read-and-delete vs. age-based filter vs. session-id correlation. → **Deferred to Phase 4** as **IC-11** (see Inherited Constraints below). Issue #123 body updated with the carry-forward link.
+  - **R1.4** (Top 4) test coverage gaps: Claude empty-stdin / invalid-JSON subprocess smokes missing; Codex marker JSON parse not validated; HC-1 marker absence relies on manual smoke. → **Applied**: 4 new tests (`test_claude_hook_empty_stdin_fail_open`, `test_claude_hook_invalid_json_fail_open`, `test_codex_hook_empty_stdin_fail_open`, `test_codex_hook_invalid_json_fail_open`) plus `test_codex_marker_written_on_match` upgraded to JSON-parse validation. Total fixtures 30 → 34.
+  - **R1.5** (Top 5) Codex side stdin asymmetry — Claude fail-opens, Codex crashes. Issue #117 Non-Goal "false-positive blocking" suggests symmetry. → **Applied**: Codex `main()` now reads raw stdin, returns 0 on empty / `JSONDecodeError` / non-dict payload before the safety check runs. (See "Self-Coherence Note" below for the migration-safety reasoning.)
+
+### Round 2 — Cross-Check on Round 1 (gate-on-gate, Claude self-administered stand-in)
+
+- **Target**: post-R1-fix working tree (4 commits + R1 deltas applied). Pytest 34/34 PASSED.
+- **Reviewer**: **Claude** (`gpt-5.5 --sandbox read-only` Codex run was attempted; the user reported "codex가 크레딧이 모두 소모돼서 클로드가 자체적으로 다시한번 확인해봐야할거 같아" mid-flight; the running Codex job and its monitor were stopped; Claude performed Round 2 as a self-administered cross-check using **PR #125 Round 7 R7.1 ~ R7.7 patterns** as the audit framework, since those patterns are the most recent record of *what self-review tends to miss*).
+- **Final Verdict**: `minor fixes recommended (no merge blockers)`. 2 open R-points; both close in the same commit set as this entry.
+- **Substitution caveat**: Self-administered Round 2 cannot replicate the cross-tool review's structural value (an independent reviewer with a different reasoning trace catching what Claude's reasoning trace systematically misses). The user's `feedback_codex_cross_review.md` memory captures this lesson explicitly. The substitution is recorded here so a future reader can re-run Round 2 with Codex once credit returns and compare findings; if the comparison surfaces additional R-points, those land as a follow-up commit on this same log entry per the log-only-backfill exclusion in [`governor-paths.md`](../governor-paths.md).
+- **R-points**:
+  - **R2.1** (R7.6 pattern) IC-11 carry-forward into Phase 4 issue body had not landed at Round-2 time. → **Applied** in the same commit set as this entry: `gh issue edit 123` injects an "Inherited Review Constraints" note linking this entry and citing IC-11.
+  - **R2.2** (R7.2 / R7.3 pattern) "Behaviour-preserving extension" framing tension — R1.5 introduced fail-open for empty / invalid stdin, which is technically a behaviour change from the pre-Phase-2 crash. → **Applied** here (this Self-Coherence Note): the safety-block contract itself is preserved verbatim; only the corner-case crash path is replaced by `return 0`. Empty / invalid stdin cannot carry a destructive prompt because the prompt field is unreachable until JSON parsing succeeds, so fail-open does not weaken IC-1.
+
+#### Round-2 Evidence (separated from Findings per R7.1)
+
+These OK observations support the verdict; they are not findings.
+
+- §1~§9 architecture checklist all N/A: no `src/` change.
+- Bucket-share consistency: denominator 56→58, Keep 48→50, Overlay 8 unchanged. ~86% / ~14% rounding holds (50/58 = 86.21%, 8/58 = 13.79%). ADR 045 §D4 / `target-operating-model.md` §7 / `migration-strategy.md` §6 mention `~86% / ~14%` — no edit needed (R7.4 regression avoided).
+- Tier 3 hook count arithmetic: 5 Claude shell + 2 Claude py + 6 Codex py = 13. Counting note `Tier 0=9 + Tier 1=17 + Tier 2=14 + Tier 3=13 + Tier 4=6 = 59; Total 58 excludes .claude/settings.local.json` — internally consistent.
+- Stale-count residue check: `grep -n "\b56\b" docs/ai/shared/harness-asset-matrix.md` returns only the Update Log line documenting the 56→58 transition (intended as historical evolution record); no stale count elsewhere.
+- HC-1 still in force after R1.5 fail-open: empty / invalid stdin path returns 0 before PROMPT_RULES, but those paths cannot carry a destructive prompt, so safety surface is unchanged.
+- chmod +x on `.claude/hooks/user-prompt-submit.sh` preserved across `git add` (mode `100755` confirmed via `git ls-files --stage`).
+- Pytest 34/34 PASSED. Manual smoke (Korean token, CRLF, dangerous-prompt-with-token-prefix block + no marker) all green.
+- pre-commit hooks (ruff format / ruff check / detect-secrets / mypy / domain-import / entity-pattern) green on every commit.
+- governor-paths.md Tier B `.claude/**` + `.codex/**` already covers the new files; no edit needed there (R5.1 / R5.2 regression avoided).
+
+### Round 3 — (skipped)
+
+Round 2 final verdict was `minor fixes recommended (no merge blockers)` and both R2 R-points close in the same commit set as this entry. No conditional Round 3 needed per the plan §"Cross-Tool Review Cadence" rule. If a future Codex re-run of Round 2 (after credit returns) surfaces additional R-points, that becomes Round 3 and lands in this same log entry as a backfill commit per the log-only-backfill exclusion.
+
+## Inherited Constraints (carried forward to Phase 3~5 and any future governor-changing PR)
+
+This entry inherits IC-1 ~ IC-10 from [`pr-125-hybrid-harness-target-architecture.md`](pr-125-hybrid-harness-target-architecture.md) verbatim and adds one new constraint:
+
+- **IC-11** (Phase 2 R1.3 deferral) **Marker lifecycle is unspecified at Phase 2.** The Phase 2 hooks write `.claude/state/exception-token-{ts}-{uuid}.json` / `.codex/state/...` markers when an exception token is recognised, but the markers accumulate across sessions with no consumed / age / session-id field. Phase 4 (#123) **must commit to a lifecycle policy** before promoting the completion gate from informational to harder reminder. Candidate policies (not exhaustive): (a) read-and-delete by the completion-gate hook on each Stop; (b) age-based filter (e.g. only consider markers within the last N minutes); (c) session-id correlation (require `session_id` field added to the marker schema and matched against the current session). Whichever Phase 4 picks, the marker schema may grow new fields — Phase 5 (#124) will then consolidate the writer in `.agents/shared/governor/`. Until Phase 4 lands, users may delete `.claude/state/*.json` and `.codex/state/*.json` manually (both are gitignored).
+
+## Self-Application Proof
+
+PR #126 is governor-changing. The governor's own self-review and completion-gate steps are recorded here.
+
+### `/review-architecture all` (manual scan, structural only — no `src/` changes in this PR)
+
+```
+Scope
+- Target: all (changed surface of feat/121-userpromptsubmit-token-parser, final file count read from `git diff --stat main..HEAD` at merge time)
+- Audited domains: none (no src/ change)
+- Important exclusions: src/ tree (untouched in this PR)
+
+Sources Loaded
+- AGENTS.md
+- docs/ai/shared/project-dna.md
+- docs/ai/shared/architecture-review-checklist.md
+- docs/ai/shared/governor-paths.md
+- docs/ai/shared/governor-review-log/pr-125-hybrid-harness-target-architecture.md (IC-1 ~ IC-10)
+
+Findings
+- none
+
+Drift Candidates
+- target: docs/ai/shared/governor-review-log/pr-{NNN}-userpromptsubmit-token-parser.md
+  reason: Per IC-8 + IC-10 + HC-3, governor-changing PR must add a new entry whose filename's {NNN} equals the PR number.
+  auto-fix: yes (this commit)
+  sync-required: true
+- target: docs/ai/shared/governor-review-log/README.md Index
+  reason: New PR row needed.
+  auto-fix: yes (this commit)
+  sync-required: true
+- target: docs/ai/shared/repo-facts.md
+  reason: `.claude/state/` + `.codex/state/` are new gitignored governance state surfaces.
+  auto-fix: yes (commit 4 already applied)
+  sync-required: true (closed by commit 4)
+- target: PR template Governor-Changing PR section
+  reason: must be filled in PR body (Round-7 R7.7).
+  auto-fix: yes (already applied during gh pr create)
+  sync-required: true (closed)
+
+Next Actions
+- Apply this commit (governor-review-log entry + Index row).
+- Edit issue #123 body with IC-11 carry-forward link.
+- Wait for review / merge.
+
+Completion State
+- complete on architecture surface (no src/ findings); drift candidates closed by this commit + post-PR-create steps.
+
+Sync Required
+- true (closed by this commit)
+```
+
+### `/sync-guidelines` (manual scan against drift-checklist 1A~1D)
+
+```
+Mode: review follow-up
+
+Input Drift Candidates: 6 consumed
+- governor-review-log/pr-126-userpromptsubmit-token-parser.md (this entry)
+- governor-review-log/README.md Index row
+- repo-facts.md `.claude/state/` + `.codex/state/` row
+- harness-asset-matrix.md Tier 3 update (already applied in commit 4)
+- PR template Governor-Changing PR section (already filled in PR body)
+- IC-11 (Phase 4 marker lifecycle) carry-forward (R1 Top R3, deferred to Phase 4)
+
+project-dna: unchanged (no code-pattern shift; project-dna §0~§14 still accurate)
+
+AUTO-FIX:
+- harness-asset-matrix.md Tier 3 row count 11→13 + 2 new Claude rows + Codex hook role updated; intro sentence + Counting note + Bucket Distribution Summary refreshed; Update Log records the 56→58 transition.
+- repo-facts.md adds row for `.claude/state/` + `.codex/state/`.
+- governor-review-log/pr-126-userpromptsubmit-token-parser.md created (this entry) with: Summary, Review Rounds 0~2 (each with explicit Final Verdict), Inherited Constraints (IC-1~IC-10 link + new IC-11), Self-Application Proof.
+- governor-review-log/README.md Index row added.
+- PR body Governor-Changing PR section filled (during gh pr create).
+
+REVIEW:
+- IC-11 (proposed and adopted) — Phase 4 marker lifecycle. Carried into issue #123 body via gh issue edit. Policy choice (read-and-delete vs age-based vs session-id) deferred to Phase 4 design.
+
+Remaining: none
+
+Next Actions:
+- Re-run /review-pr (or its manual equivalent) on the PR head once GitHub picks up the additional commit. Treat the governor as having satisfied its own quality gate for this PR.
+- Phase 3 (#122) and Phase 4 (#123) issues already exist; both inherit IC-1 ~ IC-11 from this entry.
+```
+
+### `/review-pr` (Claude-side completion gate)
+
+```
+Scope
+- PR: #126 — Hybrid Harness Phase 2: UserPromptSubmit exception-token parser (Closes #121)
+- Base/Head: main / feat/121-userpromptsubmit-token-parser
+- Affected domains: process/governance layer only (no src/ change)
+- Changed files: 9 (counts read from `git diff --stat` at merge time)
+
+Sources Loaded
+- AGENTS.md
+- docs/ai/shared/project-dna.md
+- docs/ai/shared/architecture-review-checklist.md
+- docs/ai/shared/security-checklist.md
+- docs/ai/shared/governor-paths.md
+- docs/ai/shared/governor-review-log/pr-125-hybrid-harness-target-architecture.md
+- docs/ai/shared/migration-strategy.md §1 Phase 2 acceptance
+
+Findings
+- none
+
+Drift Candidates
+- none (all closed in this commit set; matrix + repo-facts updated in commit 4; this entry + Index row + issue #123 edit close the rest)
+
+Next Actions
+- User reviews the PR on GitHub UI and merges.
+- Phase 3 (#122) picks up via Inherited Review Constraints IC-1 ~ IC-11.
+
+Completion State
+- Claude-side completion gate: PASSED.
+
+Sync Required
+- false
+```
+
+## Recommendations Carried Forward
+
+For Phase 3~5 implementations, link this entry's `Inherited Constraints` block from each PR description. In particular:
+
+- Phase 3 (#122) verify-first adapter must read the exception-token marker as the natural escape signal (e.g. `[exploration]` skips the verification reminder entirely).
+- Phase 4 (#123) completion gate must commit to the marker lifecycle policy described in IC-11 before promoting from informational to harder reminder.
+- Phase 5 (#124) shared governor module must absorb the parser, the marker writer, and the lifecycle policy chosen by Phase 4.
+- Future governor-changing PRs that change the regex / vocabulary / payload schema must re-run cross-tool review (Round 0 + at least Round 1) and add their own entry; the log-only-backfill exclusion does **not** apply to schema changes.

--- a/docs/ai/shared/harness-asset-matrix.md
+++ b/docs/ai/shared/harness-asset-matrix.md
@@ -504,7 +504,7 @@ Bucket guideline:
 
 ## Tier 3 — Hooks
 
-Eleven hook scripts (4 Claude shell + 1 Claude Python implementation + 6 Codex Python). Currently every hook handles **safety, formatting, or drift reminders**. None handle process governing — that's the Phase 2~5 gap.
+Thirteen hook scripts (5 Claude shell + 2 Claude Python implementations + 6 Codex Python). Phase 2 (#121) added `.claude/hooks/user-prompt-submit.sh` + `.claude/hooks/user_prompt_submit.py` as the first Claude UserPromptSubmit hook surface; the Codex side `.codex/hooks/user-prompt-submit.py` was extended (behaviour-preserving) with the same exception-token parser. Pre-Phase-2 every hook handled **safety, formatting, or drift reminders**; Phase 2 introduced the first *process-governor* hook (token recognition).
 
 | Asset | Bucket | Risk | Impact |
 |---|---|---|---|
@@ -512,7 +512,9 @@ Eleven hook scripts (4 Claude shell + 1 Claude Python implementation + 6 Codex P
 | `.claude/hooks/pre-tool-security.sh` | Keep | Low | Medium |
 | `.claude/hooks/post-tool-format.sh` | Keep | Low | Medium |
 | `.claude/hooks/stop-sync-reminder.sh` | Keep | Low | Medium |
+| `.claude/hooks/user-prompt-submit.sh` | Keep | Low | Medium |
 | `.claude/hooks/pre_tool_security.py` | Keep | Low | Medium |
+| `.claude/hooks/user_prompt_submit.py` | Keep | Low | Medium |
 | `.codex/hooks/_shared.py` | Keep | Low | Low |
 | `.codex/hooks/session-start.py` | Keep | Low | Low |
 | `.codex/hooks/user-prompt-submit.py` | Keep | Low | Medium |
@@ -570,9 +572,23 @@ Eleven hook scripts (4 Claude shell + 1 Claude Python implementation + 6 Codex P
 
 ### `.codex/hooks/user-prompt-submit.py`
 
-- **Current role**: Prompt safety check.
-- **Bucket**: Keep — Phase 2 extends this hook with the exception-token parser.
-- **Notes**: Codex R3 — exception-token recognition runs before any safety check that the parser would invalidate; safety still wins (D1.3).
+- **Current role**: Prompt safety check (rule-bypass / destructive git / destructive shell) **plus** Phase 2 (#121) exception-token parser. Order: safety check first; on `decision: block`, return without parsing or writing a marker (HC-1 from PR #121). Only after safety has passed does the parser run; its output is informational and never blocks submission.
+- **Bucket**: Keep — Phase 2 (#121) extension is behaviour-preserving.
+- **Notes**: Codex R3 — exception-token recognition never overrides safety / sandbox / Absolute Prohibitions (IC-1). Safety still wins (D1.3). Marker file location: `.codex/state/exception-token-{ts}-{seq}.json` (gitignored).
+
+### `.claude/hooks/user-prompt-submit.sh`
+
+- **Current role**: Phase 2 (#121) UserPromptSubmit wrapper. Mirrors `pre-tool-security.sh` shape — pipes stdin to the Python helper. Informational only, exits 0.
+- **Why it exists**: Claude did not have a UserPromptSubmit hook before Phase 2; this PR adds the surface so the exception-token vocabulary defined in PR #125 becomes machine-readable on the Claude side.
+- **Bucket**: Keep.
+- **Notes**: Mirrored against Codex `.codex/hooks/user-prompt-submit.py` for Phase 5 consolidation under `.agents/shared/governor/`.
+
+### `.claude/hooks/user_prompt_submit.py`
+
+- **Current role**: Phase 2 (#121) parser helper. NFKC normalisation + canonical regex `^\s*\[(trivial|hotfix|exploration|자명|긴급|탐색)\](?:\s|$)` (case-insensitive). Emits `{matched, token, rationale_required}` JSON to stderr; on match, writes a marker file under `.claude/state/`.
+- **Why it exists**: Sh wrapper + py helper split (matches the `pre-tool-security.sh` + `pre_tool_security.py` pattern). Avoids shell-escaping NFKC + regex inline.
+- **Bucket**: Keep.
+- **Notes**: Output is identical to `.codex/hooks/user-prompt-submit.py` parser. Parity asserted by `tests/unit/agents_shared/test_token_parser.py` (silent-divergence safety net for D1=B).
 
 ### `.codex/hooks/pre-tool-security.py`
 
@@ -653,17 +669,17 @@ Six rule files (5 Claude + 1 Codex). All `Keep` except `commands.md` which becom
 
 | Bucket | Count | Share | Notes |
 |---|---|---|---|
-| Keep | 48 | ~86% | Project-specific architecture / safety / reference value (incl. 4 design + 3 self-coherence-recovery process-governor artefacts) |
+| Keep | 50 | ~86% | Project-specific architecture / safety / reference value (incl. 4 design + 3 self-coherence-recovery process-governor artefacts + 2 Phase 2 #121 hooks) |
 | Overlay | 8 | ~14% | Process discipline now routed by Default Flow |
 | Replace | 0 | 0% | None in initial inventory; reserved for future passes |
 | Drop | 0 | 0% | Initial pass found no genuinely removable assets |
-| **Total** | **56** | 100% | |
+| **Total** | **58** | 100% | |
 
-Counting note: `Tier 0=9` (8 + ADR 045 + `.github/pull_request_template.md`), `Tier 1=17` (12 reference + 3 design living docs + `governor-review-log/` directory + `governor-paths.md`), `Tier 2=14` (skill rows; each row covers all 3 wrapper layers), `Tier 3=11`, `Tier 4=6` — sum 57. The 56 figure above excludes `.claude/settings.local.json` from the active-share count because it is `.gitignore`d (its row is recorded for completeness only). The bucket-share percentages use 56 as the denominator.
+Counting note: `Tier 0=9` (8 + ADR 045 + `.github/pull_request_template.md`), `Tier 1=17` (12 reference + 3 design living docs + `governor-review-log/` directory + `governor-paths.md`), `Tier 2=14` (skill rows; each row covers all 3 wrapper layers), `Tier 3=13` (Phase 2 #121 added `.claude/hooks/user-prompt-submit.sh` + `.claude/hooks/user_prompt_submit.py`; previously 11), `Tier 4=6` — sum 59. The 58 figure above excludes `.claude/settings.local.json` from the active-share count because it is `.gitignore`d (its row is recorded for completeness only). The bucket-share percentages use 58 as the denominator.
 
 This distribution matches the "Mostly Local with Philosophy Overlay" model declared in [ADR 045 §D4](../../history/045-hybrid-harness-target-architecture.md). The `Replace` and `Drop` columns are both empty in the initial pass: no asset's content is being rewritten, and self-verification during cross-link work showed that the only `Drop` candidate identified during the first triage was actually an active component (a sh-wrapper `.py` pair).
 
-If a future `Replace` candidate emerges, the threshold is: Keep+Overlay would otherwise force the asset into structural inconsistency with the Default Flow. None of the current 56 assets meet that.
+If a future `Replace` candidate emerges, the threshold is: Keep+Overlay would otherwise force the asset into structural inconsistency with the Default Flow. None of the current 58 assets meet that.
 
 ## Verification
 
@@ -692,3 +708,4 @@ The following self-checks must pass before this matrix is treated as authoritati
 ## Update Log
 
 - 2026-04-26 — Initial inventory under ADR 045 / Phase 1.
+- 2026-04-26 — Phase 2 (#121): added `.claude/hooks/user-prompt-submit.sh` + `.claude/hooks/user_prompt_submit.py` to Tier 3; updated `.codex/hooks/user-prompt-submit.py` role to include exception-token parsing (behaviour-preserving). Total 56 → 58.

--- a/docs/ai/shared/repo-facts.md
+++ b/docs/ai/shared/repo-facts.md
@@ -31,6 +31,7 @@ This file contains stable repository facts for both Claude and Codex workflows.
 - `docs/ai/shared/governor-review-log/`: permanent archive of cross-tool review trails for governor-changing PRs (ADR 045 Pillar 4); see `governor-review-log/README.md` for entry shape and prompt template
 - `docs/ai/shared/governor-paths.md`: canonical source of governor-changing path globs (Tier A / B / C + exclusions). All consumer docs link this file; do not redeclare the list (Round-4 R4.3)
 - `.github/pull_request_template.md`: GitHub PR template with the Governor-Changing PR checklist that artefact-locks cross-tool review and self-application proof (ADR 045 Pillar 5)
+- `.claude/state/` + `.codex/state/` (gitignored): per-session governance state surfaces. Phase 2 (#121) writes exception-token marker JSON files here when a leading `[trivial]` / `[hotfix]` / `[exploration]` / `[자명]` / `[긴급]` / `[탐색]` token is recognised. Phase 4 completion gate will read these markers; lifecycle (read-and-delete vs. age-based filter vs. session-id correlation) is the open question carried as Inherited Constraint into Phase 4.
 
 ## Context Management
 

--- a/tests/unit/agents_shared/test_token_parser.py
+++ b/tests/unit/agents_shared/test_token_parser.py
@@ -1,0 +1,271 @@
+"""Phase 2 (#121) — UserPromptSubmit exception-token parser parity tests.
+
+Tests cover:
+- payload-shape contract (`{matched, token, rationale_required}`)
+- English + Korean (precomposed) tokens
+- malformed bracket / no-whitespace boundary / body-only token / etc.
+- Claude / Codex parser parity (silent-divergence safety net for D1=B)
+- HC-1: Codex safety check still blocks dangerous prompts and skips parsing
+
+The Codex hook filename contains a hyphen (`user-prompt-submit.py`) which is
+not importable via the standard import system; per plan §"Test import strategy"
+both helpers are loaded via `importlib.util.spec_from_file_location` (option a)
+for unit tests, and a small subprocess-driven smoke (option b) covers the
+safety-preservation invariant end-to-end.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CLAUDE_HOOK = REPO_ROOT / ".claude" / "hooks" / "user_prompt_submit.py"
+CODEX_HOOK = REPO_ROOT / ".codex" / "hooks" / "user-prompt-submit.py"
+
+
+def _load(name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def claude_parser() -> ModuleType:
+    return _load("claude_user_prompt_submit", CLAUDE_HOOK)
+
+
+@pytest.fixture(scope="module")
+def codex_parser() -> ModuleType:
+    return _load("codex_user_prompt_submit", CODEX_HOOK)
+
+
+@pytest.fixture(scope="module")
+def parsers(claude_parser: ModuleType, codex_parser: ModuleType) -> tuple:
+    return (claude_parser.parse_exception_token, codex_parser.parse_exception_token)
+
+
+# ---------------------------------------------------------------------------
+# Match cases — produce {matched: True, token, rationale_required: True}
+# ---------------------------------------------------------------------------
+MATCH_CASES = [
+    pytest.param("[trivial] typo fix", "trivial", id="english-trivial"),
+    pytest.param("[hotfix] urgent revert", "hotfix", id="english-hotfix"),
+    pytest.param(
+        "[exploration] poking around", "exploration", id="english-exploration"
+    ),
+    pytest.param("[자명] 오타 수정", "자명", id="korean-trivial"),
+    pytest.param("[긴급] 즉시 패치", "긴급", id="korean-hotfix"),
+    pytest.param("[탐색] 그냥 살펴봄", "탐색", id="korean-exploration"),
+    pytest.param("[TRIVIAL] case-insensitive", "trivial", id="english-uppercase"),
+    pytest.param("[trivial]\nbody on next line", "trivial", id="newline-after-token"),
+    pytest.param("[trivial]", "trivial", id="bare-token-EOL"),
+    pytest.param(
+        "\n[trivial] leading-newline accepted", "trivial", id="leading-newline"
+    ),
+    pytest.param("  [trivial] leading-spaces", "trivial", id="leading-spaces"),
+    pytest.param("[trivial] " + ("x" * 10_000), "trivial", id="very-long-prompt"),
+]
+
+
+@pytest.mark.parametrize("prompt,expected_token", MATCH_CASES)
+def test_match_cases(parsers, prompt: str, expected_token: str) -> None:
+    claude_parse, codex_parse = parsers
+    expected = {
+        "matched": True,
+        "token": expected_token,
+        "rationale_required": True,
+    }
+    assert claude_parse(prompt) == expected
+    assert codex_parse(prompt) == expected
+
+
+# ---------------------------------------------------------------------------
+# No-match cases — produce {matched: False, token: None, rationale_required: False}
+# ---------------------------------------------------------------------------
+NO_MATCH_CASES = [
+    pytest.param("", id="empty"),
+    pytest.param("   ", id="whitespace-only"),
+    pytest.param("just a normal prompt", id="plain-text"),
+    pytest.param("[trivial]hello", id="no-whitespace-after-bracket"),
+    pytest.param("[trivialx] non-vocab", id="non-vocabulary-suffix"),
+    pytest.param("[trivial extra] extras", id="extras-inside-brackets"),
+    pytest.param("[trivial malformed", id="missing-closing-bracket"),
+    pytest.param("trivial] no opener", id="missing-opening-bracket"),
+    pytest.param(
+        "Please fix this:\n[trivial] body-only token must be ignored",
+        id="body-only-token-not-line1",
+    ),
+    pytest.param("[fix] not in vocabulary", id="out-of-vocab-token"),
+]
+
+
+@pytest.mark.parametrize("prompt", NO_MATCH_CASES)
+def test_no_match_cases(parsers, prompt: str) -> None:
+    claude_parse, codex_parse = parsers
+    expected = {"matched": False, "token": None, "rationale_required": False}
+    assert claude_parse(prompt) == expected
+    assert codex_parse(prompt) == expected
+
+
+# ---------------------------------------------------------------------------
+# CRLF — `\r` is whitespace per the regex `(?:\s|$)`, so `[trivial]\r\nbody`
+# still matches. This documents the expected behaviour.
+# ---------------------------------------------------------------------------
+def test_crlf_first_line_matches(parsers) -> None:
+    claude_parse, codex_parse = parsers
+    prompt = "[trivial]\r\nbody"
+    assert claude_parse(prompt)["matched"] is True
+    assert codex_parse(prompt)["matched"] is True
+
+
+# ---------------------------------------------------------------------------
+# Decomposed jamo — out of spec; documented as such.
+# Compatibility-jamo input does NOT round-trip through NFKC into the Hangul
+# precomposed form (per plan §Round 0 NFKC caveat). Either result is allowed
+# but Claude and Codex must agree.
+# ---------------------------------------------------------------------------
+def test_decomposed_jamo_parity(parsers) -> None:
+    claude_parse, codex_parse = parsers
+    prompt = "[ㅈㅏㅁㅕㅇ] decomposed compatibility jamo"
+    assert claude_parse(prompt) == codex_parse(prompt)
+
+
+# ---------------------------------------------------------------------------
+# Marker file: written on match, absent on no-match.
+# ---------------------------------------------------------------------------
+def test_marker_written_on_match(claude_parser, tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(claude_parser, "STATE_DIR", tmp_path / "state")
+    payload = {"matched": True, "token": "trivial", "rationale_required": True}
+    marker = claude_parser.write_marker(payload)
+    assert marker is not None and marker.exists()
+    record = json.loads(marker.read_text(encoding="utf-8"))
+    assert record["token"] == "trivial"
+    assert record["matched"] is True
+    assert record["rationale_required"] is True
+    assert "ts" in record
+
+
+def test_marker_absent_on_no_match(claude_parser, tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(claude_parser, "STATE_DIR", tmp_path / "state")
+    payload = {"matched": False, "token": None, "rationale_required": False}
+    assert claude_parser.write_marker(payload) is None
+    assert not (tmp_path / "state").exists()
+
+
+def test_codex_marker_written_on_match(codex_parser, tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(codex_parser, "STATE_DIR", tmp_path / "state")
+    payload = {"matched": True, "token": "자명", "rationale_required": True}
+    marker = codex_parser.write_marker(payload)
+    assert marker is not None and marker.exists()
+    record = json.loads(marker.read_text(encoding="utf-8"))
+    assert record["matched"] is True
+    assert record["token"] == "자명"
+    assert record["rationale_required"] is True
+    assert "ts" in record
+
+
+# ---------------------------------------------------------------------------
+# HC-1 safety preservation — Codex hook still blocks destructive prompts and
+# does NOT write a marker even when the prompt also begins with a token.
+# This is the end-to-end smoke (option b) referenced in the plan.
+# ---------------------------------------------------------------------------
+def _run_codex_hook(prompt: str) -> subprocess.CompletedProcess[str]:
+    payload = json.dumps({"prompt": prompt})
+    return subprocess.run(  # noqa: S603
+        [sys.executable, str(CODEX_HOOK)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_safety_block_on_destructive_prompt() -> None:
+    result = _run_codex_hook("please run rm -rf /tmp/foo for me")
+    assert result.returncode == 0, result.stderr
+    blob = json.loads(result.stdout.strip())
+    assert blob.get("decision") == "block"
+
+
+def test_safety_block_with_token_prefix_does_not_write_marker() -> None:
+    """`[trivial] please rm -rf /` → safety must still block, no marker written."""
+    result = _run_codex_hook("[trivial] please rm -rf /tmp/foo")
+    assert result.returncode == 0
+    blob = json.loads(result.stdout.strip())
+    assert blob.get("decision") == "block"
+    # stderr must NOT contain a parser payload (parser was skipped)
+    assert "matched" not in result.stderr
+
+
+def test_benign_token_prompt_passes() -> None:
+    result = _run_codex_hook("[trivial] benign typo fix")
+    assert result.returncode == 0
+    # safety did not block → stdout is empty
+    assert result.stdout == ""
+    # parser emitted payload to stderr
+    payload = json.loads(result.stderr.strip())
+    assert payload == {
+        "matched": True,
+        "token": "trivial",
+        "rationale_required": True,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Subprocess smokes — Claude side fail-open behaviour (R1.4 / R1.5).
+# ---------------------------------------------------------------------------
+def _run_claude_hook(stdin: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603
+        [sys.executable, str(CLAUDE_HOOK)],
+        input=stdin,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_claude_hook_empty_stdin_fail_open() -> None:
+    result = _run_claude_hook("")
+    assert result.returncode == 0
+    payload = json.loads(result.stderr.strip())
+    assert payload == {"matched": False, "token": None, "rationale_required": False}
+
+
+def test_claude_hook_invalid_json_fail_open() -> None:
+    result = _run_claude_hook("not json at all")
+    assert result.returncode == 0
+    payload = json.loads(result.stderr.strip())
+    assert payload == {"matched": False, "token": None, "rationale_required": False}
+
+
+def test_codex_hook_empty_stdin_fail_open() -> None:
+    """Round 1 R1.5 — Codex side now matches Claude's fail-open behaviour."""
+    result = _run_codex_hook_raw("")
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_codex_hook_invalid_json_fail_open() -> None:
+    result = _run_codex_hook_raw("not json at all")
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def _run_codex_hook_raw(stdin: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603
+        [sys.executable, str(CODEX_HOOK)],
+        input=stdin,
+        capture_output=True,
+        text=True,
+        check=False,
+    )


### PR DESCRIPTION
## Related Issue
- Closes #121
- Phase 2 of #117 / [ADR 045](../blob/main/docs/history/045-hybrid-harness-target-architecture.md), per [`migration-strategy.md` §1 Phase 2](../blob/main/docs/ai/shared/migration-strategy.md#phase-2--exception-token-vocabulary--userpromptsubmit-adapters-separate-issue).

## Change Summary
- **Claude side (new)** `.claude/hooks/user-prompt-submit.sh` + `.claude/hooks/user_prompt_submit.py` + `.claude/settings.json` `UserPromptSubmit` entry. Mirrors the existing `pre-tool-security.sh` + `pre_tool_security.py` sh-wrapper / py-helper pattern.
- **Codex side (extend, behaviour-preserving)** `.codex/hooks/user-prompt-submit.py` keeps the existing safety check verbatim and runs the token parser only after safety passes. Empty / invalid stdin now fail-open (matches Claude side; pre-Phase-2 path crashed).
- **Recognised tokens** (NFKC, leading-bracketed, case-insensitive): `[trivial]` / `[hotfix]` / `[exploration]` / `[자명]` / `[긴급]` / `[탐색]` per IC-3 canonical regex `^\s*\[(trivial|hotfix|exploration|자명|긴급|탐색)\](?:\s|$)`.
- **Decision payload** `{matched, token, rationale_required}` — identical schema across both tools.
- **Marker file** (only on match): `.claude/state/exception-token-{ts}-{uuid}.json` / `.codex/state/...`. Adds `ts` (ISO 8601). State directories are gitignored.
- **Tests** `tests/unit/agents_shared/test_token_parser.py` — 34 cases (parser parity across Claude/Codex parser via `importlib.util.spec_from_file_location`, marker schema, HC-1 safety-preservation, fail-open).
- **Docs** `harness-asset-matrix.md` Tier 3 row count 11→13, intro sentence rewrite, Codex-side role updated, Bucket Distribution Summary 56→58 (Keep 50/58 ≈ 86%, Overlay 8/58 ≈ 14% — unchanged at one decimal). `repo-facts.md` adds row for `.claude/state/` + `.codex/state/`.

## Type of Change
- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] refactor: Code restructuring
- [x] docs: Documentation
- [ ] chore: Build/tooling
- [x] test: Tests
- [ ] ci: CI/CD
- [ ] perf: Performance
- [ ] style: Code style

## Checklist
- [x] Architecture rules followed (no Domain -> Infrastructure imports — N/A: no `src/` change)
- [x] Tests pass — `pytest tests/unit/agents_shared/test_token_parser.py -v` → 34 / 34 PASSED
- [x] Linting passes — pre-commit hooks (ruff format / ruff check / detect-secrets / mypy) green on each commit

## How to Test
- `uv run pytest tests/unit/agents_shared/test_token_parser.py -v` (34 cases)
- Manual smoke (Claude side): `echo '{"prompt":"[자명] 오타 수정"}' | bash .claude/hooks/user-prompt-submit.sh` → stderr `{"matched": true, "token": "자명", "rationale_required": true}`; marker JSON in `.claude/state/`.
- Manual smoke (HC-1 safety preservation): `echo '{"prompt":"[trivial] please rm -rf /tmp/foo"}' | python3 .codex/hooks/user-prompt-submit.py` → stdout `decision: block`; **no marker file written**; stderr empty.
- Empty stdin / invalid JSON: both hooks exit 0 without crashing or writing markers.

---

## Governor-Changing PR (delete this section if not applicable)

This PR **is** governor-changing: it touches `.claude/**`, `.codex/**`, `.gitignore`, `docs/ai/shared/**` (Tier A + B per [`governor-paths.md`](../blob/main/docs/ai/shared/governor-paths.md)). The full Governor-Changing PR checklist below is filled in (per Round-7 R7.7 lesson — do not delete this section even when most boxes are easily checked).

Source of truth: [`AGENTS.md` § Default Coding Flow](../blob/main/AGENTS.md#default-coding-flow) + [`docs/ai/shared/governor-paths.md`](../blob/main/docs/ai/shared/governor-paths.md) + [`docs/ai/shared/governor-review-log/README.md`](../blob/main/docs/ai/shared/governor-review-log/README.md).

### Triggered files

- [x] At least one file in `changed_files` matches a Tier A / B / C path in `governor-paths.md`, and no full-set exclusion applies. (Tier B `.claude/**` + `.codex/**`; Tier A `docs/ai/shared/**`.)

### Cross-tool review

- [x] Codex `gpt-5.5 --sandbox read-only` review completed. Round 0 (plan stage) and Round 1 (impl review) captured.
- [x] All R-points addressed or explicitly deferred with rationale. Round 0 R0.1~R0.11 → applied to plan + impl. Round 1 R1.1 (matrix update) / R1.2 (uuid4 marker suffix) / R1.4 (4 new fail-open tests + Codex marker JSON parse validation) / R1.5 (Codex fail-open) → applied. Round 1 R1.3 (marker lifecycle) → deferred to Phase 4 as IC-11 (see governor-review-log entry once landed).
- [x] Final Verdict captured (Round 0: `still needs reinforcement` → addressed; Round 1: `minor fixes recommended` → addressed).
- [x] **Round 2 substitution note**: Codex API credit was exhausted before Round 2 (gate-on-gate) could complete. Round 2 was performed by Claude as a self-administered cross-check using PR #125 Round 7 R7.1~R7.7 patterns as the audit framework. Result: `minor fixes recommended (no merge blockers)` with two open items (R2.1: IC-11 link in issue #123 body; R2.2: behaviour-preserving extension self-coherence note). Both close in the follow-up commit that lands the `governor-review-log/pr-{N}-...md` entry. The substitution is recorded explicitly so the artefact is auditable.

### Self-application proof

- [x] `/review-architecture all` (manual scan) — `Findings: none` (no `src/` change). Drift Candidates: 4 scheduled artefacts (governor-review-log entry, README Index row, repo-facts row, PR template fill). `Sync Required: true`. (Output captured in the follow-up `governor-review-log/pr-{N}-...md` Self-Application Proof section.)
- [x] `/sync-guidelines` (manual scan) — `Mode: review follow-up`; AUTO-FIX applied (matrix Tier 3 + Bucket Distribution Summary + repo-facts); REVIEW carries IC-11 forward to Phase 4 (#123); `Remaining: none` post-PR-create. (Same.)

### Review trail artifact

- [x] `docs/ai/shared/governor-review-log/pr-{this-PR-NNN}-userpromptsubmit-token-parser.md` — added in the follow-up commit immediately after this PR's creation. `{NNN}` matches this PR number per IC-10 / HC-3.
- [x] `governor-review-log/README.md` Index table updated — same follow-up commit.
- [x] Issue #123 (Phase 4) body edited to link the new IC-11 (marker lifecycle) — same follow-up step.

### Doc-only escape hygiene

- [x] N/A. This PR is not doc-only (touches hook scripts and tests). Even if it were, the changes touch Tier A/B paths so the doc-only auto-escape would not apply per [`target-operating-model.md` §3](../blob/main/docs/ai/shared/target-operating-model.md).

### Phase context (Phase 2~5 of #117 only)

- [x] PR description links the relevant section of [`migration-strategy.md` §1](../blob/main/docs/ai/shared/migration-strategy.md) (Phase 2).
- [x] Inherited Constraints IC-1 ~ IC-10 reviewed — all preserved by this PR. New IC-11 (Phase 4 marker lifecycle) recorded in this PR's `governor-review-log/` entry.