### PR TITLE
docs(adr): ADR 046 — OTEL core + Langfuse opt-in recipe + prompt domain defer

### DIFF
--- a/docs/ai/shared/ai-infrastructure-overview.md
+++ b/docs/ai/shared/ai-infrastructure-overview.md
@@ -1,20 +1,27 @@
 # AI Infrastructure Overview
 
 > Temporary design document for cross-session context transfer.
-> Covers the full scope of issues #15, Langfuse integration, and AI Usage Tracking.
-> After all three issues are complete, merge into project-dna.md via `/sync-guidelines` and archive this file.
+> Covers the full scope of issues #15 (PydanticAI core), observability (#74 split), and AI Usage Tracking (#75).
+> After all three are complete, merge into project-dna.md via `/sync-guidelines` and archive this file.
+>
+> **2026-04-28 update**: ADR 038 (Langfuse 1st-class) superseded by ADR 046 (OTEL core + Langfuse opt-in recipe + prompt domain defer). Architecture diagram and technology table updated accordingly.
 
 ## Architecture Diagram
 
 ```
 PydanticAI Agent execution
 │
-├─ Path 1: OTEL spans ──→ Langfuse (self-hosted)
-│   ├─ Ops team: step-by-step tracing (span waterfall)
-│   ├─ Prompt designers: live edit, version control, SDK fetch
-│   └─ Ops team: model-level cost analysis
+├─ Trace path: OTEL spans ──→ OTLP backend (backend-agnostic)
+│   │   Backends: Jaeger / Grafana Tempo / Arize Phoenix / Langfuse (opt-in)
+│   │
+│   ├─ Base (otel extra): token usage, latency, input/output messages
+│   │
+│   └─ Langfuse opt-in recipe adds:
+│       ├─ Prompt version → trace linkage (requires Langfuse SDK/API)
+│       ├─ Evaluation scores and datasets
+│       └─ A/B prompt label analysis
 │
-└─ Path 2: result.usage() ──→ Self DB (ai_usage_log)
+└─ Usage path: result.usage() ──→ Self DB (ai_usage_log)
     ├─ Customers: per-org AI call history
     ├─ Customers: real-time usage/cost dashboard
     ├─ Customers: billing justification
@@ -26,8 +33,23 @@ PydanticAI Agent execution
 | Component | Choice | Why | ADR |
 |-----------|--------|-----|-----|
 | Agent Framework | PydanticAI v1.0+ | Pydantic-native structured output, OTEL standard, FastAPI DI philosophy, v1.0 stable | [037](../../docs/history/037-pydanticai-agent-integration.md) |
-| Observability | Langfuse (self-hosted) | MIT full OSS, tracing + prompt mgmt + cost API — only tool covering all three | [038](../../docs/history/archive/038-llm-observability-dual-path.md) |
-| Customer Billing | Self-owned `ai_usage` domain | Business-critical data cannot depend on external system | [038](../../docs/history/archive/038-llm-observability-dual-path.md) |
+| Trace output | OTEL (OTLP exporter) | Backend-agnostic; `Agent.instrument_all()` one line; any OTLP backend works | [046](../../docs/history/046-otel-core-langfuse-recipe-prompt-domain-defer.md) |
+| Langfuse | Opt-in recipe | MIT OSS; adds prompt linking + eval + A/B analysis on top of OTEL traces; not required at quickstart | [046](../../docs/history/046-otel-core-langfuse-recipe-prompt-domain-defer.md) |
+| Customer Billing | Self-owned `ai_usage` domain | Business-critical data cannot depend on external system | [046](../../docs/history/046-otel-core-langfuse-recipe-prompt-domain-defer.md) |
+| Prompt domain | **Deferred** | No real demand yet (no non-developer editing, <3 prompts). `PromptSnapshot` VO defines the contract. | [046](../../docs/history/046-otel-core-langfuse-recipe-prompt-domain-defer.md) |
+
+### OTEL Backend Comparison
+
+Teams choosing an OTLP backend:
+
+| Backend | Self-host | Prompt mgmt | Evaluation | Best for |
+|---------|-----------|-------------|------------|----------|
+| **Langfuse** | Docker Compose (5 services) | ✅ full | ✅ datasets, scores | Full LLMOps (prompt iteration + eval loop) |
+| Arize Phoenix | Docker (single container) | ❌ | ✅ basic | Trace inspection + drift detection |
+| Grafana Tempo | Docker | ❌ | ❌ | Existing Grafana stack |
+| Jaeger | Docker (single container) | ❌ | ❌ | Simple trace inspection |
+
+All accept OTLP — only the exporter endpoint changes. No agent code modifications required when switching.
 
 ### Rejected Alternatives
 
@@ -35,31 +57,36 @@ PydanticAI Agent execution
 - **Agno**: Non-OTEL tracing, not Pydantic-native
 - **Direct SDK**: No abstraction, duplicated boilerplate across 10+ domains
 - **LangSmith**: LangChain-centric, $39/user/month, limited self-hosting
-- **Arize Phoenix**: No prompt management
 - **Helicone**: Shallow tracing, proxy-based architecture
+- **Langfuse as mandatory** (ADR 038): 5-component quickstart stack; violates ADR 042 opt-in principle
 
 ## Issue Dependencies
 
 ```
-Issue #15 (PydanticAI Core)
-├──→ Issue A (Langfuse OTEL + Prompt Management)    ← can start after #15
-└──→ Issue B (AI Usage Tracking Domain)              ← can start after #15
-                                                      A ∥ B (parallel)
+Issue #15 (PydanticAI Core) — COMPLETED
+├──→ #74-A (OTEL core setup)                         ← split from #74
+│       └──→ #74-B (Langfuse opt-in recipe doc)      ← depends on #74-A
+└──→ #75 (AI Usage Tracking Domain)                  ← can run parallel to #74-A/B
+        └──→ #97 (simple-chatbot example)             ← depends on #75
 ```
+
+Note: `#74-A` and `#74-B` are placeholder names; actual issue numbers assigned after #74 closes.
 
 ## Key Design Decisions
 
 1. **No BaseAgentProtocol** — PydanticAI Agent IS the abstraction. Double-wrapping adds complexity without value.
-2. **No providers.Selector for LLM** — PydanticAI handles model switching internally via `model="provider:model-name"` string. This is "same class, different params" (like S3/MinIO), not "different classes, different signatures" (like Broker).
+2. **No providers.Selector for LLM** — PydanticAI handles model switching internally via `model="provider:model-name"` string.
 3. **No BaseAIService** — AI services are heterogeneous (classify, generate, query). No common CRUD interface to factor out.
 4. **Hybrid DI** — dependency-injector for singletons (LLMConfig, database) + PydanticAI RunContext for per-request data (org_id, user_id).
 5. **LLMConfig value object** — Domain layer cannot import Settings (infrastructure). `LLMConfig(model_name, api_key)` carries only what agents need.
-6. **Dual-path independence** — OTEL→Langfuse failure does not affect customer billing. Self DB failure does not affect ops tracing.
-7. **Optional infrastructure** — `LANGFUSE_ENABLED=false` disables tracing. PydanticAI is an optional dependency (`uv sync --extra pydantic-ai`).
+6. **OTEL path independence** — OTEL→backend failure does not affect customer billing. Self DB failure does not affect tracing.
+7. **Optional infrastructure** — `OTEL_ENABLED=false` (default) means zero overhead at quickstart. `uv sync --extra otel` enables tracing.
+8. **Prompt domain deferred** — `PromptSnapshot(name, version, content, source, external_ref, metadata)` VO defines the consumer contract. Build the domain when: non-developer live edit is required, OR 3+ prompts need simultaneous version management.
+9. **prompt_version is metadata, not a registry** — Nullable `prompt_version` in `ai_usage_log` is a billing/analytics label. Labels can move; it is not a reproducible prompt reference. Exact reproduction requires the deferred prompt domain.
 
 ## File Map by Issue
 
-### Issue #15: PydanticAI Core
+### Issue #15: PydanticAI Core (COMPLETED)
 
 **Modified**:
 - `src/_core/config.py` — LLM_PROVIDER, LLM_MODEL, LLM_API_KEY, LLM_BEDROCK_* fields + validation
@@ -72,46 +99,64 @@ Issue #15 (PydanticAI Core)
 - `src/_core/infrastructure/llm/exceptions.py` — `LLMException` hierarchy
 - `src/classification/` — Prototype AI domain (full domain scaffold)
 - `docs/history/037-pydanticai-agent-integration.md`
-- `docs/history/archive/038-llm-observability-dual-path.md`
+- `docs/history/archive/038-llm-observability-dual-path.md` ← superseded by ADR 046
 
-### Issue A: Langfuse OTEL + Prompt Management
+### Issue #74-A: OTEL Core Setup (PENDING)
 
 **Modified**:
-- `src/_core/config.py` — LANGFUSE_ENABLED, LANGFUSE_PUBLIC_KEY, LANGFUSE_SECRET_KEY, LANGFUSE_HOST + validation
-- `src/_core/infrastructure/di/core_container.py` — `langfuse_client`, `prompt_service` providers
-- `src/_apps/server/bootstrap.py` — OTEL initialization at startup
-- `src/_apps/worker/bootstrap.py` — OTEL initialization at startup
-- `pyproject.toml` — `langfuse` optional dependency group (langfuse, opentelemetry-*)
+- `src/_core/config.py` — `otel_enabled`, `otel_exporter_otlp_endpoint` fields
+- `src/_apps/server/bootstrap.py` — `_maybe_configure_otel()` call
+- `src/_apps/worker/bootstrap.py` — `_maybe_configure_otel()` call
+- `pyproject.toml` — `otel` optional extra
 
 **New**:
-- `src/_core/infrastructure/langfuse/langfuse_client.py` — SDK wrapper (lazy import)
-- `src/_core/infrastructure/langfuse/otel_setup.py` — OTEL TracerProvider + Langfuse OTLP exporter
-- `src/_core/infrastructure/langfuse/prompt_service.py` — Prompt fetch + cache + fallback
-- `src/_core/infrastructure/langfuse/exceptions.py` — LangfuseException hierarchy
-- `docker-compose.langfuse.yml` — Self-hosted Langfuse stack (PG:5433, ClickHouse, Redis:6380, MinIO:9090, web:3000)
+- `src/_core/infrastructure/observability/otel_setup.py` — `configure_otel(settings)` + `Agent.instrument_all()`
+- `.env.example` — `OTEL_ENABLED`, `OTEL_EXPORTER_OTLP_ENDPOINT`
+- Recipe doc: Jaeger/Tempo quickstart
 
-### Issue B: AI Usage Tracking Domain
+### Issue #74-B: Langfuse Opt-in Recipe (PENDING, depends on #74-A)
+
+**New**:
+- `docker-compose.langfuse.yml` — Langfuse stack (PG:5433, ClickHouse, Redis:6380, MinIO:9090, web:3000)
+- `Makefile` — `observability-langfuse` target
+- `docs/operations/observability-langfuse.md` — OTLP endpoint config + note: prompt linking requires Langfuse SDK in addition to OTLP
+
+### Issue #75: AI Usage Tracking Domain (PENDING)
 
 **New**:
 - `src/ai_usage/` — Full domain (auto-discovered):
   - `domain/dtos/ai_usage_dto.py` — AiUsageDTO
   - `domain/protocols/ai_usage_repository_protocol.py` — Extended with aggregate queries
   - `domain/services/ai_usage_service.py` — BaseService + custom summary/org queries
-  - `infrastructure/database/models/ai_usage_model.py` — ai_usage_log table (BigInteger PK, indexed org_id)
-  - `infrastructure/repositories/ai_usage_repository.py` — Custom `select_usage_summary`, `select_usage_by_org`
+  - `infrastructure/database/models/ai_usage_model.py` — ai_usage_log table (nullable prompt ref columns, no FK)
   - `interface/server/routers/ai_usage_router.py` — GET /v1/usage, /usage/summary, /usage/{id}
   - `interface/admin/` — BaseAdminPage config + pages
 - `src/_core/common/usage_tracker.py` — `track_agent_usage` async context manager
-- Alembic migration for `ai_usage_log` table
+- `src/_core/domain/value_objects/prompt_snapshot.py` — `PromptSnapshot` Pydantic ValueObject
+- Alembic migration for `ai_usage_log` table (with nullable prompt_name/version/source/external_prompt_ref)
+
+**ai_usage_log schema changes vs ADR 038**:
+
+| ADR 038 (removed) | ADR 046 (replaced with) | Reason |
+|-------------------|-------------------------|--------|
+| `prompt_id` FK | `prompt_name String(200) nullable` | No FK lock-in before prompt domain exists |
+| — | `prompt_version String(50) nullable` | Langfuse-compatible label string (not integer) |
+| — | `prompt_source String(20) nullable` | `"inline"` / `"langfuse"` / `"self"` / None |
+| — | `external_prompt_ref String(500) nullable` | Langfuse prompt UUID or other external ref |
+
+### Issue #97: simple-chatbot Example (PENDING, depends on #75)
+
+- Inline `SYSTEM_PROMPT` constant — no prompt domain dependency
+- `tokens_used` in response for educational purposes
+- Comment: "Production usage tracking: see ai_usage domain (#75)"
 
 ## Patterns to Follow
 
 | Pattern | Reference Implementation | Key File |
 |---------|--------------------------|----------|
-| Settings validation (partial config group) | Embedding provider validation | `src/_core/config.py:339-366` |
-| Lazy import for optional deps | OpenAI embedding client | `src/_core/infrastructure/embedding/openai_embedding_client.py` |
-| Exception hierarchy | EmbeddingException family | `src/_core/infrastructure/embedding/exceptions.py` |
-| CoreContainer provider registration | Embedding Selector | `src/_core/infrastructure/di/core_container.py:105-119` |
+| Optional infra (Settings + Selector) | Embedding provider | `src/_core/config.py` + `core_container.py` |
+| Lazy import for optional extras | OpenAI embedding client | `src/_core/infrastructure/embedding/openai_embedding_client.py` |
+| Bootstrap conditional init | `_maybe_bootstrap_admin()` | `src/_apps/server/bootstrap.py` |
+| Pydantic ValueObject (frozen, validated) | EmbeddingConfig or VectorQuery | `src/_core/domain/value_objects/` |
 | Domain auto-discovery | discover_domains() | `src/_core/infrastructure/discovery.py` |
 | Admin page (BaseAdminPage) | User admin | `src/user/interface/admin/` |
-| Domain scaffold (reference) | User domain | `src/user/` |

--- a/docs/history/046-otel-core-langfuse-recipe-prompt-domain-defer.md
+++ b/docs/history/046-otel-core-langfuse-recipe-prompt-domain-defer.md
@@ -1,0 +1,226 @@
+# 046. LLM Observability — OTEL Core + Langfuse Opt-in Recipe + Prompt Domain Defer
+
+- Status: Proposed
+- Date: 2026-04-28
+- Related issues: #74 (Langfuse integration — superseded), #75 (AI Usage domain), #97 (simple-chatbot example)
+- Related ADRs: [037](037-pydanticai-agent-integration.md)(PydanticAI), [042](042-optional-infrastructure-di-pattern.md)(Optional Infra DI), [038 (archive)](archive/038-llm-observability-dual-path.md)(superseded by this ADR)
+- Supersedes: [archive/038](archive/038-llm-observability-dual-path.md)
+
+## Summary
+
+Re-evaluation of ADR 038 (Langfuse as 1st-class observability dependency) prompted by OSS onboarding friction and misalignment with ADR 042 (opt-in infrastructure). This ADR adopts **Model E**: OTEL as the standard trace output + Langfuse as an explicit opt-in recipe + prompt domain deferred until real demand.
+
+The three core principles:
+
+1. **OTEL core** — `Agent.instrument_all()` + OTLP exporter as the default trace path. Backend-agnostic: Jaeger, Tempo, Phoenix, or Langfuse.
+2. **Langfuse opt-in** — `docker-compose.langfuse.yml` + `make observability-langfuse` as an explicit ops recipe. Not in quickstart.
+3. **Prompt domain deferred** — Only `PromptSnapshot` value object defined now. Full prompt domain (editor, versioning, RBAC) built when real demand exists.
+
+## Background
+
+ADR 038 chose Langfuse as the 1st-class observability dependency for two reasons: (a) it is the only OSS tool covering tracing + prompt management + cost API, and (b) the project targets SaaS multi-tenant use where those three ops requirements coexist.
+
+That rationale remains partially valid for **production SaaS teams** who need prompt iteration and trace linkage. However, it creates two problems that emerged after ADR 038:
+
+| Problem | Impact |
+|---------|--------|
+| 5-component self-hosted stack (PG, ClickHouse, Redis, MinIO, web) required at quickstart | OSS contributors blocked on first `docker compose up` |
+| ADR 042 (opt-in infra) established that no non-DB infra is mandatory | ADR 038's required Langfuse contradicts this principle |
+
+A Codex cross-review (2026-04-28, `claude-opus-4-7`, sandbox=read-only) stress-tested four candidate models and converged on Model E as the lowest-failure-cost option. The review specifically rejected Model D (OTEL-only, no Langfuse, self-built prompt editor) for overstating what OTEL alone can replace.
+
+## Problem
+
+### 1. Langfuse at quickstart violates ADR 042
+
+ADR 042 established that no non-DB infrastructure is mandatory — all optional infras use `providers.Selector` + graceful degradation. A required 5-component Langfuse stack is the single largest exception to this principle and the most common OSS onboarding failure point.
+
+### 2. "OTEL-only" does not replace Langfuse-native features
+
+PydanticAI's `Agent.instrument_all()` emits OTEL GenAI semantic convention spans. This covers: token usage, input/output messages, system instructions, latency. It does **not** cover:
+
+- Prompt version linkage (which version was served for a given trace)
+- Evaluation scores and dataset regression tests
+- A/B prompt label analysis
+- Live prompt editing with trace feedback
+
+Langfuse receives OTLP, but its prompt linking, scores, datasets, and evaluations require the Langfuse SDK/API or custom span processors — not just OTLP. "OTEL-standardized" means trace *collection* is backend-agnostic, not that LLMOps product features are portable.
+
+### 3. Self-built prompt editor is underscoped
+
+An in-house NiceGUI prompt editor can reach CRUD parity in ~1 week. An **operationally viable** prompt editor requires diff view, rollback, audit trail, variable validation, preview/compile test, staging/production label workflow, RBAC, and concurrent edit conflict handling. Omitting these produces a DB row editor, not a prompt management system.
+
+Additionally, a 30-second in-memory TTL cache is not "live editing" — it is eventual consistency with up to 30s lag. In multi-worker deployments (4 server processes + 2 workers), a bad prompt rollback leaves some workers serving the bad version for up to 30 seconds with no trace linkage to identify affected requests.
+
+### 4. prompt_id FK creates premature lock-in
+
+Wiring `ai_usage_log` to a `prompt` table FK before the prompt domain is built forces the schema to commit to a domain model that does not yet exist. Nullable metadata columns are the minimum viable anchor.
+
+## Alternatives Considered
+
+| Model | Summary | Key risk | Verdict |
+|-------|---------|----------|---------|
+| **A — Langfuse mandatory** (ADR 038) | Langfuse 1st-class, required at quickstart | OSS onboarding barrier; violates ADR 042 | Rejected |
+| **B — Self-build only** | Custom trace waterfall + prompt editor; no Langfuse | Span waterfall UI + prompt versioning = months of work | Rejected |
+| **C — Selector dual-path** | Maintain both Langfuse and self-built paths simultaneously | Two code paths, maintenance cost scales with both | Rejected |
+| **D — OTEL-only** | OTEL trace out + self-built prompt CRUD + ai_usage domain; Langfuse deprecated | Conflates "OTEL trace collection" with "LLMOps product features". Self-built prompt editor underscoped. Internal contradiction: PromptServiceProtocol DIP + "defer Selector abstraction" cannot coexist | Rejected (Codex cross-review) |
+| **E — OTEL core + Langfuse recipe (chosen)** | OTEL as trace standard + Langfuse as explicit opt-in + prompt domain deferred | Langfuse-native features (prompt linking, eval) require opt-in recipe step; prompt management absent until real demand | **Adopted** |
+
+## Decision
+
+### 1. OTEL core (`otel` extra)
+
+OTLP trace output as the standard. Backend-agnostic — any OTLP-compatible backend (Jaeger, Grafana Tempo, Arize Phoenix, Langfuse) works.
+
+```python
+# pyproject.toml
+[project.optional-dependencies]
+otel = [
+    "opentelemetry-api",
+    "opentelemetry-sdk",
+    "opentelemetry-exporter-otlp-proto-grpc",
+]
+
+# src/_core/infrastructure/observability/otel_setup.py
+def configure_otel(settings: Settings) -> None:
+    """Called at server/worker bootstrap when OTEL_ENABLED=true."""
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+    ...
+    Agent.instrument_all()  # PydanticAI GenAI semantic convention spans
+
+# bootstrap.py
+def _maybe_configure_otel(settings: Settings) -> None:
+    if not settings.otel_enabled:
+        return
+    try:
+        from src._core.infrastructure.observability.otel_setup import configure_otel
+        configure_otel(settings)
+    except ImportError:
+        logger.warning("otel_extra_not_installed", hint="uv sync --extra otel")
+```
+
+**Settings additions** (`src/_core/config.py`):
+```
+otel_enabled: bool = False                         # OTEL_ENABLED
+otel_exporter_otlp_endpoint: str | None = None     # OTEL_EXPORTER_OTLP_ENDPOINT
+```
+
+**Default state**: `make quickstart` works unchanged. Zero new required env vars.
+
+### 2. Langfuse opt-in recipe
+
+Langfuse is not removed — it becomes an explicit ops recipe for teams that need prompt linking and evaluation.
+
+```
+# Opt-in (not in base quickstart)
+make observability-langfuse   # starts docker-compose.langfuse.yml
+# then set OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318/v1/traces
+
+# What OTLP alone gives you (backend-agnostic):
+#   token usage, latency, input/output messages, system instructions
+
+# What requires Langfuse SDK/API in addition:
+#   prompt version → trace linkage
+#   evaluation scores and datasets
+#   A/B label analysis
+# See docs/operations/observability-langfuse.md for the full recipe.
+```
+
+`docker-compose.langfuse.yml` remains in the repo for teams that want it. It is **not** referenced from `docker-compose.yml` or `make quickstart`.
+
+### 3. AI Usage domain (#75) — nullable prompt reference columns
+
+`ai_usage_log` records nullable prompt metadata instead of a `prompt_id` FK:
+
+| Column | Type | Purpose |
+|--------|------|---------|
+| `prompt_name` | `String(200), nullable` | Prompt identifier (name or key) |
+| `prompt_version` | `String(50), nullable` | Version label — Langfuse-compatible string, not integer |
+| `prompt_source` | `String(20), nullable` | `"inline"` \| `"langfuse"` \| `"self"` \| `None` |
+| `external_prompt_ref` | `String(500), nullable` | Langfuse prompt UUID or other external reference |
+
+**Important constraint**: these columns are **usage metadata for billing/analytics only** — they are not a reproducible prompt registry. A `prompt_version` label may point to different content over time (labels move). If exact prompt reproduction is required, that signals time to build the deferred prompt domain (see §4 below).
+
+### 4. PromptSnapshot value object (deferred domain anchor)
+
+The full prompt domain (editor, versioning, RBAC) is deferred. A lightweight `PromptSnapshot` value object is defined now so consumer domains have a stable contract.
+
+```python
+# src/_core/domain/value_objects/prompt_snapshot.py
+from src._core.domain.value_objects.base import ValueObject  # Pydantic BaseModel, frozen=True
+
+class PromptSnapshot(ValueObject):
+    """Immutable carrier for a resolved prompt at execution time.
+
+    Pydantic ValueObject base chosen (over plain frozen dataclass) because
+    name/source validation is needed: name must be non-empty, source must be
+    a known vocabulary. Config-only VOs with no validation use dataclass(frozen=True);
+    this VO has lightweight field constraints.
+    """
+    name: str
+    version: str | None = None
+    content: str
+    source: str  # "inline" | "langfuse" | "self"
+    external_ref: str | None = None
+    metadata: dict = {}
+
+    @field_validator("name")
+    @classmethod
+    def name_not_empty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("prompt name must not be empty")
+        return v
+```
+
+Consumer domains use `get_active(name) -> PromptSnapshot` as the contract. The concrete implementation is deferred — consumers stub with `PromptSnapshot(name="...", content=INLINE_PROMPT, source="inline")`.
+
+**Trigger conditions to build the full prompt domain**:
+- A non-developer needs to edit prompts without code deployment, **or**
+- The project operates 3+ distinct prompts simultaneously requiring version management
+
+### 5. simple-chatbot example (#97)
+
+`examples/simple-chatbot/` uses an inline system prompt (module constant). No dependency on `ai_usage` or the prompt domain.
+
+```python
+SYSTEM_PROMPT = "You are a helpful assistant."
+# tokens_used shown in response for educational purposes only.
+# Production usage tracking: see ai_usage domain (#75).
+```
+
+## Rationale
+
+### Why not commit to the prompt domain now?
+
+The two real trigger conditions (non-developer editing + multi-prompt operations) are not yet present in this project. Building a production-grade prompt editor before the demand exists is the exact failure mode ADR 042 was written to prevent. The `PromptSnapshot` contract is sufficient — consumer domains can be written against the interface today without the implementation.
+
+### Why keep Langfuse at all?
+
+Langfuse remains the best opt-in tool for teams who need prompt-to-trace linkage, evaluation datasets, and A/B analysis. Removing it from the recipe would force those teams to rebuild functionality that is free under MIT. The key change is: Langfuse is no longer a default dependency, it is an explicitly-documented opt-in path.
+
+### Why OTEL as the core?
+
+`Agent.instrument_all()` is one line. Any OTLP-compatible backend receives the standard GenAI semantic convention spans immediately. Teams not needing LLMOps product features (small projects, quickstart evaluation, cost-conscious deployments) get useful telemetry with zero vendor commitment.
+
+## Trade-offs Accepted
+
+- **Prompt management absent from base blueprint** — teams that expect a prompt editor out of the box will find it missing. Mitigation: the `PromptSnapshot` contract and defer rationale in this ADR are documented so contributors know exactly when to build it.
+- **Langfuse-native features require opt-in recipe step** — prompt-to-trace linkage requires following `docs/operations/observability-langfuse.md`. This cannot be simplified further without re-introducing Langfuse as a required dependency.
+- **prompt_version is not a reproducible reference** — Langfuse labels can move. Teams relying on exact reproduction must either use `external_prompt_ref` (Langfuse prompt UUID, which is stable) or wait for the full prompt domain.
+
+## Issue Sequence
+
+This ADR governs the following issue updates (execute after this ADR merges):
+
+1. Close #74 (superseded). Create split follow-up issues for OTEL core setup and Langfuse opt-in recipe. Backfill actual issue numbers here once created.
+2. Update #75 acceptance: replace `prompt_id FK` with the four nullable columns above + the "usage metadata only" disclaimer.
+3. Update #97 acceptance: inline system prompt, no prompt domain dependency, `tokens_used` retained as educational output.
+
+## Self-check
+
+- [x] Does this decision address the root cause, not just the symptom?
+- [x] Is this the right approach for the current project scale and team situation?
+- [x] Will a reader understand "why" 6 months from now without additional context?
+- [x] Does this align with ADR 042 (optional infrastructure)?
+- [x] Were the Codex cross-review corrections (PromptSnapshot base class, prompt_version semantics, placeholder issue numbers) incorporated?

--- a/docs/history/archive/038-llm-observability-dual-path.md
+++ b/docs/history/archive/038-llm-observability-dual-path.md
@@ -1,6 +1,6 @@
 # 038. LLM Observability — Dual-Path Architecture
 
-- Status: Accepted
+- Status: Superseded by [046](../046-otel-core-langfuse-recipe-prompt-domain-defer.md)
 - Date: 2026-04-15
 - Related issue: #15 (design), subsequent issues for Langfuse and AI Usage implementation
 - Related ADRs: [037](../037-pydanticai-agent-integration.md)(PydanticAI), [029](029-broker-abstraction-selector.md)(Selector pattern), [035](035-embedding-service-abstraction.md)(Embedding abstraction)


### PR DESCRIPTION
## Summary

- Adds **ADR 046** — re-evaluates and supersedes archive/038 (Langfuse 1st-class observability)
- Marks `archive/038` status as `Superseded by 046`
- Updates `docs/ai/shared/ai-infrastructure-overview.md`: removes Langfuse 1st-class framing, adds OTEL backend comparison matrix, documents prompt domain defer rationale

## Decision (Model E)

Three pillars:

1. **OTEL core (`otel` extra)** — `Agent.instrument_all()` + OTLP exporter, backend-agnostic. Zero required env vars at quickstart.
2. **Langfuse opt-in recipe** — `docker-compose.langfuse.yml` + `make observability-langfuse`. Not in base quickstart. Langfuse-native features (prompt linking, eval, A/B) documented as requiring the recipe step.
3. **Prompt domain deferred** — `PromptSnapshot` VO defines the consumer contract. Full domain (editor, versioning, RBAC) built when real demand exists (non-developer editing OR 3+ prompts in simultaneous use).

## Why not ADR 038?

ADR 038's Langfuse-mandatory approach creates two problems:
- 5-component self-hosted stack (PG, ClickHouse, Redis, MinIO, web) blocks OSS quickstart
- Conflicts with ADR 042 (opt-in infrastructure principle)

Codex cross-review (2026-04-28) rejected Model D (OTEL-only, self-built prompt editor) and proposed Model E as lower-failure-cost: OTEL cannot replace Langfuse-native LLMOps features; a self-built prompt editor is underscoped at ~1 week estimate.

## Follow-up (after merge)

- Close #74 + create split follow-up issues for OTEL core setup and Langfuse opt-in recipe
- Update #75 acceptance: nullable `prompt_name`/`prompt_version`/`prompt_source`/`external_prompt_ref` columns instead of `prompt_id` FK
- Update #97 acceptance: inline system prompt, no prompt domain dependency
- Post contributor notice on #97 re: prerequisites and implementation style decision

## Checklist

- [x] ADR 046 in English (Tier 1 language policy)
- [x] Tier 1 language policy pre-commit check passed
- [x] archive/038 status updated
- [x] ai-infrastructure-overview.md updated
- [x] Codex cross-review corrections incorporated (PromptSnapshot base class, prompt_version semantics, placeholder issue numbers)