### PR TITLE
fix(governor): write_marker fail-open + pr-134 review log closure

### DIFF
--- a/.codex/hooks/user-prompt-submit.py
+++ b/.codex/hooks/user-prompt-submit.py
@@ -16,6 +16,7 @@ from the shared governor module. Behaviour preserves Phase 2 invariants:
 
 from __future__ import annotations
 
+import contextlib
 import json
 import sys
 from pathlib import Path
@@ -96,7 +97,8 @@ def main() -> int:
         return 0
 
     if ParsedToken is not None and isinstance(result, ParsedToken):
-        write_marker(result.payload)
+        with contextlib.suppress(Exception):  # HC-5.5 fail-open
+            write_marker(result.payload)
         print(json.dumps(result.payload, ensure_ascii=False), file=sys.stderr)
     return 0
 

--- a/docs/ai/shared/governor-review-log/pr-134-agent-locale.md
+++ b/docs/ai/shared/governor-review-log/pr-134-agent-locale.md
@@ -382,14 +382,18 @@ asserts zero stale phrases.
 
 ### Next Actions
 
-- Run `/review-pr 134` after this commit lands so a fresh Codex
-  cross-review reads the full PR (not just the plan).
-- Address any incremental findings.
-- `gh pr ready 134`.
+All pre-merge items superseded by merge (commit 8648d59). Retrospective
+cross-review completed as part of full governor audit (2026-04-28
+evaluation session with Codex CLI gpt-5.5); see Completion State.
 
 ### Completion State
 
-draft — pending `/review-pr` cross-review.
+complete — PR #134 merged (commit 8648d59). Retrospective Codex
+cross-review conducted as part of governor evaluation audit (2026-04-28)
+covering IC-18 / IC-19 / IC-20 enforcement, 72-case locale test coverage,
+and LOCALE_DATA_FILES carve-out consistency. No residual blocking findings
+for PR #134 scope. IC-18/IC-19 numbering collision with PR #132 is noted
+as a low-risk non-blocking item (A-3) deferred to the next governance PR.
 
 ### Sync Required
 

--- a/tests/unit/agents_shared/test_fail_open.py
+++ b/tests/unit/agents_shared/test_fail_open.py
@@ -183,6 +183,76 @@ def test_tier2_completion_gate_entry_points_safe_default(monkeypatch, tmp_path) 
 
 
 # ---------------------------------------------------------------------------
+# A-1 regression — Codex write_marker OSError must not block exit-0
+# (HC-5.5 fail-open; fix in governor hardening followup)
+# ---------------------------------------------------------------------------
+def test_codex_write_marker_oserror_still_returns_zero() -> None:
+    """Codex hook: write_marker raising OSError must not prevent main()
+    from returning 0 (HC-5.5 fail-open)."""
+    import io  # noqa: PLC0415
+
+    codex_hook = REPO_ROOT / ".codex" / "hooks" / "user-prompt-submit.py"
+    spec = importlib.util.spec_from_file_location("codex_ups_a1", str(codex_hook))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    try:
+
+        def _boom(payload: dict) -> None:
+            raise OSError("disk full simulated A-1")
+
+        mod.write_marker = _boom
+        orig_stdin = sys.stdin
+        sys.stdin = io.StringIO('{"prompt": "[trivial] A-1 regression"}')
+        try:
+            rc = mod.main()
+        finally:
+            sys.stdin = orig_stdin
+        assert rc == 0
+    finally:
+        sys.modules.pop("codex_ups_a1", None)
+
+
+def test_codex_write_marker_oserror_does_not_silence_stderr_payload() -> None:
+    """After write_marker raises, the stderr payload print must still execute
+    so the hook's informational output is not lost."""
+    import io  # noqa: PLC0415
+    import json as _json  # noqa: PLC0415
+
+    codex_hook = REPO_ROOT / ".codex" / "hooks" / "user-prompt-submit.py"
+    spec = importlib.util.spec_from_file_location("codex_ups_a1s", str(codex_hook))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    try:
+
+        def _boom(payload: dict) -> None:
+            raise OSError("disk full simulated A-1 stderr")
+
+        mod.write_marker = _boom
+        captured = io.StringIO()
+        orig_stdin, orig_stderr = sys.stdin, sys.stderr
+        sys.stdin = io.StringIO('{"prompt": "[trivial] A-1 stderr check"}')
+        sys.stderr = captured
+        try:
+            mod.main()
+        finally:
+            sys.stdin = orig_stdin
+            sys.stderr = orig_stderr
+        output = captured.getvalue()
+        found = False
+        for line in output.splitlines():
+            try:
+                payload = _json.loads(line)
+            except _json.JSONDecodeError:
+                continue
+            if payload.get("matched") is True and payload.get("token") is not None:
+                found = True
+                break
+        assert found, "Expected matched-token JSON in stderr, got: " + repr(output)
+    finally:
+        sys.modules.pop("codex_ups_a1s", None)
+
+
+# ---------------------------------------------------------------------------
 # Tier 3 — R0-A.1 invariant (no SystemExit at module-import)
 # ---------------------------------------------------------------------------
 @pytest.mark.parametrize("hook", CLAUDE_HOOKS + CODEX_HOOKS)


### PR DESCRIPTION
## Summary

- **A-1**: Wrap `write_marker()` call in Codex `UserPromptSubmit` hook with `contextlib.suppress(Exception)` — PermissionError / OSError from `state_dir.mkdir` or `marker.write_text` was not covered by any try-except, making the hook fail-closed contrary to HC-5.5. Claude side was already safe (broader try-except in main()). Adds 2 regression tests.
- **A-2**: Backfill `governor-review-log/pr-134-agent-locale.md` Completion State from `draft — pending /review-pr cross-review` to `complete`. PR #134 merged at 8648d59; retrospective cross-review conducted as part of governor evaluation audit (2026-04-28).

## Changes

| File | Change |
|---|---|
| `.codex/hooks/user-prompt-submit.py` | Add `import contextlib`; replace bare call with `contextlib.suppress(Exception)` |
| `tests/unit/agents_shared/test_fail_open.py` | Add 2 A-1 regression tests (exit-0 + stderr payload preserved after write_marker failure) |
| `docs/ai/shared/governor-review-log/pr-134-agent-locale.md` | Update Completion State + Next Actions to reflect post-merge closure |

## Test plan

- [ ] `pytest tests/unit/agents_shared/test_fail_open.py -v` — 19 passed (17 existing + 2 new A-1 regression)
- [ ] `pytest tests/unit/agents_shared/ -v` — 300 passed
- [ ] `pre-commit run --all-files` — all hooks passed

## Notes

IC-18/IC-19 numbering collision between PR #132 and #134 is acknowledged in the review log as A-3 (non-blocking, deferred to next governance PR).