### PR TITLE
feat(governor): standardise cross-tool review prompts

### DIFF
--- a/.agents/skills/review-architecture/SKILL.md
+++ b/.agents/skills/review-architecture/SKILL.md
@@ -19,3 +19,6 @@ metadata:
 4. Audit the target against the 9 architecture checklist categories (Phase 1).
 5. Determine `Drift Candidates` and whether `Sync Required` is `true` or `false` (Phase 2).
 6. Report using the shared review contract: `Scope`, `Sources Loaded`, `Findings`, `Drift Candidates`, `Next Actions`, `Completion State`, `Sync Required` (Phase 3).
+
+For cross-tool review prompts, use the `Cross-Tool Review Prompt Template`
+section in `docs/ai/shared/skills/review-architecture.md`; do not duplicate it here.

--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -20,3 +20,6 @@ metadata:
 5. Determine `Drift Candidates` and whether `Sync Required` is `true` or `false` (Phase 2).
 6. Report using the shared review contract: `Scope`, `Sources Loaded`, `Findings`, `Drift Candidates`, `Next Actions`, `Completion State`, `Sync Required` (Phase 3).
 7. Optionally post the final review after user confirmation (Phase 4).
+
+For cross-tool review prompts, use the `Cross-Tool Review Prompt Template`
+section in `docs/ai/shared/skills/review-pr.md`; do not duplicate it here.

--- a/.agents/skills/security-review/SKILL.md
+++ b/.agents/skills/security-review/SKILL.md
@@ -19,3 +19,6 @@ metadata:
 4. Audit the target against the 12 security checklist categories using the shared applicability rules (Phase 1).
 5. Determine stale-reference drift, other `Drift Candidates`, and whether `Sync Required` is `true` or `false` (Phase 2).
 6. Report using the shared review contract: `Scope`, `Sources Loaded`, `Findings`, `Drift Candidates`, `Next Actions`, `Completion State`, `Sync Required` (Phase 3).
+
+For cross-tool review prompts, use the `Cross-Tool Review Prompt Template`
+section in `docs/ai/shared/skills/security-review.md`; do not duplicate it here.

--- a/.agents/skills/sync-guidelines/SKILL.md
+++ b/.agents/skills/sync-guidelines/SKILL.md
@@ -19,3 +19,6 @@ metadata:
 3. Reconcile drift candidates with code, shared references, harness docs, and wrappers (Phase 1).
 4. Refresh `project-dna` and dependent shared references as needed (Phase 2).
 5. Verify Hybrid C parity for both Claude and Codex wrappers, then close with the sync contract (Phase 3).
+
+For cross-tool review prompts, use the `Cross-Tool Review Prompt Template`
+section in `docs/ai/shared/skills/sync-guidelines.md`; do not duplicate it here.

--- a/.claude/skills/review-architecture/SKILL.md
+++ b/.claude/skills/review-architecture/SKILL.md
@@ -24,3 +24,5 @@ Target: $ARGUMENTS (domain name or "all")
 
 Read `docs/ai/shared/skills/review-architecture.md` for detailed steps and output format.
 Also refer to `docs/ai/shared/architecture-review-checklist.md` for the full checklist.
+For cross-tool review prompts, use the shared procedure's
+`Cross-Tool Review Prompt Template` section; do not duplicate the template here.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -24,6 +24,8 @@ Target: $ARGUMENTS (PR number, GitHub URL, or empty for current branch)
 5. Post to GitHub only after user confirmation (Phase 4)
 
 Read `docs/ai/shared/skills/review-pr.md` for detailed steps and output format.
+For cross-tool review prompts, use that shared procedure's
+`Cross-Tool Review Prompt Template` section; do not duplicate the template here.
 
 ## Claude-Specific: Rule Sources
 You may cross-check the final wording against `.claude/rules/architecture-conventions.md`,

--- a/.claude/skills/security-review/SKILL.md
+++ b/.claude/skills/security-review/SKILL.md
@@ -24,3 +24,5 @@ Target: $ARGUMENTS (domain name, file path, or "all")
 
 Read `docs/ai/shared/skills/security-review.md` for detailed steps and output format.
 Also refer to `docs/ai/shared/security-checklist.md` for the full checklist.
+For cross-tool review prompts, use the shared procedure's
+`Cross-Tool Review Prompt Template` section; do not duplicate the template here.

--- a/.claude/skills/sync-guidelines/SKILL.md
+++ b/.claude/skills/sync-guidelines/SKILL.md
@@ -25,6 +25,8 @@ Read `docs/ai/shared/skills/sync-guidelines.md` for detailed steps.
 Also refer to `docs/ai/shared/drift-checklist.md` for inspection items.
 
 Closing summary must include: `Mode`, `Input Drift Candidates`, `project-dna`, `AUTO-FIX`, `REVIEW`, `Remaining`, `Next Actions` - see "Sync Contract" in the shared procedure.
+For cross-tool review prompts, use the shared procedure's
+`Cross-Tool Review Prompt Template` section; do not duplicate the template here.
 
 ## Claude-Specific Post-Steps
 

--- a/docs/ai/shared/governor-review-log/README.md
+++ b/docs/ai/shared/governor-review-log/README.md
@@ -101,3 +101,4 @@ specialisations in
 | #138 | ADR 046 follow-up: Status Accepted + issue backfill #136/#137 + project-status sync | #74 / #135 | [pr-138-adr-046-followup.md](pr-138-adr-046-followup.md) |
 | #141 | OTEL core: `[otel]` extra + settings + bootstrap wiring + recipe doc | #136 | [pr-141-otel-core.md](pr-141-otel-core.md) |
 | #143 | Reasoning-Level Consistency Guards (F / G / H / I) — Tier 1 Layer 2 governor | — | [pr-143-reasoning-guards.md](pr-143-reasoning-guards.md) |
+| #147 | Cross-tool prompt template standardisation for review skills | #144 | [pr-147-cross-tool-prompt-standardisation.md](pr-147-cross-tool-prompt-standardisation.md) |

--- a/docs/ai/shared/governor-review-log/README.md
+++ b/docs/ai/shared/governor-review-log/README.md
@@ -81,7 +81,11 @@ Each review angle: assessment + 1~3 paragraph analysis citing file:line where po
 - **Open questions** for the user
 ```
 
-The prompt is a starting point; phase-specific reviews (Phase 2 token parser, Phase 3 verify adapter, Phase 4 completion gate, Phase 5 shared module) extend it with phase-specific angles.
+The prompt is a starting point; phase-specific reviews (Phase 2 token parser,
+Phase 3 verify adapter, Phase 4 completion gate, Phase 5 shared module) extend
+it with phase-specific angles. For quality-gate skills, use the per-skill
+specialisations in
+`docs/ai/shared/skills/{review-pr,sync-guidelines,security-review,review-architecture}.md`.
 
 ## Index
 

--- a/docs/ai/shared/governor-review-log/pr-147-cross-tool-prompt-standardisation.md
+++ b/docs/ai/shared/governor-review-log/pr-147-cross-tool-prompt-standardisation.md
@@ -31,7 +31,7 @@ specialisations.
   separation from issues #145 and #146.
 - **Result**: not executed. Claude Code returned
   `Not logged in - Please run /login`.
-- **Final Verdict**: deferred with rationale. The implementation proceeded
+- **Final Verdict**: Deferred-with-rationale. The implementation proceeded
   after local verification because the blocker was authentication state, not a
   finding against the plan.
 
@@ -45,9 +45,29 @@ specialisations.
   pointer-only behavior, and Tier 1 English-only policy.
 - **Result**: not executed. Claude Code returned
   `Not logged in - Please run /login`.
-- **Final Verdict**: deferred with rationale. The blocker must be closed by
+- **Final Verdict**: Deferred-with-rationale. The blocker must be closed by
   re-running Claude cross-review after login before this draft PR is marked
   ready for merge.
+
+### Round 2 - Claude Opus Implementation Review
+
+- **Target**: current PR #147 workspace after the implementation commit and
+  review-log backfill commit.
+- **Reviewer**: Claude Opus 4.7 through Claude Code CLI, run after local
+  authentication was restored.
+- **Prompt focus**: #144 acceptance criteria, canonical shared-source
+  placement, wrapper pointer-only behavior, exact closure vocabulary, exclusion
+  of #145 / #146 work, and truthfulness of this review-log entry.
+- **Final Verdict**: minor fixes recommended. Claude confirmed that the four
+  shared skill procedures contain the required prompt templates and that the
+  wrappers are pointer-only. It surfaced three review-log hygiene points:
+  canonicalise the prose spelling of `Deferred-with-rationale`, record the
+  actual Claude review outcome now that it has run, and optionally defer the
+  README starter-template round-numbering mismatch (`1/2/3` vs `0/1/2`) as a
+  follow-up drift candidate.
+- **Outcome**: prose verdict spelling and actual-review capture were fixed in
+  this entry. The README round-numbering mismatch is deferred because it
+  predates the per-skill template shape and does not block #144 acceptance.
 
 ### Local Verification
 
@@ -86,9 +106,9 @@ No new inherited constraint is introduced by this PR.
 - **Scope check**: no linter, parser, retrospective audit script, or legacy
   review-log backfill from issues #145 or #146 is included.
 - **Language-policy check**: Tier 1 language policy passes with 0 violations.
-- **Cross-tool limitation**: Claude Opus review is still required before merge
-  readiness because both attempted Claude rounds were blocked by local
-  authentication state.
+- **Cross-tool review**: Claude Opus Round 2 completed after login and found
+  only review-log hygiene issues. This entry records the completed review and
+  closes the stale blocked-review wording.
 
 ## R-points Closure Table
 
@@ -99,3 +119,6 @@ No new inherited constraint is introduced by this PR.
 | Local verification | Tier 1 language policy | **Fixed** | `python3 tools/check_language_policy.py` and pre-commit language hook passed |
 | Local verification | Required prompt slots present | **Fixed** | Four templates include original question, success metric, sources, R-points, final verdict, and closure vocabulary |
 | Scope control | Issue #145 and #146 work not implemented | **Fixed** | This PR only adds text prompt templates and wrapper pointers |
+| Round 2 | Claude implementation review outcome missing from this entry | **Fixed** | Round 2 now records the actual Claude Opus review after login |
+| Round 2 | Non-canonical prose spelling of `Deferred-with-rationale` | **Fixed** | Round 0 and Round 1 final verdict prose now uses the canonical spelling |
+| Round 2 | README starter-template round numbering differs from per-skill templates | **Deferred-with-rationale** | Existing README template uses `1/2/3`; per-skill templates use `0/1/2`; deferrable follow-up because #144 acceptance is about per-skill specialisations |

--- a/docs/ai/shared/governor-review-log/pr-147-cross-tool-prompt-standardisation.md
+++ b/docs/ai/shared/governor-review-log/pr-147-cross-tool-prompt-standardisation.md
@@ -1,0 +1,101 @@
+# PR #147 - Cross-Tool Prompt Template Standardisation
+
+> Issue: [#144](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/144)
+> Pull Request: [#147](https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/147)
+> ADR: ADR 045 and PR #143 Reasoning-Level Consistency Guards
+
+## Summary
+
+Adds canonical cross-tool review prompt templates to the four quality-gate
+shared skill procedures: `/review-pr`, `/sync-guidelines`, `/security-review`,
+and `/review-architecture`. The templates standardise the input and output
+frame for read-only cross-tool reviews, including the original user question,
+success metric, sources loaded, review angles, R-points, final verdict, and
+the three canonical closure categories from AGENTS.md guard G:
+`Fixed`, `Deferred-with-rationale`, and `Rejected`.
+
+The canonical prompt bodies live only in `docs/ai/shared/skills/*.md`.
+Claude and Codex wrapper skills were updated with pointer-only references so
+the prompt body is not duplicated across tool-specific surfaces. The
+governor-review-log README now links quality-gate reviewers to the per-skill
+specialisations.
+
+## Review Rounds
+
+### Round 0 - Plan Review Attempt
+
+- **Target**: issue #144 implementation plan, with Option A selected.
+- **Reviewer**: Claude Opus 4.7 through Claude Code CLI.
+- **Prompt focus**: canonical-source placement, inherited constraints
+  IC-RG-1 through IC-RG-5, false-positive risk, wrapper drift risk, and scope
+  separation from issues #145 and #146.
+- **Result**: not executed. Claude Code returned
+  `Not logged in - Please run /login`.
+- **Final Verdict**: deferred with rationale. The implementation proceeded
+  after local verification because the blocker was authentication state, not a
+  finding against the plan.
+
+### Round 1 - Implementation Review Attempt
+
+- **Target**: local diff after adding the four shared prompt templates,
+  wrapper pointers, and governor-review-log README cross-reference.
+- **Reviewer**: Claude Opus 4.7 through Claude Code CLI.
+- **Prompt focus**: canonical-source placement, exact closure category
+  vocabulary, original user question and success metric slots, wrapper
+  pointer-only behavior, and Tier 1 English-only policy.
+- **Result**: not executed. Claude Code returned
+  `Not logged in - Please run /login`.
+- **Final Verdict**: deferred with rationale. The blocker must be closed by
+  re-running Claude cross-review after login before this draft PR is marked
+  ready for merge.
+
+### Local Verification
+
+- `python3 tools/check_language_policy.py` passed with 0 violations.
+- `uv run pre-commit run --all-files` passed.
+- `git diff --check` passed.
+- Grep checks confirmed one `Cross-Tool Review Prompt Template` section in
+  each of the four target shared skill procedures.
+- Grep checks confirmed `original user question`, `success metric`, and the
+  canonical `Fixed, Deferred-with-rationale, or Rejected` closure vocabulary
+  in all four templates.
+
+## Inherited Constraints
+
+- **IC-RG-1** - Canonical body stays in shared sources. This PR places prompt
+  bodies in `docs/ai/shared/skills/*.md`; wrappers only point to them.
+- **IC-RG-2** - New review prompt slots are evidence-sourced from PR #143's
+  documented miss patterns: stale facts, closure drift, effect/process drift,
+  and self-review bias.
+- **IC-RG-3** - Trigger remains narrow. Only the four quality-gate skills gain
+  prompt specialisations.
+- **IC-RG-4** - Closure vocabulary remains exactly `Fixed`,
+  `Deferred-with-rationale`, and `Rejected`.
+- **IC-RG-5** - This PR adds text prompt templates only. Mechanical closure
+  linting remains issue #145.
+
+No new inherited constraint is introduced by this PR.
+
+## Self-Application Proof
+
+- **Canonical-source check**: shared prompt bodies are present only in the four
+  target files under `docs/ai/shared/skills/`.
+- **Wrapper check**: `.claude/skills/**/SKILL.md` and
+  `.agents/skills/**/SKILL.md` contain pointer-only references to the shared
+  template sections.
+- **Scope check**: no linter, parser, retrospective audit script, or legacy
+  review-log backfill from issues #145 or #146 is included.
+- **Language-policy check**: Tier 1 language policy passes with 0 violations.
+- **Cross-tool limitation**: Claude Opus review is still required before merge
+  readiness because both attempted Claude rounds were blocked by local
+  authentication state.
+
+## R-points Closure Table
+
+| Source | R-point | Closure | Note |
+|---|---|---|---|
+| Round 0 | Claude plan review unavailable | **Deferred-with-rationale** | Claude Code was not logged in; rerun after login before marking the PR ready |
+| Round 1 | Claude implementation review unavailable | **Deferred-with-rationale** | Same authentication blocker; not a plan or diff finding |
+| Local verification | Tier 1 language policy | **Fixed** | `python3 tools/check_language_policy.py` and pre-commit language hook passed |
+| Local verification | Required prompt slots present | **Fixed** | Four templates include original question, success metric, sources, R-points, final verdict, and closure vocabulary |
+| Scope control | Issue #145 and #146 work not implemented | **Fixed** | This PR only adds text prompt templates and wrapper pointers |

--- a/docs/ai/shared/skills/review-architecture.md
+++ b/docs/ai/shared/skills/review-architecture.md
@@ -157,3 +157,62 @@ Sync Required
 
 When the audit is clean, still emit `Findings: none`, `Drift Candidates: none`,
 and `Sync Required: false`.
+
+## Cross-Tool Review Prompt Template
+
+Use this template when another tool or reviewer cross-checks a
+`/review-architecture` result, an audited domain, or an architecture-related
+readiness decision. The purpose is a consistent input and output frame; findings
+must remain grounded in shared architecture sources and live code evidence.
+
+```text
+Cross-tool review for /review-architecture (read-only). Do not modify files. Do
+not run git commands.
+
+Context
+- Repo: fastapi-agent-blueprint
+- Audit target: <all / domain / examples/name>
+- Issue link: <#NNN or none>
+- Round: <0 plan / 1 implementation / 2 gate-on-gate / N>
+- original user question: <verbatim or concise restatement>
+- success metric: <what the user said would count as success>
+- Inherited constraints: <links to relevant governor-review-log entries>
+
+What you are reviewing
+- Architecture surface: <layers, DTO conversion, DI, repository, worker,
+  admin, bootstrap, DynamoDB, or examples profile>
+- Prior audit result: <Findings / Drift Candidates / Sync Required summary>
+- Important exclusions: <examples profile, inactive optional infra, or none>
+
+Sources Loaded
+- AGENTS.md
+- docs/ai/shared/project-dna.md
+- docs/ai/shared/architecture-review-checklist.md
+- docs/ai/shared/security-checklist.md when the architecture issue overlaps a
+  security boundary
+- Live code evidence from audited files and relevant wiring
+
+Review Angles
+1. Layer and dependency rules: did the audit verify Domain, Service,
+   Repository, Infrastructure, and Interface boundaries from current code?
+2. Conversion and DTO integrity: did it check Request, DTO, Response, Model,
+   and DynamoModel flow without inventing mapper or entity patterns?
+3. DI and bootstrap correctness: did it inspect container providers, selectors,
+   task wiring, and admin/service contracts where applicable?
+4. Drift decision: did documented-pattern changes become drift candidates
+   instead of being hidden inside a clean architecture verdict?
+5. Volatile facts: are domains, file paths, line references, and optional
+   feature claims verified from current repository evidence?
+
+Output format
+- Scope
+- Sources Loaded
+- Findings: open issues only, each with severity, rule source, file:line,
+  impact, and recommended fix
+- Drift Candidates: target, reason, auto-fix, sync-required
+- R-points: every cross-review point must include one closure category:
+  Fixed, Deferred-with-rationale, or Rejected. Do not use non-canonical labels.
+- Final Verdict: clean / minor fixes recommended / still needs architecture
+  review / block merge
+- Sync Required: true or false
+```

--- a/docs/ai/shared/skills/review-pr.md
+++ b/docs/ai/shared/skills/review-pr.md
@@ -156,3 +156,61 @@ Ask before posting.
 
 If `Sync Required: true`, do not treat the review as fully closed until the
 follow-up sync path is acknowledged.
+
+## Cross-Tool Review Prompt Template
+
+Use this template when another tool or reviewer cross-checks a `/review-pr`
+result, a PR diff, or a readiness decision. The purpose is a consistent input
+and output frame; reviewers may disagree with the original review when the
+evidence supports it.
+
+```text
+Cross-tool review for /review-pr (read-only). Do not modify files. Do not run
+git commands.
+
+Context
+- Repo: fastapi-agent-blueprint
+- Review target: <PR number, branch, or diff scope>
+- Issue link: <#NNN or none>
+- Round: <0 plan / 1 implementation / 2 gate-on-gate / N>
+- original user question: <verbatim or concise restatement>
+- success metric: <what the user said would count as success>
+- Inherited constraints: <links to relevant governor-review-log entries>
+
+What you are reviewing
+- Summary: <one-paragraph change summary>
+- Changed files: <3-8 highest-signal paths>
+- Prior review result: <Findings / Drift Candidates / Sync Required summary>
+
+Sources Loaded
+- AGENTS.md
+- docs/ai/shared/project-dna.md
+- docs/ai/shared/architecture-review-checklist.md
+- docs/ai/shared/security-checklist.md
+- docs/ai/shared/governor-paths.md when the change may be governor-changing
+- Relevant changed files and surrounding code
+
+Review Angles
+1. Diff-scope correctness: did the review inspect the changed files and enough
+   surrounding code to judge the shared rules?
+2. Architecture and security rule grounding: are all findings backed by the
+   shared sources above, with no tool-local rule invention?
+3. Drift decision: is `Sync Required` correct, especially for shared rule
+   sources, skill procedures, wrappers, and documented patterns?
+4. Volatile facts: are branch, PR number, changed-file counts, file paths, and
+   line references verified from current evidence?
+5. Completion-gate closure: does the review distinguish open findings,
+   resolved items, and follow-up sync work without masking risk?
+
+Output format
+- Scope
+- Sources Loaded
+- Findings: open issues only, each with severity, rule source, file:line,
+  impact, and recommended fix
+- Drift Candidates: target, reason, auto-fix, sync-required
+- R-points: every cross-review point must include one closure category:
+  Fixed, Deferred-with-rationale, or Rejected. Do not use non-canonical labels.
+- Final Verdict: merge-ready / minor fixes recommended / still needs
+  reinforcement / block merge
+- Sync Required: true or false
+```

--- a/docs/ai/shared/skills/security-review.md
+++ b/docs/ai/shared/skills/security-review.md
@@ -172,3 +172,62 @@ Sync Required
 
 When there are no security findings, still emit all sections. In particular, do
 not omit `Drift Candidates` or `Sync Required`.
+
+## Cross-Tool Review Prompt Template
+
+Use this template when another tool or reviewer cross-checks a
+`/security-review` result, an audited file/domain, or a security-related
+freshness preflight. The purpose is a consistent input and output frame; the
+reviewer should prefer live code evidence when it conflicts with cached shared
+references.
+
+```text
+Cross-tool review for /security-review (read-only). Do not modify files. Do not
+run git commands.
+
+Context
+- Repo: fastapi-agent-blueprint
+- Audit target: <all / domain / file>
+- Issue link: <#NNN or none>
+- Round: <0 plan / 1 implementation / 2 gate-on-gate / N>
+- original user question: <verbatim or concise restatement>
+- success metric: <what the user said would count as success>
+- Inherited constraints: <links to relevant governor-review-log entries>
+
+What you are reviewing
+- Security surface: <auth, credentials, logging, storage, AI provider, worker,
+  file handling, or other surface>
+- Prior audit result: <Findings / Drift Candidates / Sync Required summary>
+- Important exclusions: <tests, examples, inactive optional infra, or none>
+
+Sources Loaded
+- AGENTS.md
+- docs/ai/shared/project-dna.md
+- docs/ai/shared/security-checklist.md
+- Live code evidence from audited files and relevant wiring
+- Related shared references when the audit reports stale-reference drift
+
+Review Angles
+1. Feature freshness: did the audit compare `project-dna` expectations with
+   live imports, settings, DI wiring, and interface surfaces?
+2. OWASP coverage: were all applicable security checklist categories audited,
+   and were inactive categories skipped only after live-code confirmation?
+3. Sensitive data handling: are logs, responses, errors, credentials, and
+   provider settings free of accidental exposure?
+4. Drift decision: did secure-but-undocumented behavior become a drift
+   candidate instead of a fake code finding?
+5. Volatile facts: are file paths, line references, active-feature claims, and
+   dependency claims verified from current evidence?
+
+Output format
+- Scope
+- Sources Loaded
+- Findings: open issues only, each with severity, rule source, file:line,
+  impact, and recommended fix
+- Drift Candidates: target, reason, auto-fix, sync-required
+- R-points: every cross-review point must include one closure category:
+  Fixed, Deferred-with-rationale, or Rejected. Do not use non-canonical labels.
+- Final Verdict: clean / minor fixes recommended / still needs security review /
+  block merge
+- Sync Required: true or false
+```

--- a/docs/ai/shared/skills/sync-guidelines.md
+++ b/docs/ai/shared/skills/sync-guidelines.md
@@ -138,3 +138,64 @@ REVIEW: 1 item (security checklist wording changed and needs human approval)
 Remaining: none
 Next Actions: rerun the originating review or acknowledge the open review item
 ```
+
+## Cross-Tool Review Prompt Template
+
+Use this template when another tool or reviewer cross-checks a
+`/sync-guidelines` result, a shared-docs scan, or a drift-closure decision. The
+purpose is a consistent input and output frame; reviewers may surface new drift
+when current repository evidence supports it.
+
+```text
+Cross-tool review for /sync-guidelines (read-only). Do not modify files. Do not
+run git commands.
+
+Context
+- Repo: fastapi-agent-blueprint
+- Review target: <shared-docs scan, PR diff, or drift candidate set>
+- Issue link: <#NNN or none>
+- Round: <0 plan / 1 implementation / 2 gate-on-gate / N>
+- original user question: <verbatim or concise restatement>
+- success metric: <what the user said would count as success>
+- Inherited constraints: <links to relevant governor-review-log entries>
+
+What you are reviewing
+- Mode: <standalone inspection / review follow-up>
+- Input Drift Candidates: <none or summarized candidates>
+- Changed shared surfaces: <AGENTS.md, docs/ai/shared, wrappers, harness docs>
+- Claimed closure: <AUTO-FIX / REVIEW / Remaining / Next Actions summary>
+
+Sources Loaded
+- AGENTS.md
+- docs/ai/shared/project-dna.md
+- docs/ai/shared/drift-checklist.md
+- docs/ai/shared/governor-paths.md
+- docs/ai/shared/harness-asset-matrix.md
+- docs/ai/shared/repo-facts.md
+- Affected shared procedures, wrappers, checklists, and harness docs
+
+Review Angles
+1. Candidate reconciliation: were incoming drift candidates consumed, closed,
+   or promoted instead of silently re-reported or dropped?
+2. Shared-source consistency: do AGENTS.md, shared docs, wrappers, and harness
+   docs agree without re-declaring governor-path globs?
+3. Hybrid C parity: do shared procedures and both wrapper families point to the
+   same canonical source without duplicating bodies?
+4. Volatile facts: are file existence, path lists, index rows, and changed
+   surfaces verified from current repository state?
+5. Closure discipline: are AUTO-FIX, REVIEW, Remaining, and Next Actions
+   separated without calling unresolved policy judgment "done"?
+
+Output format
+- Mode
+- Sources Loaded
+- Drift Candidates: target, reason, auto-fix, sync-required
+- AUTO-FIX
+- REVIEW
+- Remaining
+- R-points: every cross-review point must include one closure category:
+  Fixed, Deferred-with-rationale, or Rejected. Do not use non-canonical labels.
+- Final Verdict: closed / closed after minor fixes / still needs review /
+  block merge
+- Sync Required: true or false
+```


### PR DESCRIPTION
## Summary
- Adds canonical cross-tool review prompt templates to the four quality-gate shared skill procedures.
- Keeps Claude and Codex skill wrappers as pointers to the shared templates instead of duplicating prompt bodies.
- Adds a governor-review-log README cross-reference to the per-skill specialisations.

## Issue
Closes #144

## Verification
- `python3 tools/check_language_policy.py`
- `uv run pre-commit run --all-files`
- `git diff --check`
- Grep checks for template headings, original user question, success metric, and canonical closure categories.

## Governor-Changing PR
- Trigger: edits `docs/ai/shared/**`, `.claude/skills/**`, and `.agents/skills/**`.
- Cross-tool review: Claude Opus 4.7 Round 2 completed after login. Verdict: minor fixes recommended; review-log hygiene fixes were applied. README starter-template round numbering drift is deferred with rationale in the review log.
- Self-application proof: local review confirmed canonical body placement in shared skill docs, wrapper pointer-only behavior, Tier 1 language policy compliance, and no #145/#146 implementation in this PR.
- Review log: `docs/ai/shared/governor-review-log/pr-147-cross-tool-prompt-standardisation.md`.