### PR TITLE
feat(governor): Phase 3 verify-first adapters (Claude PostToolUse + Codex Stop)

### DIFF
--- a/.claude/hooks/verify-first.sh
+++ b/.claude/hooks/verify-first.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# PostToolUse Edit|Write Hook — verify-first reminder (Phase 3 of #117 / #122).
+# Always exits 0 (informational only, never blocks tool use — HC-3.3).
+INPUT=$(cat)
+echo "$INPUT" | python3 "$(dirname "$0")/verify_first.py" || true
+exit 0

--- a/.claude/hooks/verify_first.py
+++ b/.claude/hooks/verify_first.py
@@ -1,0 +1,94 @@
+"""PostToolUse Edit|Write — verify-first reminder (Phase 3 of #117 / #122).
+
+Emits a stderr reminder when a `.py` file is edited and the latest Phase 2
+marker is NOT an [exploration]/[탐색] token. Read-only on Phase 2 markers
+(IC-11 from PR #126; Phase 4 #123 owns lifecycle). Fail-open on every error
+path (HC-3.6).
+
+REMINDER_TEXT is frozen at Phase 3 and string-equal to the Codex side's
+`.codex/hooks/verify_first.py` constant. Parity is asserted by
+`tests/unit/agents_shared/test_verify_first.py::test_reminder_text_string_equality`.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+STATE_DIR = REPO_ROOT / ".claude" / "state"
+
+EXPLORATION_TOKENS = frozenset({"exploration", "탐색"})
+
+REMINDER_TEXT = "\n".join(
+    [
+        "[verify-first] verify 단계가 누락된 것 같습니다. 변경된 .py 파일에 대해 테스트/검증을 권장합니다.",
+        "[verify-first] Verify step appears to be missing for the changed .py files.",
+        "Suggested next: `/test-domain run <domain>` (or `pytest tests/unit/<domain>/`)",
+        "Silence with `[exploration]` / `[탐색]` prefix when intentionally exploring.",
+    ]
+)
+
+
+def read_latest_token_marker(state_dir: Path) -> str | None:
+    """Return token of the most-recent valid Phase 2 marker, or None.
+
+    Most-recent = max by `ts` field (ISO 8601 UTC; lexically chronological).
+    Read-only — never deletes/mutates (IC-11). Phase 4 owns lifecycle.
+    """
+    if not state_dir.exists():
+        return None
+    candidates: list[tuple[str, str]] = []
+    for path in state_dir.glob("exception-token-*.json"):
+        try:
+            record = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        ts = record.get("ts")
+        token = record.get("token")
+        if isinstance(ts, str) and isinstance(token, str):
+            candidates.append((ts, token))
+    if not candidates:
+        return None
+    return max(candidates, key=lambda item: item[0])[1]
+
+
+def extract_file_path(payload: dict) -> str | None:
+    tool_input = payload.get("tool_input") or {}
+    file_path = tool_input.get("file_path")
+    return file_path if isinstance(file_path, str) else None
+
+
+def is_python_source(file_path: str | None) -> bool:
+    return bool(file_path) and file_path.endswith(".py")
+
+
+def should_remind(payload: dict, state_dir: Path = STATE_DIR) -> bool:
+    if not is_python_source(extract_file_path(payload)):
+        return False
+    token = read_latest_token_marker(state_dir)
+    return token not in EXPLORATION_TOKENS
+
+
+def main() -> int:
+    """Read PostToolUse Edit|Write payload from stdin; emit reminder if needed.
+
+    Fail-open: any unexpected exception returns 0 with no output.
+    """
+    try:
+        raw = sys.stdin.read()
+        if not raw.strip():
+            return 0
+        payload = json.loads(raw)
+        if not isinstance(payload, dict):
+            return 0
+        if should_remind(payload):
+            print(REMINDER_TEXT, file=sys.stderr)
+    except Exception:  # noqa: BLE001 — fail-open per HC-3.6
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/rules/project-status.md
+++ b/.claude/rules/project-status.md
@@ -1,6 +1,6 @@
 # Project Status
 
-> Last synced: 2026-04-26 via /sync-guidelines (ADR 045 hybrid harness target architecture + Default Coding Flow + Phase 1 14×3 skill wrapper sync; examples/todo + examples profile + plan-feature approach options)
+> Last synced: 2026-04-27 via /sync-guidelines (Phase 2 #121 UserPromptSubmit token parser + Phase 3 #122 verify-first adapters; migration-strategy.md §7 #NNN → actual issue numbers)
 
 ## Current Version Context
 - Latest release: v0.4.0 (2026-04-21)
@@ -41,6 +41,8 @@
 | Plan-feature Approach Options | #116 | `/plan-feature` workflow에 Phase 1 "Approach Options" 추가 (2-3개 후보 제시 + trade-off + 추천). 기존 Phase 0(Requirements)→1(Architecture)→2(Security)→3(Tasks)이 0→1(Approach)→2(Architecture)→3(Security)→4(Tasks)로 재번호 |
 | examples/todo + Examples Profile | #112, #119 | `examples/{name}/`는 `src/{domain}/` 레이아웃을 그대로 미러링하지만 production test baseline(factories/integration/e2e)을 강제하지 않는 contributor reference. `/review-architecture`가 examples profile을 인식해 §5 Test Coverage(단일 unit test 허용)와 §2 Auth(생략 허용) 항목을 완화. 자동 발견 대상이 아니므로 `cp -r examples/todo src/todo` 후 `make quickstart`로 시연 |
 | Hybrid Harness Target Architecture | #117 (ADR 045) | 7-step Default Coding Flow (`framing → approach options → plan → implement → verify → self-review → completion gate`)을 AGENTS.md § 신설. exception token vocabulary (`[trivial]`/`[hotfix]`/`[exploration]`/`[자명]`/`[긴급]`/`[탐색]`)으로 trivial work에만 escape. Default Flow는 sandbox/approval/`.codex/rules`/safety hook/Absolute Prohibitions 보다 하위. Phase 0+1: 4 design doc (matrix/operating-model/migration-strategy + ADR) + 14×3 skill wrapper에 Default Flow Position section 추가. Phase 2~5는 별도 issue (UserPromptSubmit token parser / Claude PostToolUse Edit\|Write + Codex Stop changed-files / Stop completion gate / shared governor module). |
+| Hybrid Harness Phase 2: UserPromptSubmit Token Parser | #121 (PR #126) | `UserPromptSubmit` 훅에 exception-token 파서 추가. `[trivial]`/`[hotfix]`/`[exploration]`/`[자명]`/`[긴급]`/`[탐색]` prefix 감지 → `.claude/state/` + `.codex/state/`에 Phase 2 마커 JSON 기록. 양쪽 훅 string-equality 보장(IC-2). 마커 lifecycle은 Phase 4(#123)로 유예 (IC-11). |
+| Hybrid Harness Phase 3: verify-first Adapters | #122 (PR #127) | `PostToolUse Edit\|Write` (Claude) / Stop hook (Codex) 양쪽에 verify-first informational reminder 추가. `.py` 수정 후 verify step 누락 시 stderr(Claude) / systemMessage(Codex) 경고. `[exploration]`/`[탐색]` 마커 및 verify-log freshness(`ts_epoch_ns`)로 silence. `CODEX_THREAD_ID` 기반 session-isolated verify-log. 절대 blocking 없음 (HC-3.3). 마커 read-only (IC-11). |
 
 ## Architecture Violation Status
 - Domain → Infrastructure import: CLEAN

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -44,6 +44,10 @@
           {
             "type": "command",
             "command": "bash .claude/hooks/post-tool-format.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/verify-first.sh"
           }
         ]
       }

--- a/.codex/hooks/post-tool-format.py
+++ b/.codex/hooks/post-tool-format.py
@@ -1,31 +1,74 @@
+"""PostToolUse Bash hook (Codex side).
+
+Two responsibilities, both fail-open per HC-3.6:
+1. Format `.py` files touched by a Bash command via `ruff format` + `ruff check --fix`.
+2. Phase 3 (#122): record verify-class commands (`pytest`, `make test`, etc.)
+   to the current-session verify-log so the Stop hook can determine whether
+   verify happened in this session.
+
+R0.4 reinforcement: the entire body is wrapped in a top-level fail-open so
+malformed stdin / missing dependencies / unexpected exceptions never crash
+the hook.
+"""
+
 from __future__ import annotations
 
+import contextlib
 import json
 import shutil
 import subprocess
 import sys
 
-from _shared import REPO_ROOT, extract_python_paths
 
-payload = json.load(sys.stdin)
-command = payload.get("tool_input", {}).get("command", "")
-paths = extract_python_paths(command)
+def _format_python_paths(command: str) -> None:
+    from _shared import REPO_ROOT, extract_python_paths  # local import — fail-open
 
-if not paths or shutil.which("ruff") is None:
-    raise SystemExit(0)
+    paths = extract_python_paths(command)
+    if not paths or shutil.which("ruff") is None:
+        return
+    for path in paths:
+        subprocess.run(  # noqa: S603
+            ["ruff", "format", str(path)],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        subprocess.run(  # noqa: S603
+            ["ruff", "check", "--fix", str(path)],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
 
-for path in paths:
-    subprocess.run(  # noqa: S603
-        ["ruff", "format", str(path)],
-        cwd=REPO_ROOT,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    subprocess.run(  # noqa: S603
-        ["ruff", "check", "--fix", str(path)],
-        cwd=REPO_ROOT,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+
+def _record_verify_class(command: str) -> None:
+    from verify_first import append_verify_log  # local import — fail-open
+
+    append_verify_log(command)
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 0
+    if not isinstance(payload, dict):
+        return 0
+    command = payload.get("tool_input", {}).get("command", "")
+    if not isinstance(command, str) or not command:
+        return 0
+
+    # Both branches fail-open per HC-3.6: formatting / verify-log writer errors
+    # must never crash the hook.
+    with contextlib.suppress(Exception):
+        _format_python_paths(command)
+    with contextlib.suppress(Exception):
+        _record_verify_class(command)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.codex/hooks/post-tool-format.py
+++ b/.codex/hooks/post-tool-format.py
@@ -9,6 +9,10 @@ Two responsibilities, both fail-open per HC-3.6:
 R0.4 reinforcement: the entire body is wrapped in a top-level fail-open so
 malformed stdin / missing dependencies / unexpected exceptions never crash
 the hook.
+
+R1.2 reinforcement: `tool_input` may be null even when the payload is valid
+JSON — use `(payload.get("tool_input") or {})` instead of `.get("tool_input", {})`
+so that None does not propagate to `.get("command")`. Outer broad except added.
 """
 
 from __future__ import annotations
@@ -52,21 +56,20 @@ def _record_verify_class(command: str) -> None:
 def main() -> int:
     try:
         payload = json.load(sys.stdin)
-    except (json.JSONDecodeError, ValueError):
-        return 0
-    if not isinstance(payload, dict):
-        return 0
-    command = payload.get("tool_input", {}).get("command", "")
-    if not isinstance(command, str) or not command:
-        return 0
+        if not isinstance(payload, dict):
+            return 0
+        command = (payload.get("tool_input") or {}).get("command", "")
+        if not isinstance(command, str) or not command:
+            return 0
 
-    # Both branches fail-open per HC-3.6: formatting / verify-log writer errors
-    # must never crash the hook.
-    with contextlib.suppress(Exception):
-        _format_python_paths(command)
-    with contextlib.suppress(Exception):
-        _record_verify_class(command)
-
+        # Both branches fail-open per HC-3.6: formatting / verify-log writer errors
+        # must never crash the hook.
+        with contextlib.suppress(Exception):
+            _format_python_paths(command)
+        with contextlib.suppress(Exception):
+            _record_verify_class(command)
+    except Exception:  # noqa: BLE001 — broad fail-open per HC-3.6 + R1.2
+        return 0
     return 0
 
 

--- a/.codex/hooks/stop-sync-reminder.py
+++ b/.codex/hooks/stop-sync-reminder.py
@@ -1,5 +1,18 @@
+"""Stop hook (Codex side) — sync-reminder + Phase 3 verify-first segment.
+
+Single Stop event output (IC-2): all advisories are collected into a list of
+segments and emitted as one ``{"systemMessage": "<segments joined by \\n\\n>"}``
+JSON line. Empty list = no output.
+
+Phase 3 (#122 / R0.1) reinforcement: the verify-first import is performed
+inside the same ``try`` block that calls ``should_remind`` so an ImportError
+or any module-level failure never crashes the existing sync-reminder
+behaviour (HC-3.6 fail-open).
+"""
+
 from __future__ import annotations
 
+import contextlib
 import json
 
 from _shared import changed_files
@@ -38,26 +51,41 @@ structure = [
     and any(marker in path for marker in STRUCTURE_MARKERS)
 ]
 
+segments: list[str] = []
+
 if foundation:
-    message = "\n".join(
-        [
-            "Guideline sync required before closing this work.",
-            "Foundation files changed:",
-            *[f"- {path}" for path in foundation[:12]],
-            "Codex: run $sync-guidelines",
-            "Claude Code: run /sync-guidelines as well",
-            "Sync is incomplete until project-dna, AUTO-FIX, REVIEW, and Remaining are all reported.",
-            "REVIEW targets must be reported even when no automatic doc edit is needed.",
-        ]
+    segments.append(
+        "\n".join(
+            [
+                "Guideline sync required before closing this work.",
+                "Foundation files changed:",
+                *[f"- {path}" for path in foundation[:12]],
+                "Codex: run $sync-guidelines",
+                "Claude Code: run /sync-guidelines as well",
+                "Sync is incomplete until project-dna, AUTO-FIX, REVIEW, and Remaining are all reported.",
+                "REVIEW targets must be reported even when no automatic doc edit is needed.",
+            ]
+        )
     )
-    print(json.dumps({"systemMessage": message}))
 elif structure:
-    message = "\n".join(
-        [
-            "Guideline sync recommended.",
-            "Domain structure files changed:",
-            *[f"- {path}" for path in structure[:12]],
-            "When you run sync, report both AUTO-FIX and REVIEW targets before closing.",
-        ]
+    segments.append(
+        "\n".join(
+            [
+                "Guideline sync recommended.",
+                "Domain structure files changed:",
+                *[f"- {path}" for path in structure[:12]],
+                "When you run sync, report both AUTO-FIX and REVIEW targets before closing.",
+            ]
+        )
     )
-    print(json.dumps({"systemMessage": message}))
+
+# Phase 3 verify-first segment — fail-open: ImportError / unexpected
+# exception leaves only the existing sync-reminder behaviour intact (R0.1).
+with contextlib.suppress(Exception):
+    import verify_first  # noqa: PLC0415 — local import for fail-open per R0.1
+
+    if verify_first.should_remind():
+        segments.append(verify_first.REMINDER_TEXT)
+
+if segments:
+    print(json.dumps({"systemMessage": "\n\n".join(segments)}))

--- a/.codex/hooks/verify_first.py
+++ b/.codex/hooks/verify_first.py
@@ -17,6 +17,13 @@ R0 reinforcement (post-Round-0 of PR #122):
   ordering when pytest and an edit land in the same wall-clock second
   (R0.3).
 
+R1 reinforcement (post-Round-1 of PR #127):
+- session_id prefers CODEX_THREAD_ID (injected by Codex CLI into ALL hook
+  processes in a session — same value for PostToolUse writer and Stop reader).
+  Falls back to CODEX_SESSION_ID, then to ppid-pid-startns. The ppid-pid-startns
+  fallback is writer/reader-incompatible (each hook process has a different PID
+  and startns) but is preserved for non-Codex test environments (R1.1).
+
 REMINDER_TEXT is frozen at Phase 3 and string-equal to
 `.claude/hooks/verify_first.py` REMINDER_TEXT.
 """
@@ -58,11 +65,11 @@ _PROCESS_START_NS = time.monotonic_ns()
 def session_id() -> str:
     """Stable id within one Codex CLI invocation.
 
-    Prefers ``CODEX_SESSION_ID`` env var; falls back to ``ppid-pid-startns``.
-    The ``startns`` suffix prevents PPID collisions across rapid Codex
-    re-invocations (R0.2).
+    Priority: CODEX_THREAD_ID (Codex-injected, same across all hook processes in
+    a session — R1.1) → CODEX_SESSION_ID (fallback alias) → ppid-pid-startns
+    (non-Codex environments only; writer/reader-incompatible in live Codex).
     """
-    explicit = os.environ.get("CODEX_SESSION_ID")
+    explicit = os.environ.get("CODEX_THREAD_ID") or os.environ.get("CODEX_SESSION_ID")
     if explicit:
         return explicit
     return f"{os.getppid()}-{os.getpid()}-{_PROCESS_START_NS:016x}"

--- a/.codex/hooks/verify_first.py
+++ b/.codex/hooks/verify_first.py
@@ -1,0 +1,198 @@
+"""Stop-side verify-first helper (Phase 3 of #117 / #122).
+
+Imported by `.codex/hooks/stop-sync-reminder.py` (segment merge — IC-2 single
+Stop event output) and by `.codex/hooks/post-tool-format.py` (verify-log
+writer on PostToolUse Bash). NOT registered as its own hook.
+
+Read-only on Phase 2 markers (IC-11 from PR #126; Phase 4 #123 owns
+lifecycle).
+
+R0 reinforcement (post-Round-0 of PR #122):
+- session_id includes pid + monotonic_ns to defeat PPID collisions across
+  concurrent Codex sessions (R0.2).
+- verify-log freshness reads ONLY current session's log file (R0.2 — defeats
+  cross-session silence).
+- Timestamps stored as `ts_epoch_ns: int` (`time.time_ns()`) and compared
+  against `Path.stat().st_mtime_ns`; subsecond precision preserves
+  ordering when pytest and an edit land in the same wall-clock second
+  (R0.3).
+
+REMINDER_TEXT is frozen at Phase 3 and string-equal to
+`.claude/hooks/verify_first.py` REMINDER_TEXT.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+from pathlib import Path
+
+from _shared import REPO_ROOT, changed_files
+
+STATE_DIR = REPO_ROOT / ".codex" / "state"
+
+EXPLORATION_TOKENS = frozenset({"exploration", "탐색"})
+
+REMINDER_TEXT = "\n".join(
+    [
+        "[verify-first] verify 단계가 누락된 것 같습니다. 변경된 .py 파일에 대해 테스트/검증을 권장합니다.",
+        "[verify-first] Verify step appears to be missing for the changed .py files.",
+        "Suggested next: `/test-domain run <domain>` (or `pytest tests/unit/<domain>/`)",
+        "Silence with `[exploration]` / `[탐색]` prefix when intentionally exploring.",
+    ]
+)
+
+VERIFY_PATTERNS = (
+    r"\bpytest\b",
+    r"\bmake\s+test\b",
+    r"\bmake\s+demo(?:-rag)?\b",
+    r"\balembic\s+upgrade\b",
+)
+
+# Cached at module import — collision-resistant suffix even if PPID is reused.
+_PROCESS_START_NS = time.monotonic_ns()
+
+
+def session_id() -> str:
+    """Stable id within one Codex CLI invocation.
+
+    Prefers ``CODEX_SESSION_ID`` env var; falls back to ``ppid-pid-startns``.
+    The ``startns`` suffix prevents PPID collisions across rapid Codex
+    re-invocations (R0.2).
+    """
+    explicit = os.environ.get("CODEX_SESSION_ID")
+    if explicit:
+        return explicit
+    return f"{os.getppid()}-{os.getpid()}-{_PROCESS_START_NS:016x}"
+
+
+def verify_log_path(state_dir: Path = STATE_DIR) -> Path:
+    return state_dir / f"verify-log-{session_id()}.json"
+
+
+def append_verify_log(command: str, state_dir: Path = STATE_DIR) -> Path | None:
+    """Append a verify-class command record to current-session JSONL.
+
+    Append-only (race-safe across concurrent Codex sessions writing different
+    files). Records both ``ts`` (ISO 8601 UTC for human reading) and
+    ``ts_epoch_ns`` (int for subsecond freshness comparison — R0.3).
+    Returns the log path on append, or None if the command does not match
+    any verify pattern.
+    """
+    if not any(re.search(pattern, command) for pattern in VERIFY_PATTERNS):
+        return None
+    state_dir.mkdir(parents=True, exist_ok=True)
+    record = {
+        "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "ts_epoch_ns": time.time_ns(),
+        "cmd": command,
+    }
+    path = verify_log_path(state_dir)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+    return path
+
+
+def current_session_latest_verify_ns(state_dir: Path = STATE_DIR) -> int | None:
+    """Most-recent verify-class entry in the CURRENT session's log only.
+
+    Reads `verify-log-{session_id()}.json` exclusively — does not glob other
+    sessions. Defeats cross-session silence (R0.2). Returns the largest
+    ``ts_epoch_ns`` integer, or ``None`` if the file is missing / empty /
+    every line malformed.
+    """
+    path = verify_log_path(state_dir)
+    if not path.exists():
+        return None
+    latest: int | None = None
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        ns = record.get("ts_epoch_ns")
+        if isinstance(ns, int) and (latest is None or ns > latest):
+            latest = ns
+    return latest
+
+
+def read_latest_token_marker(state_dir: Path) -> str | None:
+    """Return token of the most-recent valid Phase 2 marker, or None.
+
+    Same contract as `.claude/hooks/verify_first.py.read_latest_token_marker`.
+    Duplicated until Phase 5 (#124) consolidates into
+    `.agents/shared/governor/`.
+    """
+    if not state_dir.exists():
+        return None
+    candidates: list[tuple[str, str]] = []
+    for path in state_dir.glob("exception-token-*.json"):
+        try:
+            record = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        ts = record.get("ts")
+        token = record.get("token")
+        if isinstance(ts, str) and isinstance(token, str):
+            candidates.append((ts, token))
+    if not candidates:
+        return None
+    return max(candidates, key=lambda item: item[0])[1]
+
+
+def changed_python_files() -> list[str]:
+    return [p for p in changed_files() if p.endswith(".py")]
+
+
+def max_changed_py_mtime_ns(repo_root: Path = REPO_ROOT) -> int | None:
+    """Largest ``st_mtime_ns`` across changed `.py` files.
+
+    Uses ``stat().st_mtime_ns`` directly so subsecond ordering is preserved
+    (R0.3). Returns ``None`` when no changed `.py` exists or when every
+    file disappeared between ``git status`` and the stat (race).
+    """
+    paths = changed_python_files()
+    mtimes_ns: list[int] = []
+    for relative in paths:
+        full = repo_root / relative
+        try:
+            mtimes_ns.append(full.stat().st_mtime_ns)
+        except OSError:
+            continue
+    if not mtimes_ns:
+        return None
+    return max(mtimes_ns)
+
+
+def should_remind() -> bool:
+    """Codex-side decision. ``False`` = silent, ``True`` = emit reminder.
+
+    Logic:
+      1. No changed `.py` → silent.
+      2. Latest Phase 2 marker is `[exploration]`/`[탐색]` → silent.
+      3. Current session has a verify-class log entry whose
+         ``ts_epoch_ns`` ≥ the largest changed-`.py` ``st_mtime_ns`` →
+         silent (verification is fresh enough).
+      4. Otherwise → emit reminder.
+    """
+    if not changed_python_files():
+        return False
+    token = read_latest_token_marker(REPO_ROOT / ".codex" / "state")
+    if token in EXPLORATION_TOKENS:
+        return False
+    verify_ns = current_session_latest_verify_ns()
+    if verify_ns is None:
+        return True
+    py_mtime_ns = max_changed_py_mtime_ns()
+    if py_mtime_ns is None:
+        return True
+    # Stale verify when log is older than the most recent .py edit.
+    return verify_ns < py_mtime_ns

--- a/docs/ai/shared/governor-review-log/README.md
+++ b/docs/ai/shared/governor-review-log/README.md
@@ -89,3 +89,4 @@ The prompt is a starting point; phase-specific reviews (Phase 2 token parser, Ph
 |---|---|---|---|
 | #125 | hybrid harness target architecture + Phase 1 | #117 | [pr-125-hybrid-harness-target-architecture.md](pr-125-hybrid-harness-target-architecture.md) |
 | #126 | Phase 2: UserPromptSubmit exception-token parser | #121 | [pr-126-userpromptsubmit-token-parser.md](pr-126-userpromptsubmit-token-parser.md) |
+| #127 | Phase 3: verify-first adapters (Claude PostToolUse + Codex Stop) | #122 | [pr-127-verify-first-adapters.md](pr-127-verify-first-adapters.md) |

--- a/docs/ai/shared/governor-review-log/pr-127-verify-first-adapters.md
+++ b/docs/ai/shared/governor-review-log/pr-127-verify-first-adapters.md
@@ -1,0 +1,116 @@
+# PR #127 — Hybrid Harness Phase 3: verify-first adapters (Claude PostToolUse + Codex Stop)
+
+- GitHub PR: <https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/127>
+- Closes: #122
+- Branch: `feat/122-verify-first-adapters` → `main`
+- Date range: 2026-04-27
+- Cross-tool reviewer: `codex exec -m gpt-5.5 --sandbox read-only` (Round 0); Round 1 / Round 2 in progress.
+
+## Summary
+
+Implements Phase 3 of [ADR 045](../../history/045-hybrid-harness-target-architecture.md): adds informational verify-first reminders to both harnesses so the `verify` step of the Default Coding Flow is not silently skipped.
+
+- **Claude side** — new `PostToolUse Edit|Write` sibling hook pair (`.claude/hooks/verify-first.sh` + `.claude/hooks/verify_first.py`). On every `.py` edit, reads the latest Phase 2 marker from `.claude/state/exception-token-*.json`; emits bilingual stderr reminder unless the token is `[exploration]`/`[탐색]`. Never blocks (HC-3.3). Fail-open on all error paths (HC-3.6).
+- **Codex side** — Stop hook segment merge pattern (IC-2). New library module `.codex/hooks/verify_first.py` imported by the existing `stop-sync-reminder.py` (no new hooks.json entry). `.codex/hooks/post-tool-format.py` extended with a verify-log writer that records `pytest` / `make test` / `make demo[-rag]` / `alembic upgrade` invocations as JSONL to `.codex/state/verify-log-{session_id}.json`. `stop-sync-reminder.py` refactored to a segments list (IC-2 single output) and appends a verify-first segment when changed `.py` files exist and the current-session verify-log is absent or stale.
+- Phase 2 `[exploration]`/`[탐색]` markers silence both adapters. Read-only on Phase 2 markers (IC-11; lifecycle is Phase 4 #123's responsibility). Informational only — never blocks commit or Stop (HC-3.3).
+- Tests: `tests/unit/agents_shared/test_verify_first.py` (25 cases). String-equality of `REMINDER_TEXT` across tools (IC-2 cornerstone). Silence on `[exploration]`/`[탐색]` markers (both Claude and Codex). Non-silence on `[trivial]`/`[hotfix]`. Non-Python edits silent. Codex verify-log freshness (recent → silent; stale → remind). Cross-session silence prevention (R0.2). Fail-open smokes. Marker read idempotency (IC-11). 7-case parametrised verify-log writer pattern suite.
+- Docs: `harness-asset-matrix.md` Tier 3 +3 rows (Total 58→61, Bucket Distribution updated); `repo-facts.md` registers `.codex/state/verify-log-{session_id}.json` surface.
+
+R0 reinforcement applied before any implementation file was touched: import fail-open (R0.1), current-session-only verify-log to defeat cross-session silence (R0.2), subsecond `ts_epoch_ns` freshness comparison (R0.3), top-level fail-open in `post-tool-format.py` (R0.4), Codex marker silence parity tests + test name correction (R0.5).
+
+## Review Rounds
+
+### Round 0 — Plan Review (plan stage)
+
+- **Target**: `/Users/coursemos/.claude/plans/122-playful-snail.md` (Phase 3 plan, §1~§15 + §16 R0 Reinforcement Log).
+- **Reviewer**: `codex exec -m gpt-5.5 --sandbox read-only` (Codex CLI, read-only sandbox).
+- **Final Verdict**: `still needs reinforcement` → all 5 R-points (R0.1~R0.5) reflected into plan §16 "R0 Reinforcement Log" before implementation files were created.
+- **R-points** (full text in plan §16; abbreviated here):
+  - **R0.1** (merge-blocking): `import verify_first` at module level in `stop-sync-reminder.py` — if import fails, entire Stop hook crashes, violating HC-3.6. → **Applied**: import moved inside `with contextlib.suppress(Exception):` block; existing sync-reminder behaviour preserved on ImportError.
+  - **R0.2** (merge-blocking): `latest_verify_log_ts()` originally globbed all `verify-log-*.json` files → a prior Codex session's `pytest` run could silence the current session (cross-session contamination). → **Applied**: reads only `verify-log-{session_id()}.json` (current session); `session_id()` uses `CODEX_SESSION_ID or f"{ppid}-{pid}-{start_ns_hex}"` to defeat PPID collision across rapid Codex re-invocations. Renamed to `current_session_latest_verify_ns()`.
+  - **R0.3** (merge-blocking): ISO 8601 string comparison truncated to 1-second precision → false-negative when `pytest` and `.py` edit land in the same wall-clock second. → **Applied**: JSONL stores `ts_epoch_ns: int` (`time.time_ns()`); mtime comparison uses `Path.stat().st_mtime_ns`; `should_remind()` compares `verify_ns < py_mtime_ns` (epoch-ns integers).
+  - **R0.4** (merge-blocking): `post-tool-format.py` had no top-level fail-open — `json.load(sys.stdin)` could crash on invalid stdin now that the hook has Phase 3 verify-log writer responsibility. → **Applied**: entire body wrapped in `def main()` with `try/except (json.JSONDecodeError, ValueError)` around stdin parse; both format and record branches use `with contextlib.suppress(Exception):`.
+  - **R0.5** (advisory): test name `test_codex_silent_when_verify_log_older_than_py_mtime` backwards (assert is `True` = reminds); Codex marker silence parity tests missing; `git status --porcelain` wording vs `_shared.changed_files()` wording. → **Applied**: test renamed `test_codex_reminds_when_verify_log_older_than_py_mtime`; `test_codex_silent_on_exploration_marker` + `test_codex_silent_on_korean_탐색_marker` added; wording uses function name.
+
+### Round 1 — Implementation Review
+
+- **Target**: 4-commit working tree (commits d143491, 9d88064, 000893f, 2283dad). Pytest 25/25 PASSED at submission time.
+- **Reviewer**: *(pending — to be run post-PR-create; log entry extended as backfill commit)*
+- **Status**: In progress.
+
+### Round 2 — Cross-Check (gate-on-gate)
+
+- **Target**: post-R1-fix working tree.
+- **Reviewer**: *(pending — to be run after Round 1 resolves its R-points)*
+- **Status**: In progress.
+
+## Inherited Constraints
+
+Carried from prior governor-changing PRs (no new IC introduced by Phase 3 — by design):
+
+| IC | Source | Rule | Phase 3 application |
+|---|---|---|---|
+| IC-1 | PR #125 | Shared rules live in `AGENTS.md` + `docs/ai/shared/` | Phase 3 hook spec derived from `AGENTS.md` Default Flow |
+| IC-2 | PR #125 | Single Stop event output (Codex) | `stop-sync-reminder.py` segments list → single `{"systemMessage": ...}` |
+| IC-3 | PR #125 | Token regex canonical form in `AGENTS.md` | Phase 3 reads Phase 2 markers; no new token vocab |
+| IC-4 | PR #125 | Exception tokens do not override Absolute Prohibitions | Phase 3 is informational only; no override path |
+| IC-5 | PR #125 | Codex `apply_patch` is invisible to `^Bash$` matcher | Codex reminder uses Stop changed-files (`_shared.changed_files()`); verify-log writer on PostToolUse Bash only records, never emits |
+| IC-6 | PR #125 | Hook spec lives in `AGENTS.md`; skills in `.agents/skills/` | Phase 3 hooks registered in `CLAUDE.md` + `AGENTS.md` sections |
+| IC-7 | PR #125 | `governor-paths.md` is the canonical governor-changing path list | No new paths added in Phase 3 |
+| IC-8 | PR #125 | Cross-tool review is multi-round Codex `gpt-5.5 --sandbox read-only` | Round 0 completed; Rounds 1/2 in progress |
+| IC-9 | PR #125 | Governor-review-log entry required before merge (HC-3.5) | This file — log-only-backfill commit 5 |
+| IC-10 | PR #125 | PR template Governor-Changing section required | PR #127 body fills the section |
+| IC-11 | PR #126 | Phase 2 marker lifecycle is un-decided; Phase 3 is read-only | `read_latest_token_marker()` reads only; no delete/mutate anywhere in Phase 3 |
+| HC-1 | PR #126 | Codex safety-block-first; parser runs only after safety pass | Phase 3 hooks all fail-open (HC-3.6); safety hook path unchanged |
+
+## Self-Application Proof
+
+*(Populated as backfill once Round 1 / Round 2 complete and self-review skills run)*
+
+### `/review-architecture all`
+
+```
+Scope: ...
+Sources Loaded: ...
+Findings: ...
+Drift Candidates: ...
+Next Actions: ...
+Completion State: ...
+Sync Required: ...
+```
+
+### `/sync-guidelines`
+
+```
+Mode: ...
+Input Drift Candidates: ...
+project-dna: ...
+AUTO-FIX: ...
+REVIEW: ...
+Remaining: ...
+Next Actions: ...
+```
+
+### `/review-pr 127`
+
+```
+Scope: ...
+Sources Loaded: ...
+Findings: ...
+Drift Candidates: ...
+Next Actions: ...
+Completion State: ...
+Sync Required: ...
+```
+
+## New Inherited Constraints
+
+None introduced by Phase 3 (by design — Phase 3 is informational only, no new lifecycle decisions).
+
+Open questions carried into Phase 4 (#123):
+- IC-11 marker lifecycle (read-and-delete vs. age-based filter vs. session-id correlation) — same open question as PR #126.
+- `.codex/state/verify-log-{session_id}.json` lifecycle — shares IC-11 open question; Phase 4 decides both at once.
+
+## 1-week soak measurement
+
+*(Backfill commit after 2026-05-04 — false-positive rate measurement: reminder fires / total reminder events where silence would have been correct)*

--- a/docs/ai/shared/governor-review-log/pr-127-verify-first-adapters.md
+++ b/docs/ai/shared/governor-review-log/pr-127-verify-first-adapters.md
@@ -34,9 +34,13 @@ R0 reinforcement applied before any implementation file was touched: import fail
 
 ### Round 1 — Implementation Review
 
-- **Target**: 4-commit working tree (commits d143491, 9d88064, 000893f, 2283dad). Pytest 25/25 PASSED at submission time.
-- **Reviewer**: *(pending — to be run post-PR-create; log entry extended as backfill commit)*
-- **Status**: In progress.
+- **Target**: 6-commit working tree (commits d143491, 9d88064, 000893f, 2283dad, 689f1e5, 0f02e8a). Pytest 25/25 PASSED. PR #127 open.
+- **Reviewer**: Claude Code (cross-session review via empirical env var probe + code inspection).
+- **Final Verdict**: `minor fixes recommended` → 3 R-points surfaced (R1.1~R1.3); all applied in commit `0f02e8a`.
+- **R-points** (all resolved):
+  - **R1.1** (block-级): `session_id()` originally preferred `CODEX_SESSION_ID`, but empirical `python3 -c` probe inside the Codex sandbox confirmed `CODEX_SESSION_ID` is **not injected** by Codex CLI. The actual env var is `CODEX_THREAD_ID` (stable across all hook processes in a session). → **Applied**: `session_id()` priority chain updated to `CODEX_THREAD_ID → CODEX_SESSION_ID → ppid-pid-startns`. Tests updated to `monkeypatch.setenv("CODEX_THREAD_ID", ...)` + `monkeypatch.delenv("CODEX_SESSION_ID", raising=False)`.
+  - **R1.2** (block-급): `post-tool-format.py` originally used `payload.get("tool_input", {})` which returns `None` when the key is present but explicitly `null` in the JSON payload, causing `AttributeError: 'NoneType' object has no attribute 'get'`. → **Applied**: changed to `(payload.get("tool_input") or {}).get("command", "")` + added outer broad `except Exception: return 0` (R0.4 strengthened).
+  - **R1.3** (advisory): Direct unit test that Codex `should_remind()` respects `[exploration]`/`[탐색]` marker silence was missing (only Claude side tested). → **Applied**: `test_codex_silent_on_exploration_marker_should_remind` + `test_codex_silent_on_korean_탐색_marker_should_remind` added; test count 25 → 27.
 
 ### Round 2 — Cross-Check (gate-on-gate)
 
@@ -65,42 +69,79 @@ Carried from prior governor-changing PRs (no new IC introduced by Phase 3 — by
 
 ## Self-Application Proof
 
-*(Populated as backfill once Round 1 / Round 2 complete and self-review skills run)*
+Executed in same PR #127 review session (2026-04-27).
 
 ### `/review-architecture all`
 
 ```
-Scope: ...
-Sources Loaded: ...
-Findings: ...
-Drift Candidates: ...
-Next Actions: ...
-Completion State: ...
-Sync Required: ...
+Scope: All 3 active domains (user, classification, docs) + _core
+Sources Loaded: AGENTS.md, project-dna.md, architecture-review-checklist.md,
+  security-checklist.md
+Findings:
+  [OK] §1 Layer Dependency — clean in all domains
+  [OK] §2 Auth — JWT not yet implemented (project-wide known gap per project-dna)
+  [OK] §3 Conversion — DTO ↔ Model patterns correct throughout
+  [OK] §4 Repository — no Model objects leak outside Repositories
+  [OK] §5 Test Coverage — all 3 domains have unit + integration + e2e baselines
+    [MEDIUM] pre-existing: user admin unit tests missing (src/user/interface/admin/)
+    [MEDIUM] pre-existing: classification admin unit tests missing (src/classification/interface/admin/)
+  [OK] §6 Infrastructure DI — Selector/lazy-factory pattern correct; AWS + admin extras guarded
+  [OK] §7 Error Translation — error_mapper ACL established; domain exceptions propagate correctly
+  [OK] §8 Hook surface — governance-only PR; src/ untouched; hook changes reviewed separately
+  [OK] §9 Migration — no new migrations in this PR
+Drift Candidates:
+  - docs/ai/shared/migration-strategy.md §7: #NNN → actual issue numbers
+    auto-fix: yes  sync-required: optional (advisory only)
+Next Actions: Run /sync-guidelines to fix migration-strategy.md §7 (auto-fixable).
+Completion State: complete (no open findings; 2 pre-existing MEDIUM admin test gaps pre-date this PR)
+Sync Required: false
 ```
 
 ### `/sync-guidelines`
 
 ```
-Mode: ...
-Input Drift Candidates: ...
-project-dna: ...
-AUTO-FIX: ...
-REVIEW: ...
-Remaining: ...
-Next Actions: ...
+Mode: drift-candidate follow-up (from /review-architecture all drift candidate)
+Input Drift Candidates:
+  - docs/ai/shared/migration-strategy.md §7: #NNN placeholder → actual issue numbers
+  - .claude/rules/project-status.md: Phase 2 + Phase 3 entries missing; Last synced stale
+project-dna: no changes required
+AUTO-FIX:
+  - migration-strategy.md §7: #NNN → #121/PR#126, #122/PR#127, #123, #124 (applied)
+  - project-status.md: Phase 2 (#121/PR#126) + Phase 3 (#122/PR#127) rows added;
+    Last synced updated to 2026-04-27 (applied)
+REVIEW: none
+Remaining: none
+Next Actions: commit sync changes as log-only-backfill commit
+  → committed as 1109839 "docs(governor): sync migration-strategy §7 issue numbers + project-status Phase 3 entry"
 ```
 
 ### `/review-pr 127`
 
 ```
-Scope: ...
-Sources Loaded: ...
-Findings: ...
-Drift Candidates: ...
-Next Actions: ...
-Completion State: ...
-Sync Required: ...
+Scope: PR #127 Phase 3 verify-first adapters — 11 changed files, governance-only
+Sources Loaded: AGENTS.md, project-dna.md, architecture-review-checklist.md,
+  security-checklist.md, drift-checklist.md §1D, PR #125 + PR #126 governor-review-log entries
+Findings:
+  [OK][BLOCKING-class] HC-3.6 fail-open: all 5 surfaces (verify-first.sh, verify_first.py Claude,
+    post-tool-format.py R0.4, stop-sync-reminder.py R0.1, verify_first.py Codex library)
+  [OK][BLOCKING-class] IC-5: Codex reminder from Stop only; post-tool-format records only
+  [OK][BLOCKING-class] IC-11: read_latest_token_marker() read-only in both helpers
+  [OK][BLOCKING-class] HC-3.3: informational only, exit 0 / return 0 unconditional
+  [OK][BLOCKING-class] IC-2: segments list → single systemMessage print
+  [OK][HIGH] R1.1 CODEX_THREAD_ID priority; R1.2 null tool_input; R1.3 Codex marker silence tests
+  [OK][MEDIUM] REMINDER_TEXT string equality + test assertion; R0.2 cross-session; R0.3 ts_epoch_ns
+  [OK][MEDIUM] 27 test cases; subprocess fail-open smokes; IC-11 marker idempotency
+  [OK][LOW] drift-checklist §1D: pr-127 filename match; README index row; matrix + repo-facts
+  [NOTE] governor-review-log §Round1 + §Self-Application Proof pending → filled by this backfill commit
+Drift Candidates:
+  - migration-strategy.md §7 #NNN: FIXED by /sync-guidelines run (committed 1109839)
+  - project-status.md Phase 2+3 entries: FIXED by /sync-guidelines run (committed 1109839)
+Next Actions:
+  1. Commit this Self-Application Proof update (backfill commit)
+  2. Run Round 2 Codex cross-tool review
+  3. Merge after Round 2 verdict
+Completion State: complete with no open findings; drift candidates resolved and committed
+Sync Required: true (docs/ai/shared/ in diff; resolved by /sync-guidelines run 1109839)
 ```
 
 ## New Inherited Constraints

--- a/docs/ai/shared/governor-review-log/pr-127-verify-first-adapters.md
+++ b/docs/ai/shared/governor-review-log/pr-127-verify-first-adapters.md
@@ -13,7 +13,7 @@ Implements Phase 3 of [ADR 045](../../history/045-hybrid-harness-target-architec
 - **Claude side** — new `PostToolUse Edit|Write` sibling hook pair (`.claude/hooks/verify-first.sh` + `.claude/hooks/verify_first.py`). On every `.py` edit, reads the latest Phase 2 marker from `.claude/state/exception-token-*.json`; emits bilingual stderr reminder unless the token is `[exploration]`/`[탐색]`. Never blocks (HC-3.3). Fail-open on all error paths (HC-3.6).
 - **Codex side** — Stop hook segment merge pattern (IC-2). New library module `.codex/hooks/verify_first.py` imported by the existing `stop-sync-reminder.py` (no new hooks.json entry). `.codex/hooks/post-tool-format.py` extended with a verify-log writer that records `pytest` / `make test` / `make demo[-rag]` / `alembic upgrade` invocations as JSONL to `.codex/state/verify-log-{session_id}.json`. `stop-sync-reminder.py` refactored to a segments list (IC-2 single output) and appends a verify-first segment when changed `.py` files exist and the current-session verify-log is absent or stale.
 - Phase 2 `[exploration]`/`[탐색]` markers silence both adapters. Read-only on Phase 2 markers (IC-11; lifecycle is Phase 4 #123's responsibility). Informational only — never blocks commit or Stop (HC-3.3).
-- Tests: `tests/unit/agents_shared/test_verify_first.py` (25 cases). String-equality of `REMINDER_TEXT` across tools (IC-2 cornerstone). Silence on `[exploration]`/`[탐색]` markers (both Claude and Codex). Non-silence on `[trivial]`/`[hotfix]`. Non-Python edits silent. Codex verify-log freshness (recent → silent; stale → remind). Cross-session silence prevention (R0.2). Fail-open smokes. Marker read idempotency (IC-11). 7-case parametrised verify-log writer pattern suite.
+- Tests: `tests/unit/agents_shared/test_verify_first.py` (28 cases). String-equality of `REMINDER_TEXT` across tools (IC-2 cornerstone). Silence on `[exploration]`/`[탐색]` markers (both Claude and Codex). Non-silence on `[trivial]`/`[hotfix]`. Non-Python edits silent. Codex `should_remind()` marker silence direct tests (R1.3). Codex verify-log freshness (recent → silent; stale → remind). Cross-session silence prevention (R0.2 + R1.1 CODEX_THREAD_ID). Fail-open smokes. Marker read idempotency (IC-11). 7-case parametrised verify-log writer pattern suite. `tool_input: null` fail-open regression (R2.3).
 - Docs: `harness-asset-matrix.md` Tier 3 +3 rows (Total 58→61, Bucket Distribution updated); `repo-facts.md` registers `.codex/state/verify-log-{session_id}.json` surface.
 
 R0 reinforcement applied before any implementation file was touched: import fail-open (R0.1), current-session-only verify-log to defeat cross-session silence (R0.2), subsecond `ts_epoch_ns` freshness comparison (R0.3), top-level fail-open in `post-tool-format.py` (R0.4), Codex marker silence parity tests + test name correction (R0.5).
@@ -44,9 +44,13 @@ R0 reinforcement applied before any implementation file was touched: import fail
 
 ### Round 2 — Cross-Check (gate-on-gate)
 
-- **Target**: post-R1-fix working tree.
-- **Reviewer**: *(pending — to be run after Round 1 resolves its R-points)*
-- **Status**: In progress.
+- **Target**: 9-commit working tree (commits d143491 ~ 8bbf5a5). R1.1~R1.3 applied. Self-Application Proof committed.
+- **Reviewer**: `codex exec -m gpt-5.5 --sandbox read-only` (Codex CLI, read-only sandbox).
+- **Final Verdict**: `minor fixes recommended` → 3 R-points surfaced (R2.1~R2.3); all applied in next backfill commit.
+- **R-points** (all resolved):
+  - **R2.1** (doc drift): `harness-asset-matrix.md:633` described `session_id()` as `CODEX_SESSION_ID or fallback` — stale after R1.1 changed priority to `CODEX_THREAD_ID → CODEX_SESSION_ID → ppid-pid-startns`. → **Applied**: description updated to match actual priority chain.
+  - **R2.2** (log accuracy): `pr-127-verify-first-adapters.md:16` Summary said `25 cases` — stale after R1.3 brought count to 27. → **Applied**: updated to `27 cases` (R2.3 then added one more → `28 cases`).
+  - **R2.3** (optional test): `post-tool-format.py` `tool_input: null` path tested only by code inspection; no subprocess regression test. → **Applied**: `test_codex_post_tool_format_null_tool_input_fail_open` added; 28 tests total, all pass.
 
 ## Inherited Constraints
 
@@ -130,7 +134,7 @@ Findings:
   [OK][BLOCKING-class] IC-2: segments list → single systemMessage print
   [OK][HIGH] R1.1 CODEX_THREAD_ID priority; R1.2 null tool_input; R1.3 Codex marker silence tests
   [OK][MEDIUM] REMINDER_TEXT string equality + test assertion; R0.2 cross-session; R0.3 ts_epoch_ns
-  [OK][MEDIUM] 27 test cases; subprocess fail-open smokes; IC-11 marker idempotency
+  [OK][MEDIUM] 28 test cases; subprocess fail-open smokes; IC-11 marker idempotency; R1.2 null regression
   [OK][LOW] drift-checklist §1D: pr-127 filename match; README index row; matrix + repo-facts
   [NOTE] governor-review-log §Round1 + §Self-Application Proof pending → filled by this backfill commit
 Drift Candidates:

--- a/docs/ai/shared/harness-asset-matrix.md
+++ b/docs/ai/shared/harness-asset-matrix.md
@@ -630,7 +630,7 @@ Sixteen hook scripts (6 Claude shell + 3 Claude Python implementations + 7 Codex
 - **Current role**: Phase 3 (#122) verify-first decision helper. Library module — NOT registered as its own hook (IC-2 single Stop event output). Imported by `stop-sync-reminder.py` (decision) and `post-tool-format.py` (verify-log writer).
 - **Why it exists**: Codex side cannot trigger reminders on `PostToolUse Bash` because `apply_patch` is invisible there (IC-5). Detection happens at Stop time using `_shared.changed_files()` + per-session verify-log freshness check.
 - **Bucket**: Overlay.
-- **Notes**: `REMINDER_TEXT` is string-equal to `.claude/hooks/verify_first.py`. `session_id()` = `CODEX_SESSION_ID` env var or `f"{ppid}-{pid}-{start_ns:016x}"` fallback (R0.2 — defeats PPID collision). Verify-log entries store `ts_epoch_ns` for subsecond freshness comparison against `Path.stat().st_mtime_ns` (R0.3). `read_latest_token_marker` duplicated from Claude side — consolidated by Phase 5 (#124).
+- **Notes**: `REMINDER_TEXT` is string-equal to `.claude/hooks/verify_first.py`. `session_id()` priority: `CODEX_THREAD_ID` (Codex CLI injects this into all hook processes in a session — R1.1) → `CODEX_SESSION_ID` (fallback alias) → `f"{ppid}-{pid}-{start_ns:016x}"` (non-Codex environments; writer/reader-incompatible across processes). Verify-log entries store `ts_epoch_ns` for subsecond freshness comparison against `Path.stat().st_mtime_ns` (R0.3). `read_latest_token_marker` duplicated from Claude side — consolidated by Phase 5 (#124).
 
 ---
 

--- a/docs/ai/shared/harness-asset-matrix.md
+++ b/docs/ai/shared/harness-asset-matrix.md
@@ -504,7 +504,7 @@ Bucket guideline:
 
 ## Tier 3 — Hooks
 
-Thirteen hook scripts (5 Claude shell + 2 Claude Python implementations + 6 Codex Python). Phase 2 (#121) added `.claude/hooks/user-prompt-submit.sh` + `.claude/hooks/user_prompt_submit.py` as the first Claude UserPromptSubmit hook surface; the Codex side `.codex/hooks/user-prompt-submit.py` was extended (behaviour-preserving) with the same exception-token parser. Pre-Phase-2 every hook handled **safety, formatting, or drift reminders**; Phase 2 introduced the first *process-governor* hook (token recognition).
+Sixteen hook scripts (6 Claude shell + 3 Claude Python implementations + 7 Codex Python). Phase 2 (#121) added `.claude/hooks/user-prompt-submit.sh` + `.claude/hooks/user_prompt_submit.py` as the first Claude UserPromptSubmit hook surface; Phase 3 (#122) added `.claude/hooks/verify-first.{sh,py}` as a **sibling** hook in the existing `PostToolUse Edit|Write` matcher block, plus `.codex/hooks/verify_first.py` as a library module imported by the Stop hook (segment merge, IC-2). The Codex side `.codex/hooks/post-tool-format.py` was extended (behaviour-preserving) to record verify-class commands to `.codex/state/verify-log-{session}.json`. Phase 3 introduces the second *process-governor* hook surface (verify-first reminder).
 
 | Asset | Bucket | Risk | Impact |
 |---|---|---|---|
@@ -513,14 +513,17 @@ Thirteen hook scripts (5 Claude shell + 2 Claude Python implementations + 6 Code
 | `.claude/hooks/post-tool-format.sh` | Keep | Low | Medium |
 | `.claude/hooks/stop-sync-reminder.sh` | Keep | Low | Medium |
 | `.claude/hooks/user-prompt-submit.sh` | Keep | Low | Medium |
+| `.claude/hooks/verify-first.sh` | Overlay | Low | Low |
 | `.claude/hooks/pre_tool_security.py` | Keep | Low | Medium |
 | `.claude/hooks/user_prompt_submit.py` | Keep | Low | Medium |
+| `.claude/hooks/verify_first.py` | Overlay | Low | Low |
 | `.codex/hooks/_shared.py` | Keep | Low | Low |
 | `.codex/hooks/session-start.py` | Keep | Low | Low |
 | `.codex/hooks/user-prompt-submit.py` | Keep | Low | Medium |
 | `.codex/hooks/pre-tool-security.py` | Keep | Low | Medium |
 | `.codex/hooks/post-tool-format.py` | Keep | Low | Medium |
 | `.codex/hooks/stop-sync-reminder.py` | Keep | Low | Medium |
+| `.codex/hooks/verify_first.py` | Overlay | Low | Low |
 
 ### `.claude/hooks/check-required-plugins.sh`
 
@@ -541,7 +544,7 @@ Thirteen hook scripts (5 Claude shell + 2 Claude Python implementations + 6 Code
 - **Current role**: PostToolUse on Edit / Write; runs `ruff format` + `ruff check --fix` on `.py` files.
 - **Why it exists**: Format consistency without manual invocation.
 - **Bucket**: Keep.
-- **Notes**: Phase 3 verification-first hook will be **adjacent** to this hook (different matcher), not a replacement.
+- **Notes**: Phase 3 (#122) verification-first hook (`.claude/hooks/verify-first.sh`) lives in the *same* `PostToolUse Edit|Write` matcher block as a sibling, not a separate matcher. SoC: this hook mutates files (ruff), the verify-first hook is informational stderr only.
 
 ### `.claude/hooks/stop-sync-reminder.sh`
 
@@ -590,6 +593,20 @@ Thirteen hook scripts (5 Claude shell + 2 Claude Python implementations + 6 Code
 - **Bucket**: Keep.
 - **Notes**: Output is identical to `.codex/hooks/user-prompt-submit.py` parser. Parity asserted by `tests/unit/agents_shared/test_token_parser.py` (silent-divergence safety net for D1=B).
 
+### `.claude/hooks/verify-first.sh`
+
+- **Current role**: Phase 3 (#122) PostToolUse `Edit|Write` sibling wrapper. Pipes stdin to `verify_first.py`; always exits 0 (HC-3.3 informational only).
+- **Why it exists**: New SoC surface — formatting (`post-tool-format.sh`) is mutating; verify-first is advisory. Mixing them in one script complicates failure modes.
+- **Bucket**: Overlay.
+- **Notes**: Mirrors the `pre-tool-security.sh` + `pre_tool_security.py` shape. Phase 5 (#124) consolidates with `.codex/hooks/verify_first.py` into `.agents/shared/governor/`.
+
+### `.claude/hooks/verify_first.py`
+
+- **Current role**: Phase 3 (#122) verify-first decision helper. Reads PostToolUse Edit|Write payload from stdin; if the changed `file_path` ends with `.py` AND the latest Phase 2 marker is not `[exploration]/[탐색]`, prints a frozen `REMINDER_TEXT` to stderr.
+- **Why it exists**: Reminds the user that the Default Coding Flow `verify` step is missing for the changed Python file. Read-only on Phase 2 markers (IC-11 from PR #126; Phase 4 #123 owns lifecycle).
+- **Bucket**: Overlay.
+- **Notes**: `REMINDER_TEXT` constant is string-equal to `.codex/hooks/verify_first.py`. Parity asserted by `tests/unit/agents_shared/test_verify_first.py::test_reminder_text_string_equality`. Fail-open on every error path (HC-3.6).
+
 ### `.codex/hooks/pre-tool-security.py`
 
 - **Current role**: PreToolUse Bash matcher; checks destructive commands, SQL injection patterns, secret leakage.
@@ -598,15 +615,22 @@ Thirteen hook scripts (5 Claude shell + 2 Claude Python implementations + 6 Code
 
 ### `.codex/hooks/post-tool-format.py`
 
-- **Current role**: PostToolUse Bash matcher; runs ruff after a Bash invocation that touched Python files.
-- **Bucket**: Keep — but Codex R7 is critical: this hook **does not see** edits that bypass Bash (e.g. `apply_patch`). Phase 3 verification-first must rely on Stop-side change detection for Codex, not on extending this hook.
-- **Notes**: Largest Codex-side blind spot identified during Phase 0.5 review.
+- **Current role**: PostToolUse Bash matcher. Two responsibilities: (1) runs ruff after a Bash invocation that touched Python files; (2) Phase 3 (#122) — records verify-class commands (`pytest`, `make test`, `make demo[-rag]`, `alembic upgrade`) to `.codex/state/verify-log-{session}.json` so the Stop hook can detect whether verify happened in this session.
+- **Bucket**: Keep — but Codex R7 is critical: this hook **does not see** edits that bypass Bash (e.g. `apply_patch`). Phase 3 verification-first reminder relies on Stop-side change detection for Codex (`.codex/hooks/stop-sync-reminder.py` extension), not on extending this hook to emit reminders.
+- **Notes**: Largest Codex-side blind spot identified during Phase 0.5 review. Phase 3 R0.4 wraps the file in a top-level fail-open so invalid stdin / ruff-missing / verify-log writer failures all return exit 0.
 
 ### `.codex/hooks/stop-sync-reminder.py`
 
-- **Current role**: Stop reminder for drift detection.
+- **Current role**: Stop hook with two segments merged into a single `{"systemMessage": "..."}` JSON output (IC-2): (1) sync-reminder for foundation/structure path drift; (2) Phase 3 (#122) verify-first segment via `verify_first.should_remind()` import (current-session log read only — R0.2; subsecond freshness — R0.3).
 - **Bucket**: Keep.
-- **Notes**: Phase 4 completion-gate output is merged into this hook's existing output; Codex R2.
+- **Notes**: Phase 4 completion-gate output is merged as a third segment in the same hook output; Codex R2. Phase 3 R0.1: the verify-first import is performed inside the same `try` block that calls `should_remind` so an ImportError leaves the existing sync-reminder behaviour intact (HC-3.6 fail-open).
+
+### `.codex/hooks/verify_first.py`
+
+- **Current role**: Phase 3 (#122) verify-first decision helper. Library module — NOT registered as its own hook (IC-2 single Stop event output). Imported by `stop-sync-reminder.py` (decision) and `post-tool-format.py` (verify-log writer).
+- **Why it exists**: Codex side cannot trigger reminders on `PostToolUse Bash` because `apply_patch` is invisible there (IC-5). Detection happens at Stop time using `_shared.changed_files()` + per-session verify-log freshness check.
+- **Bucket**: Overlay.
+- **Notes**: `REMINDER_TEXT` is string-equal to `.claude/hooks/verify_first.py`. `session_id()` = `CODEX_SESSION_ID` env var or `f"{ppid}-{pid}-{start_ns:016x}"` fallback (R0.2 — defeats PPID collision). Verify-log entries store `ts_epoch_ns` for subsecond freshness comparison against `Path.stat().st_mtime_ns` (R0.3). `read_latest_token_marker` duplicated from Claude side — consolidated by Phase 5 (#124).
 
 ---
 
@@ -669,13 +693,13 @@ Six rule files (5 Claude + 1 Codex). All `Keep` except `commands.md` which becom
 
 | Bucket | Count | Share | Notes |
 |---|---|---|---|
-| Keep | 50 | ~86% | Project-specific architecture / safety / reference value (incl. 4 design + 3 self-coherence-recovery process-governor artefacts + 2 Phase 2 #121 hooks) |
-| Overlay | 8 | ~14% | Process discipline now routed by Default Flow |
+| Keep | 50 | ~82% | Project-specific architecture / safety / reference value (incl. 4 design + 3 self-coherence-recovery process-governor artefacts + 2 Phase 2 #121 hooks) |
+| Overlay | 11 | ~18% | Process discipline now routed by Default Flow (Phase 3 #122 adds 3 verify-first hooks) |
 | Replace | 0 | 0% | None in initial inventory; reserved for future passes |
 | Drop | 0 | 0% | Initial pass found no genuinely removable assets |
-| **Total** | **58** | 100% | |
+| **Total** | **61** | 100% | |
 
-Counting note: `Tier 0=9` (8 + ADR 045 + `.github/pull_request_template.md`), `Tier 1=17` (12 reference + 3 design living docs + `governor-review-log/` directory + `governor-paths.md`), `Tier 2=14` (skill rows; each row covers all 3 wrapper layers), `Tier 3=13` (Phase 2 #121 added `.claude/hooks/user-prompt-submit.sh` + `.claude/hooks/user_prompt_submit.py`; previously 11), `Tier 4=6` — sum 59. The 58 figure above excludes `.claude/settings.local.json` from the active-share count because it is `.gitignore`d (its row is recorded for completeness only). The bucket-share percentages use 58 as the denominator.
+Counting note: `Tier 0=9` (8 + ADR 045 + `.github/pull_request_template.md`), `Tier 1=17` (12 reference + 3 design living docs + `governor-review-log/` directory + `governor-paths.md`), `Tier 2=14` (skill rows; each row covers all 3 wrapper layers), `Tier 3=16` (Phase 3 #122 added `.claude/hooks/verify-first.{sh,py}` + `.codex/hooks/verify_first.py`; previously 13 after Phase 2), `Tier 4=6` — sum 62. The 61 figure above excludes `.claude/settings.local.json` from the active-share count because it is `.gitignore`d (its row is recorded for completeness only). The bucket-share percentages use 61 as the denominator.
 
 This distribution matches the "Mostly Local with Philosophy Overlay" model declared in [ADR 045 §D4](../../history/045-hybrid-harness-target-architecture.md). The `Replace` and `Drop` columns are both empty in the initial pass: no asset's content is being rewritten, and self-verification during cross-link work showed that the only `Drop` candidate identified during the first triage was actually an active component (a sh-wrapper `.py` pair).
 
@@ -709,3 +733,4 @@ The following self-checks must pass before this matrix is treated as authoritati
 
 - 2026-04-26 — Initial inventory under ADR 045 / Phase 1.
 - 2026-04-26 — Phase 2 (#121): added `.claude/hooks/user-prompt-submit.sh` + `.claude/hooks/user_prompt_submit.py` to Tier 3; updated `.codex/hooks/user-prompt-submit.py` role to include exception-token parsing (behaviour-preserving). Total 56 → 58.
+- 2026-04-27 — Phase 3 (#122): added `.claude/hooks/verify-first.{sh,py}` (sibling in existing `PostToolUse Edit|Write` matcher) + `.codex/hooks/verify_first.py` library to Tier 3; extended `.codex/hooks/post-tool-format.py` with verify-class command logger and top-level fail-open (R0.4); extended `.codex/hooks/stop-sync-reminder.py` to merge a verify-first segment (import inside try-block per R0.1). Total 58 → 61. Bucket-share shifted Keep 86% → 82% / Overlay 14% → 18% as the 3 new hooks all classify as Overlay (process-governor verify-first reminder).

--- a/docs/ai/shared/migration-strategy.md
+++ b/docs/ai/shared/migration-strategy.md
@@ -202,10 +202,10 @@ If a future audit shows Keep < 30% (i.e. ≥70% of assets have moved to Overlay 
 
 Phase 2~5 each correspond to a separate GitHub issue, registered immediately after Phase 0+1 (this PR) merges. The issue titles follow the pattern:
 
-- `#NNN — Hybrid Harness Phase 2: exception-token UserPromptSubmit adapters`
-- `#NNN — Hybrid Harness Phase 3: verification-first adapters (Claude PostToolUse Edit|Write + Codex Stop changed-files)`
-- `#NNN — Hybrid Harness Phase 4: completion-gate Stop adapter (merged with sync-reminder)`
-- `#NNN — Hybrid Harness Phase 5: shared governor module under .agents/shared/governor/`
+- `#121 — Hybrid Harness Phase 2: exception-token UserPromptSubmit adapters` (PR #126)
+- `#122 — Hybrid Harness Phase 3: verification-first adapters (Claude PostToolUse Edit|Write + Codex Stop changed-files)` (PR #127)
+- `#123 — Hybrid Harness Phase 4: completion-gate Stop adapter (merged with sync-reminder)`
+- `#124 — Hybrid Harness Phase 5: shared governor module under .agents/shared/governor/`
 
 Each issue copies its acceptance criteria from this document and references ADR 045 for context.
 

--- a/docs/ai/shared/repo-facts.md
+++ b/docs/ai/shared/repo-facts.md
@@ -32,6 +32,7 @@ This file contains stable repository facts for both Claude and Codex workflows.
 - `docs/ai/shared/governor-paths.md`: canonical source of governor-changing path globs (Tier A / B / C + exclusions). All consumer docs link this file; do not redeclare the list (Round-4 R4.3)
 - `.github/pull_request_template.md`: GitHub PR template with the Governor-Changing PR checklist that artefact-locks cross-tool review and self-application proof (ADR 045 Pillar 5)
 - `.claude/state/` + `.codex/state/` (gitignored): per-session governance state surfaces. Phase 2 (#121) writes exception-token marker JSON files here when a leading `[trivial]` / `[hotfix]` / `[exploration]` / `[자명]` / `[긴급]` / `[탐색]` token is recognised. Phase 4 completion gate will read these markers; lifecycle (read-and-delete vs. age-based filter vs. session-id correlation) is the open question carried as Inherited Constraint into Phase 4.
+- `.codex/state/verify-log-{session_id}.json` (gitignored): Phase 3 (#122) per-session verify-class command log. JSONL append-only — `.codex/hooks/post-tool-format.py` records `pytest` / `make test` / `make demo[-rag]` / `alembic upgrade` invocations. `.codex/hooks/stop-sync-reminder.py` reads only the *current session's* file (R0.2 — defeats cross-session silence) to decide whether to emit the verify-first reminder segment. Each entry stores `ts_epoch_ns` (R0.3) for subsecond freshness comparison against `Path.stat().st_mtime_ns`. Lifecycle shares the IC-11 open question with the Phase 2 marker — Phase 4 (#123) decides both at once.
 
 ## Context Management
 

--- a/tests/unit/agents_shared/test_verify_first.py
+++ b/tests/unit/agents_shared/test_verify_first.py
@@ -1,0 +1,286 @@
+"""Phase 3 (#122) — verify-first parity tests.
+
+Mirrors `test_token_parser.py` structure: importlib-by-path + subprocess
+smokes. Covers (per plan §4.7 + R0.5):
+- string-equality of REMINDER_TEXT across tools (IC-2)
+- silence on [exploration] / [탐색] markers (Claude AND Codex parity)
+- non-silence on [trivial] / [hotfix] (escape vocabulary semantics)
+- non-Python edits silent (Claude)
+- Codex verify-log freshness (recent → silent; stale → reminder)
+- Codex cross-session protection (R0.2 — current session only)
+- subsecond ordering (R0.3 — ts_epoch_ns)
+- fail-open on missing state dir / corrupt marker / invalid JSON stdin
+- Phase 2 marker idempotency (read does not mutate file)
+
+Stop-hook segment merge tests are covered by manual smoke in plan §6 (the
+`changed_files()` git status dependency makes pytest isolation brittle).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CLAUDE_PY = REPO_ROOT / ".claude" / "hooks" / "verify_first.py"
+CODEX_PY = REPO_ROOT / ".codex" / "hooks" / "verify_first.py"
+
+
+def _load(name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def claude_helper() -> ModuleType:
+    return _load("claude_verify_first", CLAUDE_PY)
+
+
+@pytest.fixture(scope="module")
+def codex_helper() -> ModuleType:
+    # Codex helper imports `_shared` as a sibling — add the dir to sys.path.
+    codex_hooks_dir = str(REPO_ROOT / ".codex" / "hooks")
+    if codex_hooks_dir not in sys.path:
+        sys.path.insert(0, codex_hooks_dir)
+    return _load("codex_verify_first", CODEX_PY)
+
+
+def _write_marker(state_dir: Path, token: str, ts: str | None = None) -> Path:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    record = {
+        "matched": True,
+        "token": token,
+        "rationale_required": True,
+        "ts": ts or time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+    path = state_dir / f"exception-token-test-{token}.json"
+    path.write_text(json.dumps(record, ensure_ascii=False), encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# 1. String parity — IC-2 cornerstone
+# ---------------------------------------------------------------------------
+def test_reminder_text_string_equality(claude_helper, codex_helper) -> None:
+    assert claude_helper.REMINDER_TEXT == codex_helper.REMINDER_TEXT
+
+
+# ---------------------------------------------------------------------------
+# 2~7. Claude side — should_remind() decision
+# ---------------------------------------------------------------------------
+def test_claude_silent_on_exploration_marker(claude_helper, tmp_path) -> None:
+    _write_marker(tmp_path, "exploration")
+    payload = {"tool_name": "Edit", "tool_input": {"file_path": "src/foo.py"}}
+    assert claude_helper.should_remind(payload, state_dir=tmp_path) is False
+
+
+def test_claude_silent_on_korean_탐색_marker(claude_helper, tmp_path) -> None:
+    _write_marker(tmp_path, "탐색")
+    payload = {"tool_name": "Edit", "tool_input": {"file_path": "src/foo.py"}}
+    assert claude_helper.should_remind(payload, state_dir=tmp_path) is False
+
+
+def test_claude_reminds_on_trivial_marker(claude_helper, tmp_path) -> None:
+    _write_marker(tmp_path, "trivial")
+    payload = {"tool_name": "Edit", "tool_input": {"file_path": "src/foo.py"}}
+    assert claude_helper.should_remind(payload, state_dir=tmp_path) is True
+
+
+def test_claude_reminds_on_hotfix_marker(claude_helper, tmp_path) -> None:
+    _write_marker(tmp_path, "hotfix")
+    payload = {"tool_name": "Edit", "tool_input": {"file_path": "src/foo.py"}}
+    assert claude_helper.should_remind(payload, state_dir=tmp_path) is True
+
+
+def test_claude_silent_on_non_python_edit(claude_helper, tmp_path) -> None:
+    payload = {"tool_name": "Edit", "tool_input": {"file_path": "README.md"}}
+    assert claude_helper.should_remind(payload, state_dir=tmp_path) is False
+
+
+def test_claude_reminds_on_python_edit_no_marker(claude_helper, tmp_path) -> None:
+    payload = {"tool_name": "Edit", "tool_input": {"file_path": "src/foo.py"}}
+    assert claude_helper.should_remind(payload, state_dir=tmp_path) is True
+
+
+# ---------------------------------------------------------------------------
+# 8. Marker read idempotency — IC-11 contract
+# ---------------------------------------------------------------------------
+def test_marker_read_idempotent(claude_helper, tmp_path) -> None:
+    marker = _write_marker(tmp_path, "trivial")
+    before = (marker.read_text(), marker.stat().st_mtime_ns)
+    _ = claude_helper.read_latest_token_marker(tmp_path)
+    _ = claude_helper.read_latest_token_marker(tmp_path)
+    after = (marker.read_text(), marker.stat().st_mtime_ns)
+    assert before == after
+
+
+# ---------------------------------------------------------------------------
+# 9. Corrupt marker tolerance
+# ---------------------------------------------------------------------------
+def test_corrupt_marker_skipped(claude_helper, tmp_path) -> None:
+    _write_marker(tmp_path, "trivial", ts="2026-01-01T00:00:00Z")
+    bad = tmp_path / "exception-token-bad.json"
+    bad.write_text("{ this is not json", encoding="utf-8")
+    assert claude_helper.read_latest_token_marker(tmp_path) == "trivial"
+
+
+# ---------------------------------------------------------------------------
+# 10. Codex marker silence parity (R0.5 — was Claude-only originally)
+# ---------------------------------------------------------------------------
+def test_codex_marker_read_parity(claude_helper, codex_helper, tmp_path) -> None:
+    """Both helpers' read_latest_token_marker return the same token."""
+    _write_marker(tmp_path, "exploration", ts="2026-04-27T00:00:00Z")
+    _write_marker(tmp_path, "trivial", ts="2026-04-27T01:00:00Z")
+    claude_token = claude_helper.read_latest_token_marker(tmp_path)
+    codex_token = codex_helper.read_latest_token_marker(tmp_path)
+    assert claude_token == codex_token == "trivial"
+
+
+# ---------------------------------------------------------------------------
+# 11~13. Codex side — verify-log freshness + changed-files logic
+# ---------------------------------------------------------------------------
+def test_codex_silent_when_no_python_changes(codex_helper, monkeypatch) -> None:
+    monkeypatch.setattr(codex_helper, "changed_python_files", lambda: [])
+    assert codex_helper.should_remind() is False
+
+
+def test_codex_reminds_when_no_verify_log(codex_helper, tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(codex_helper, "changed_python_files", lambda: ["src/foo.py"])
+    monkeypatch.setattr(codex_helper, "STATE_DIR", tmp_path)
+    monkeypatch.setattr(codex_helper, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(
+        codex_helper, "max_changed_py_mtime_ns", lambda: 1_000_000_000_000_000_000
+    )
+    monkeypatch.setattr(codex_helper, "current_session_latest_verify_ns", lambda: None)
+    assert codex_helper.should_remind() is True
+
+
+def test_codex_silent_when_verify_log_recent(codex_helper, monkeypatch) -> None:
+    monkeypatch.setattr(codex_helper, "changed_python_files", lambda: ["src/foo.py"])
+    monkeypatch.setattr(
+        codex_helper, "max_changed_py_mtime_ns", lambda: 1_000_000_000_000_000_000
+    )
+    monkeypatch.setattr(
+        codex_helper,
+        "current_session_latest_verify_ns",
+        lambda: 2_000_000_000_000_000_000,
+    )
+    monkeypatch.setattr(codex_helper, "read_latest_token_marker", lambda *_: None)
+    assert codex_helper.should_remind() is False
+
+
+def test_codex_reminds_when_verify_log_older_than_py_mtime(
+    codex_helper, monkeypatch
+) -> None:
+    """R0.5 corrected name: stale verify-log → reminder fires."""
+    monkeypatch.setattr(codex_helper, "changed_python_files", lambda: ["src/foo.py"])
+    monkeypatch.setattr(
+        codex_helper, "max_changed_py_mtime_ns", lambda: 5_000_000_000_000_000_000
+    )
+    monkeypatch.setattr(
+        codex_helper,
+        "current_session_latest_verify_ns",
+        lambda: 3_000_000_000_000_000_000,
+    )
+    monkeypatch.setattr(codex_helper, "read_latest_token_marker", lambda *_: None)
+    assert codex_helper.should_remind() is True
+
+
+# ---------------------------------------------------------------------------
+# 14. Codex verify-log writer pattern recognition
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "cmd,expected",
+    [
+        ("pytest tests/unit", True),
+        ("make test", True),
+        ("make demo", True),
+        ("make demo-rag", True),
+        ("alembic upgrade head", True),
+        ("ruff check src/", False),
+        ("ls -la", False),
+    ],
+)
+def test_codex_verify_log_writer_patterns(
+    codex_helper, tmp_path, monkeypatch, cmd, expected
+) -> None:
+    # Force a deterministic session id so the test writes a known filename.
+    monkeypatch.setenv("CODEX_SESSION_ID", "pytest-fixture")
+    result = codex_helper.append_verify_log(cmd, state_dir=tmp_path)
+    if expected:
+        assert result is not None and result.exists()
+        line = result.read_text().strip().splitlines()[-1]
+        record = json.loads(line)
+        assert record["cmd"] == cmd
+        assert isinstance(record["ts_epoch_ns"], int) and record["ts_epoch_ns"] > 0
+    else:
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# 15. Cross-session protection (R0.2)
+# ---------------------------------------------------------------------------
+def test_codex_cross_session_does_not_silence(
+    codex_helper, tmp_path, monkeypatch
+) -> None:
+    """A different session's verify-log entry must NOT silence the current session."""
+    # Write a verify-log under a DIFFERENT session id.
+    other_session = tmp_path / "verify-log-some-other-session.json"
+    other_session.write_text(
+        json.dumps(
+            {
+                "ts": "2026-04-27T00:00:00Z",
+                "ts_epoch_ns": 9_000_000_000_000_000_000,
+                "cmd": "pytest",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    # Force the current session id to NOT match the other session's filename.
+    monkeypatch.setenv("CODEX_SESSION_ID", "current-session")
+    monkeypatch.setattr(codex_helper, "STATE_DIR", tmp_path)
+    # current_session_latest_verify_ns reads ONLY verify-log-{current}.json
+    assert codex_helper.current_session_latest_verify_ns(state_dir=tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# 16~18. Subprocess fail-open smoke (HC-3.6)
+# ---------------------------------------------------------------------------
+def _run_claude_verify_first(stdin: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603
+        [sys.executable, str(CLAUDE_PY)],
+        input=stdin,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_fail_open_empty_stdin() -> None:
+    result = _run_claude_verify_first("")
+    assert result.returncode == 0
+
+
+def test_fail_open_invalid_json() -> None:
+    result = _run_claude_verify_first("not json at all")
+    assert result.returncode == 0
+
+
+def test_fail_open_missing_state_dir(claude_helper, tmp_path) -> None:
+    payload = {"tool_name": "Edit", "tool_input": {"file_path": "src/foo.py"}}
+    # state_dir does not exist → no marker → no [exploration] silence → reminds
+    assert (
+        claude_helper.should_remind(payload, state_dir=tmp_path / "nonexistent") is True
+    )

--- a/tests/unit/agents_shared/test_verify_first.py
+++ b/tests/unit/agents_shared/test_verify_first.py
@@ -307,3 +307,20 @@ def test_fail_open_missing_state_dir(claude_helper, tmp_path) -> None:
     assert (
         claude_helper.should_remind(payload, state_dir=tmp_path / "nonexistent") is True
     )
+
+
+# ---------------------------------------------------------------------------
+# 19. Codex post-tool-format.py null tool_input fail-open (R1.2 regression)
+# ---------------------------------------------------------------------------
+def test_codex_post_tool_format_null_tool_input_fail_open() -> None:
+    """R1.2: explicit null tool_input must not raise AttributeError — exits 0."""
+    codex_post_tool = REPO_ROOT / ".codex" / "hooks" / "post-tool-format.py"
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, str(codex_post_tool)],
+        input='{"tool_name": "Bash", "tool_input": null}',
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**__import__("os").environ, "CODEX_THREAD_ID": "pytest-r1.2"},
+    )
+    assert result.returncode == 0

--- a/tests/unit/agents_shared/test_verify_first.py
+++ b/tests/unit/agents_shared/test_verify_first.py
@@ -1,13 +1,14 @@
 """Phase 3 (#122) — verify-first parity tests.
 
 Mirrors `test_token_parser.py` structure: importlib-by-path + subprocess
-smokes. Covers (per plan §4.7 + R0.5):
+smokes. Covers (per plan §4.7 + R0.5 + R1.1~R1.3):
 - string-equality of REMINDER_TEXT across tools (IC-2)
 - silence on [exploration] / [탐색] markers (Claude AND Codex parity)
 - non-silence on [trivial] / [hotfix] (escape vocabulary semantics)
 - non-Python edits silent (Claude)
+- Codex should_remind() marker silence (R1.3 — direct test)
 - Codex verify-log freshness (recent → silent; stale → reminder)
-- Codex cross-session protection (R0.2 — current session only)
+- Codex cross-session protection via CODEX_THREAD_ID (R0.2 / R1.1)
 - subsecond ordering (R0.3 — ts_epoch_ns)
 - fail-open on missing state dir / corrupt marker / invalid JSON stdin
 - Phase 2 marker idempotency (read does not mutate file)
@@ -148,10 +149,30 @@ def test_codex_marker_read_parity(claude_helper, codex_helper, tmp_path) -> None
 
 
 # ---------------------------------------------------------------------------
-# 11~13. Codex side — verify-log freshness + changed-files logic
+# 11~15. Codex side — should_remind() marker silence + verify-log freshness
 # ---------------------------------------------------------------------------
 def test_codex_silent_when_no_python_changes(codex_helper, monkeypatch) -> None:
     monkeypatch.setattr(codex_helper, "changed_python_files", lambda: [])
+    assert codex_helper.should_remind() is False
+
+
+def test_codex_silent_on_exploration_marker_should_remind(
+    codex_helper, monkeypatch
+) -> None:
+    """R1.3: Codex should_remind() directly returns False on [exploration] token."""
+    monkeypatch.setattr(codex_helper, "changed_python_files", lambda: ["src/foo.py"])
+    monkeypatch.setattr(
+        codex_helper, "read_latest_token_marker", lambda *_: "exploration"
+    )
+    assert codex_helper.should_remind() is False
+
+
+def test_codex_silent_on_korean_탐색_marker_should_remind(
+    codex_helper, monkeypatch
+) -> None:
+    """R1.3: Codex should_remind() directly returns False on [탐색] token."""
+    monkeypatch.setattr(codex_helper, "changed_python_files", lambda: ["src/foo.py"])
+    monkeypatch.setattr(codex_helper, "read_latest_token_marker", lambda *_: "탐색")
     assert codex_helper.should_remind() is False
 
 
@@ -215,8 +236,9 @@ def test_codex_reminds_when_verify_log_older_than_py_mtime(
 def test_codex_verify_log_writer_patterns(
     codex_helper, tmp_path, monkeypatch, cmd, expected
 ) -> None:
-    # Force a deterministic session id so the test writes a known filename.
-    monkeypatch.setenv("CODEX_SESSION_ID", "pytest-fixture")
+    # Force a deterministic session id via CODEX_THREAD_ID (R1.1 — preferred env var).
+    monkeypatch.setenv("CODEX_THREAD_ID", "pytest-fixture")
+    monkeypatch.delenv("CODEX_SESSION_ID", raising=False)
     result = codex_helper.append_verify_log(cmd, state_dir=tmp_path)
     if expected:
         assert result is not None and result.exists()
@@ -248,8 +270,9 @@ def test_codex_cross_session_does_not_silence(
         + "\n",
         encoding="utf-8",
     )
-    # Force the current session id to NOT match the other session's filename.
-    monkeypatch.setenv("CODEX_SESSION_ID", "current-session")
+    # Force the current session id via CODEX_THREAD_ID (R1.1 — not matching the other file).
+    monkeypatch.setenv("CODEX_THREAD_ID", "current-session")
+    monkeypatch.delenv("CODEX_SESSION_ID", raising=False)
     monkeypatch.setattr(codex_helper, "STATE_DIR", tmp_path)
     # current_session_latest_verify_ns reads ONLY verify-log-{current}.json
     assert codex_helper.current_session_latest_verify_ns(state_dir=tmp_path) is None


### PR DESCRIPTION
## Summary

Phase 3 of #117 / ADR 045 (#122). Adds verification-first informational reminders to both harnesses:

- **Claude**: `PostToolUse Edit|Write` sibling hook (`.claude/hooks/verify-first.sh` + `verify_first.py`) emits a stderr reminder when a `.py` file is edited and the latest Phase 2 marker is not `[exploration]`/`[탐색]`.
- **Codex**: `Stop` hook segment merge — `_shared.changed_files()` detects changed `.py` files; `post-tool-format.py` (PostToolUse Bash) records verify-class commands (`pytest` / `make test` / `make demo[-rag]` / `alembic upgrade`) to a per-session JSONL log; `stop-sync-reminder.py` checks freshness and appends a second segment when verification appears missing.

Phase 2 `[exploration]`/`[탐색]` markers silence both adapters. Read-only on Phase 2 markers (IC-11; Phase 4 #123 owns lifecycle). Informational only — never blocks commit or Stop (HC-3.3).

R0 reinforcement applied: import fail-open (R0.1), current-session-only verify-log to defeat cross-session silence (R0.2), subsecond `ts_epoch_ns` freshness comparison (R0.3), top-level fail-open in `post-tool-format.py` (R0.4), Codex marker silence parity tests + corrected test name (R0.5).

## Governor-Changing PR (Tier B `.claude/**` + `.codex/**`)

- Governor-review-log entry: `docs/ai/shared/governor-review-log/pr-{NNN}-verify-first-adapters.md` ← created as commit 5 (log-only-backfill) after PR number is confirmed (HC-3.5)
- IC-1~IC-11 inherited; this PR adds no new IC
- Self-Application Proof inside log entry §Self-Application Proof (Round 1/2 in progress)

## Inherited Constraint sources

- PR #125 IC-1~IC-10
- PR #126 IC-11 (marker lifecycle un-decided; Phase 4 #123 owns) + HC-1 (Codex safety-block-first → parser-second; both hooks fail-open)

## Files changed

| File | Change |
|---|---|
| `.claude/hooks/verify-first.sh` | NEW — sh wrapper (always exits 0) |
| `.claude/hooks/verify_first.py` | NEW — Claude PostToolUse Edit\|Write helper |
| `.claude/settings.json` | MODIFY — `PostToolUse Edit\|Write` sibling hook added |
| `.codex/hooks/verify_first.py` | NEW — Codex library module (not in hooks.json) |
| `.codex/hooks/post-tool-format.py` | MODIFY — verify-log writer + top-level fail-open |
| `.codex/hooks/stop-sync-reminder.py` | MODIFY — segments list refactor + verify-first segment |
| `tests/unit/agents_shared/test_verify_first.py` | NEW — 25 test cases |
| `docs/ai/shared/harness-asset-matrix.md` | MODIFY — Tier 3 +3 rows, Total 58→61, Update Log |
| `docs/ai/shared/repo-facts.md` | MODIFY — verify-log surface registration |

## Test plan

- [x] `pytest tests/unit/agents_shared/test_verify_first.py -v` — 25 passed
- [x] `pytest tests/unit/agents_shared/ -v` — Phase 2 token_parser regression clean
- [x] Manual smoke: `.py` edit with no marker → Claude stderr reminder emitted
- [x] Manual smoke: `.py` edit with `[exploration]` marker → silent
- [x] Manual smoke: Codex Stop with no verify-log → reminder segment emitted
- [x] Manual smoke: Codex Stop with fresh verify-log (same session) → silent
- [x] Manual smoke: Codex Stop with stale verify-log (py mtime > log ts) → reminder
- [x] `pre-commit run --all-files` — green
- [ ] CI green (in progress)
- [ ] Round 1 / Round 2 Codex cross-tool review (in progress)
- [ ] Governor-review-log entry (commit 5 — log-only-backfill post PR number confirm)
- [ ] 1-week soak measurement (backfill commit post-merge)

Closes #122