### PR TITLE
docs(observability): add Langfuse opt-in recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-.PHONY: help setup quickstart demo demo-rag dev test lint format check clean diagrams
+.PHONY: help setup quickstart demo demo-rag dev worker observability-langfuse observability-langfuse-down test lint format check clean diagrams
 
 ## Show available commands
 help:
 	@echo "Usage: make <command>"
 	@echo ""
-	@awk '/^## /{desc=substr($$0,4)} /^[a-zA-Z_-]+:/{if(desc){printf "  \033[36m%-15s\033[0m %s\n", $$1, desc; desc=""}}' $(MAKEFILE_LIST)
+	@awk '/^## /{desc=substr($$0,4)} /^[a-zA-Z_-]+:/{if(desc){printf "  \033[36m%-32s\033[0m %s\n", $$1, desc; desc=""}}' $(MAKEFILE_LIST)
 
 .DEFAULT_GOAL := help
 
@@ -48,6 +48,14 @@ dev:
 ## Start worker locally
 worker:
 	uv run python run_worker_local.py
+
+## Start the opt-in Langfuse observability stack
+observability-langfuse:
+	docker compose -f docker-compose.langfuse.yml up -d
+
+## Stop the opt-in Langfuse observability stack
+observability-langfuse-down:
+	docker compose -f docker-compose.langfuse.yml down
 
 ## Run all tests (SQLite in-memory by default)
 test:

--- a/docker-compose.langfuse.yml
+++ b/docker-compose.langfuse.yml
@@ -1,0 +1,208 @@
+name: fastapi-agent-blueprint-langfuse
+
+services:
+  langfuse-web:
+    image: langfuse/langfuse:3
+    container_name: fastapi-agent-blueprint-langfuse-web
+    restart: unless-stopped
+    depends_on: &langfuse-depends-on
+      langfuse-postgres:
+        condition: service_healthy
+      langfuse-clickhouse:
+        condition: service_healthy
+      langfuse-redis:
+        condition: service_healthy
+      langfuse-minio:
+        condition: service_healthy
+    ports:
+      - "127.0.0.1:3000:3000"
+    environment:
+      <<: &langfuse-env
+        NEXTAUTH_URL: ${LANGFUSE_NEXTAUTH_URL:-http://localhost:3000}
+        NEXTAUTH_SECRET: ${LANGFUSE_NEXTAUTH_SECRET:-local-langfuse-nextauth-secret}
+        SALT: ${LANGFUSE_SALT:-local-langfuse-salt}
+        ENCRYPTION_KEY: ${LANGFUSE_ENCRYPTION_KEY:-0000000000000000000000000000000000000000000000000000000000000000}
+        TELEMETRY_ENABLED: ${LANGFUSE_TELEMETRY_ENABLED:-false}
+        LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES: ${LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES:-true}
+
+        LANGFUSE_INIT_ORG_ID: ${LANGFUSE_INIT_ORG_ID:-fastapi-agent-blueprint}
+        LANGFUSE_INIT_ORG_NAME: ${LANGFUSE_INIT_ORG_NAME:-FastAPI Agent Blueprint}
+        LANGFUSE_INIT_PROJECT_ID: ${LANGFUSE_INIT_PROJECT_ID:-local-dev}
+        LANGFUSE_INIT_PROJECT_NAME: ${LANGFUSE_INIT_PROJECT_NAME:-Local Development}
+        LANGFUSE_INIT_PROJECT_PUBLIC_KEY: ${LANGFUSE_INIT_PROJECT_PUBLIC_KEY:-pk-lf-local-dev}
+        LANGFUSE_INIT_PROJECT_SECRET_KEY: ${LANGFUSE_INIT_PROJECT_SECRET_KEY:-sk-lf-local-dev}
+        LANGFUSE_INIT_USER_EMAIL: ${LANGFUSE_INIT_USER_EMAIL:-admin@example.com}
+        LANGFUSE_INIT_USER_NAME: ${LANGFUSE_INIT_USER_NAME:-Admin}
+        LANGFUSE_INIT_USER_PASSWORD: ${LANGFUSE_INIT_USER_PASSWORD:-local-langfuse-admin}
+
+        DATABASE_URL: postgresql://${LANGFUSE_POSTGRES_USER:-postgres}:${LANGFUSE_POSTGRES_PASSWORD:-postgres}@langfuse-postgres:5432/${LANGFUSE_POSTGRES_DB:-postgres}
+
+        CLICKHOUSE_MIGRATION_URL: clickhouse://${LANGFUSE_CLICKHOUSE_USER:-clickhouse}:${LANGFUSE_CLICKHOUSE_PASSWORD:-clickhouse}@langfuse-clickhouse:9000
+        CLICKHOUSE_URL: http://langfuse-clickhouse:8123
+        CLICKHOUSE_USER: ${LANGFUSE_CLICKHOUSE_USER:-clickhouse}
+        CLICKHOUSE_PASSWORD: ${LANGFUSE_CLICKHOUSE_PASSWORD:-clickhouse}
+        CLICKHOUSE_CLUSTER_ENABLED: ${LANGFUSE_CLICKHOUSE_CLUSTER_ENABLED:-false}
+
+        REDIS_HOST: langfuse-redis
+        REDIS_PORT: 6379
+        REDIS_AUTH: ${LANGFUSE_REDIS_AUTH:-myredissecret}
+        REDIS_TLS_ENABLED: ${LANGFUSE_REDIS_TLS_ENABLED:-false}
+
+        LANGFUSE_S3_EVENT_UPLOAD_BUCKET: ${LANGFUSE_S3_BUCKET:-langfuse}
+        LANGFUSE_S3_EVENT_UPLOAD_REGION: ${LANGFUSE_S3_REGION:-auto}
+        LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID: ${LANGFUSE_MINIO_ROOT_USER:-minio}
+        LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: ${LANGFUSE_MINIO_ROOT_PASSWORD:-miniosecret}
+        LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT: http://langfuse-minio:9000
+        LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: true
+        LANGFUSE_S3_EVENT_UPLOAD_PREFIX: events/
+
+        LANGFUSE_S3_MEDIA_UPLOAD_BUCKET: ${LANGFUSE_S3_BUCKET:-langfuse}
+        LANGFUSE_S3_MEDIA_UPLOAD_REGION: ${LANGFUSE_S3_REGION:-auto}
+        LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID: ${LANGFUSE_MINIO_ROOT_USER:-minio}
+        LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY: ${LANGFUSE_MINIO_ROOT_PASSWORD:-miniosecret}
+        LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT: http://localhost:9090
+        LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE: true
+        LANGFUSE_S3_MEDIA_UPLOAD_PREFIX: media/
+
+        LANGFUSE_S3_BATCH_EXPORT_ENABLED: ${LANGFUSE_S3_BATCH_EXPORT_ENABLED:-false}
+        LANGFUSE_S3_BATCH_EXPORT_BUCKET: ${LANGFUSE_S3_BUCKET:-langfuse}
+        LANGFUSE_S3_BATCH_EXPORT_PREFIX: exports/
+        LANGFUSE_S3_BATCH_EXPORT_REGION: ${LANGFUSE_S3_REGION:-auto}
+        LANGFUSE_S3_BATCH_EXPORT_ENDPOINT: http://langfuse-minio:9000
+        LANGFUSE_S3_BATCH_EXPORT_EXTERNAL_ENDPOINT: http://localhost:9090
+        LANGFUSE_S3_BATCH_EXPORT_ACCESS_KEY_ID: ${LANGFUSE_MINIO_ROOT_USER:-minio}
+        LANGFUSE_S3_BATCH_EXPORT_SECRET_ACCESS_KEY: ${LANGFUSE_MINIO_ROOT_PASSWORD:-miniosecret}
+        LANGFUSE_S3_BATCH_EXPORT_FORCE_PATH_STYLE: true
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3000/api/public/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+
+  langfuse-worker:
+    image: langfuse/langfuse-worker:3
+    container_name: fastapi-agent-blueprint-langfuse-worker
+    restart: unless-stopped
+    depends_on: *langfuse-depends-on
+    environment:
+      <<: *langfuse-env
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.138.0
+    container_name: fastapi-agent-blueprint-langfuse-otel-collector
+    restart: unless-stopped
+    depends_on:
+      langfuse-web:
+        condition: service_healthy
+    command: ["--config=/etc/otelcol/config.yaml"]
+    ports:
+      - "127.0.0.1:4318:4318"
+    configs:
+      - source: langfuse-otel-collector-config
+        target: /etc/otelcol/config.yaml
+
+  langfuse-postgres:
+    image: postgres:16-alpine
+    container_name: fastapi-agent-blueprint-langfuse-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${LANGFUSE_POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${LANGFUSE_POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: ${LANGFUSE_POSTGRES_DB:-postgres}
+    ports:
+      - "127.0.0.1:5433:5432"
+    volumes:
+      - langfuse_postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  langfuse-clickhouse:
+    image: clickhouse/clickhouse-server:24.8
+    container_name: fastapi-agent-blueprint-langfuse-clickhouse
+    restart: unless-stopped
+    user: "101:101"
+    environment:
+      CLICKHOUSE_DB: default
+      CLICKHOUSE_USER: ${LANGFUSE_CLICKHOUSE_USER:-clickhouse}
+      CLICKHOUSE_PASSWORD: ${LANGFUSE_CLICKHOUSE_PASSWORD:-clickhouse}
+    volumes:
+      - langfuse_clickhouse_data:/var/lib/clickhouse
+      - langfuse_clickhouse_logs:/var/log/clickhouse-server
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8123/ping || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
+
+  langfuse-redis:
+    image: redis:7-alpine
+    container_name: fastapi-agent-blueprint-langfuse-redis
+    restart: unless-stopped
+    command: ["redis-server", "--requirepass", "${LANGFUSE_REDIS_AUTH:-myredissecret}"]
+    environment:
+      REDIS_AUTH: ${LANGFUSE_REDIS_AUTH:-myredissecret}
+    ports:
+      - "127.0.0.1:6380:6379"
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli -a $$REDIS_AUTH ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  langfuse-minio:
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    container_name: fastapi-agent-blueprint-langfuse-minio
+    restart: unless-stopped
+    entrypoint: sh
+    command: -c 'mkdir -p /data/langfuse && minio server --address ":9000" --console-address ":9001" /data'
+    environment:
+      MINIO_ROOT_USER: ${LANGFUSE_MINIO_ROOT_USER:-minio}
+      MINIO_ROOT_PASSWORD: ${LANGFUSE_MINIO_ROOT_PASSWORD:-miniosecret}
+    ports:
+      - "127.0.0.1:9090:9000"
+      - "127.0.0.1:9091:9001"
+    volumes:
+      - langfuse_minio_data:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
+
+configs:
+  langfuse-otel-collector-config:
+    content: |
+      receivers:
+        otlp:
+          protocols:
+            http:
+              endpoint: 0.0.0.0:4318
+
+      processors:
+        batch:
+
+      exporters:
+        otlphttp/langfuse:
+          endpoint: http://langfuse-web:3000/api/public/otel
+          headers:
+            Authorization: Basic ${LANGFUSE_OTEL_BASIC_AUTH:-cGstbGYtbG9jYWwtZGV2OnNrLWxmLWxvY2FsLWRldg==}
+            x-langfuse-ingestion-version: "4"
+
+      service:
+        pipelines:
+          traces:
+            receivers: [otlp]
+            processors: [batch]
+            exporters: [otlphttp/langfuse]
+
+volumes:
+  langfuse_postgres_data:
+  langfuse_clickhouse_data:
+  langfuse_clickhouse_logs:
+  langfuse_minio_data:

--- a/docs/operations/observability-langfuse.md
+++ b/docs/operations/observability-langfuse.md
@@ -1,0 +1,159 @@
+# Langfuse Tracing — Operations Recipe
+
+This document covers the opt-in Langfuse recipe for receiving PydanticAI
+OpenTelemetry traces from the fastapi-agent-blueprint.
+
+Langfuse is not part of `make quickstart` or the base Docker Compose file. Use
+this stack only when a team wants the Langfuse UI on top of the existing OTEL
+trace path.
+
+## What you get
+
+With the OTEL core enabled, Langfuse can display the GenAI spans emitted by
+PydanticAI:
+
+| Span data | Available through OTLP |
+|---|---|
+| Token usage | Yes |
+| Latency | Yes |
+| Input/output messages | Yes, when emitted by the instrumented agent |
+| System instructions | Yes, when emitted by the instrumented agent |
+
+## What this recipe does not deliver
+
+This recipe is OTLP trace ingestion only. The following Langfuse-native features
+remain out of scope and require a later SDK/API or custom span-processor issue:
+
+- Prompt version to trace linkage
+- Evaluation scores and dataset regression tests
+- A/B prompt label analysis
+- Live prompt editing with trace feedback
+
+## Prerequisites
+
+Install the OTEL and PydanticAI extras:
+
+```bash
+uv sync --extra otel --extra pydantic-ai
+```
+
+The application currently uses the OTLP gRPC exporter by default. Langfuse OTLP
+ingestion uses HTTP/protobuf, so follow the HTTP exporter swap below before
+pointing the app at this recipe.
+
+> Important: complete the HTTP exporter swap before booting the app with the
+> Langfuse endpoint. A gRPC exporter cannot send traces to
+> `http://localhost:4318/v1/traces`.
+
+## HTTP exporter swap
+
+Langfuse receives OTLP over HTTP/protobuf. The local recipe exposes
+`localhost:4318` through an OpenTelemetry Collector, and the collector forwards
+traces to the Langfuse web ingestion endpoint at
+`/api/public/otel`.
+
+Install the HTTP exporter package:
+
+```bash
+uv add opentelemetry-exporter-otlp-proto-http
+```
+
+`uv add` modifies `pyproject.toml` and `uv.lock`. Treat that as a local recipe
+step unless this project later adds HTTP/protobuf support to the committed
+`otel` extra. If you later switch back to the gRPC-only Jaeger or Tempo recipes in
+[`observability-otel.md`](observability-otel.md), revert the import below or add
+a protocol toggle in a follow-up change.
+
+Then change `src/_core/infrastructure/observability/otel_setup.py`:
+
+```python
+# From (gRPC):
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+
+# To (HTTP/protobuf):
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+```
+
+## Start Langfuse
+
+```bash
+make observability-langfuse
+```
+
+The stack starts these local ports:
+
+| Service | Local URL |
+|---|---|
+| Langfuse web | `http://localhost:3000` |
+| OTLP/HTTP collector | `http://localhost:4318/v1/traces` |
+| PostgreSQL | `localhost:5433` |
+| Redis | `localhost:6380` |
+| MinIO S3 API | `http://localhost:9090` |
+| MinIO console | `http://localhost:9091` |
+
+ClickHouse is internal to the Compose network and is not published to the host.
+
+The default bootstrap credentials are for local development only:
+
+| Credential | Default |
+|---|---|
+| Login email | `admin@example.com` |
+| Login password | `local-langfuse-admin` |
+| Project public key | `pk-lf-local-dev` |
+| Project secret key | `sk-lf-local-dev` |
+
+For production-like testing, override the `LANGFUSE_INIT_*` and secret
+environment variables before starting the stack.
+
+Set the HTTP traces endpoint:
+
+```bash
+OTEL_ENABLED=true \
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318/v1/traces \
+LLM_PROVIDER=openai \
+LLM_API_KEY=sk-... \
+make dev
+```
+
+If you override `LANGFUSE_INIT_PROJECT_PUBLIC_KEY` or
+`LANGFUSE_INIT_PROJECT_SECRET_KEY`, also set `LANGFUSE_OTEL_BASIC_AUTH` to the
+base64 value of `public_key:secret_key` before running
+`make observability-langfuse`:
+
+```bash
+printf %s 'pk-lf-your-key:sk-lf-your-key' | base64
+```
+
+If this value does not match the bootstrapped project keys, the collector
+exporter will receive HTTP 401 responses from Langfuse.
+
+## Verify the first trace
+
+1. Open `http://localhost:3000` and log in with the local bootstrap user.
+2. Start the app with `OTEL_ENABLED=true` and
+   `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318/v1/traces`.
+3. Trigger a classification or RAG request against the running API.
+4. In Langfuse, open the local project and check the Traces view.
+
+The first trace should show the blueprint service name plus GenAI span data such
+as token usage, latency, messages, and system instructions when those attributes
+are emitted by PydanticAI.
+
+## Stop Langfuse
+
+```bash
+make observability-langfuse-down
+```
+
+This stops the containers but keeps named volumes. Remove volumes manually only
+when you want to discard the local Langfuse data.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| No traces in Langfuse | App is still using the gRPC exporter | Apply the HTTP exporter swap |
+| HTTP 401 from collector exporter | Collector auth header does not match project keys | Recompute `LANGFUSE_OTEL_BASIC_AUTH` |
+| App validation error on boot | `OTEL_ENABLED=true` without endpoint | Set `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318/v1/traces` |
+| Port collision on `3000`, `4318`, `5433`, `6380`, or `9090` | Another local service is using the port | Stop the other service or override the Compose port mapping locally |
+| Langfuse web is slow on first boot | Migrations and ClickHouse initialization are still running | Wait for `docker compose -f docker-compose.langfuse.yml ps` to show healthy services |


### PR DESCRIPTION
## Related Issue
- Closes #137

## Change Summary
- Added a standalone `docker-compose.langfuse.yml` opt-in stack for Langfuse, including PostgreSQL on `5433`, Redis on `6380`, MinIO on `9090`, Langfuse web on `3000`, ClickHouse, worker, and an OTEL Collector bridge on `4318`.
- Added `make observability-langfuse` and `make observability-langfuse-down` without wiring Langfuse into `make quickstart` or the base compose files.
- Added `docs/operations/observability-langfuse.md` with the HTTP exporter swap, first-trace verification, troubleshooting, and explicit out-of-scope notes for prompt linking, evals, A/B analysis, and live prompt editing.

## Type of Change
- [ ] feat: New feature
- [ ] fix: Bug fix
- [ ] refactor: Code restructuring
- [x] docs: Documentation
- [x] chore: Build/tooling
- [ ] test: Tests
- [ ] ci: CI/CD
- [ ] perf: Performance
- [ ] style: Code style

## Checklist
- [x] Architecture rules followed (no Domain -> Infrastructure imports)
- [x] Tests pass
- [x] Linting passes (`ruff check src/`)

## How to Test
- `docker compose -f docker-compose.langfuse.yml config --quiet`
- `make -n observability-langfuse`
- `make -n observability-langfuse-down`
- `python3 tools/check_language_policy.py`
- `git diff --check`
- `uv run ruff check src/`

## Review Notes
- Claude Opus 4.7 cross-review completed on PR #142: acceptance criteria passed, 0 blocking/high/medium findings.
- The review recommended clarifying the HTTP exporter dependency workflow; that note was incorporated into the Langfuse operations doc.
- Drift candidates were noted for post-merge guideline/status sync, but this PR does not touch governor paths.
- `test.md` remains an unrelated untracked local file and is not included in this branch.