### PR TITLE
feat(worker): add Taskiq error handling middleware (#120)

### DIFF
--- a/src/_apps/worker/bootstrap.py
+++ b/src/_apps/worker/bootstrap.py
@@ -9,7 +9,9 @@ from src._core.config import settings
 from src._core.infrastructure.discovery import discover_domains
 from src._core.infrastructure.logging.configure import configure_logging
 from src._core.infrastructure.logging.taskiq_middleware import (
+    PermanentAwareSmartRetryMiddleware,
     StructlogContextMiddleware,
+    TaskErrorLoggingMiddleware,
 )
 
 _logger = structlog.stdlib.get_logger("src._apps.worker.bootstrap")
@@ -36,8 +38,12 @@ def _configure_logging_pipeline() -> None:
 
 
 def _install_middleware(app: AsyncBroker) -> None:
-    """Bind correlation IDs and task identifiers on every task execution."""
-    app.add_middlewares(StructlogContextMiddleware())
+    """Bind task context, log failures, and retry transient task errors."""
+    app.add_middlewares(
+        StructlogContextMiddleware(),
+        PermanentAwareSmartRetryMiddleware(),
+        TaskErrorLoggingMiddleware(),
+    )
 
 
 def _register_startup_event(app: AsyncBroker) -> None:

--- a/src/_core/infrastructure/logging/taskiq_middleware.py
+++ b/src/_core/infrastructure/logging/taskiq_middleware.py
@@ -1,19 +1,28 @@
-"""Taskiq middleware that wires structlog context for every task run (#9).
+"""Taskiq middleware for worker context, failure logging, and retry (#9/#120).
 
-On ``pre_execute`` the middleware binds the task identifier into the
-current async context so every log emitted from within the task
-carries ``taskiq_task_id`` / ``taskiq_task_name``. If the dispatcher
-attached a ``correlation_id`` label (e.g. the HTTP request that kicked
-the task), it is re-bound here too — that's how request → task
-correlation is preserved across the process boundary.
+``StructlogContextMiddleware`` binds the task identifier into the current
+async context so every log emitted from within the task carries
+``taskiq_task_id`` / ``taskiq_task_name``. If the dispatcher attached a
+``correlation_id`` label (e.g. the HTTP request that kicked the task), it is
+re-bound here too. That's how request-to-task correlation is preserved across
+the process boundary.
 
-On ``post_execute`` the keys this middleware owns are cleared so the
-next task picked up by the same worker loop starts with a clean
-context. Middleware registration:
+``TaskErrorLoggingMiddleware`` emits one structured ``taskiq_task_failed``
+record for every failed execution attempt. ``PermanentAwareSmartRetryMiddleware``
+uses Taskiq's smart retry path for transient errors and lets permanent errors
+fail immediately.
+
+On ``post_execute`` the keys ``StructlogContextMiddleware`` owns are cleared so
+the next task picked up by the same worker loop starts with a clean context.
+Middleware registration:
 
 ```python
 # src/_apps/worker/app.py
-broker.add_middlewares(StructlogContextMiddleware())
+broker.add_middlewares(
+    StructlogContextMiddleware(),
+    PermanentAwareSmartRetryMiddleware(),
+    TaskErrorLoggingMiddleware(),
+)
 ```
 
 Dispatcher side, pass the correlation ID through labels:

--- a/src/_core/infrastructure/logging/taskiq_middleware.py
+++ b/src/_core/infrastructure/logging/taskiq_middleware.py
@@ -97,6 +97,9 @@ class TaskErrorLoggingMiddleware(TaskiqMiddleware):
 class PermanentAwareSmartRetryMiddleware(SmartRetryMiddleware):
     """Retry transient task errors while letting permanent errors fail."""
 
+    # ValueError and TypeError are treated as programming/configuration errors
+    # that retry cannot repair. Transient task failures should raise exceptions
+    # outside this permanent set.
     PERMANENT_ERROR_TYPES: tuple[type[BaseException], ...] = (
         BaseCustomException,
         ValueError,

--- a/src/_core/infrastructure/logging/taskiq_middleware.py
+++ b/src/_core/infrastructure/logging/taskiq_middleware.py
@@ -29,10 +29,15 @@ Background: https://github.com/orgs/taskiq-python/discussions/273
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import Any
 
 import structlog
+from pydantic import ValidationError
 from taskiq import TaskiqMessage, TaskiqMiddleware, TaskiqResult
+from taskiq.middlewares.smart_retry_middleware import SmartRetryMiddleware
+
+from src._core.exceptions.base_exception import BaseCustomException
 
 
 class StructlogContextMiddleware(TaskiqMiddleware):
@@ -56,3 +61,72 @@ class StructlogContextMiddleware(TaskiqMiddleware):
         self, message: TaskiqMessage, result: TaskiqResult[Any]
     ) -> None:
         structlog.contextvars.clear_contextvars()
+
+
+class TaskErrorLoggingMiddleware(TaskiqMiddleware):
+    """Emit one structured failure event for each failed task execution."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._logger = structlog.stdlib.get_logger("src._core.infrastructure.logging")
+
+    async def on_error(
+        self,
+        message: TaskiqMessage,
+        result: TaskiqResult[Any],
+        exception: BaseException,
+    ) -> None:
+        self._logger.error(
+            "taskiq_task_failed",
+            taskiq_task_id=message.task_id,
+            taskiq_task_name=message.task_name,
+            exception_type=type(exception).__name__,
+            exc_info=exception,
+        )
+
+
+class PermanentAwareSmartRetryMiddleware(SmartRetryMiddleware):
+    """Retry transient task errors while letting permanent errors fail."""
+
+    PERMANENT_ERROR_TYPES: tuple[type[BaseException], ...] = (
+        BaseCustomException,
+        ValueError,
+        TypeError,
+        ValidationError,
+    )
+
+    def __init__(
+        self,
+        *,
+        default_retry_count: int = 3,
+        default_retry_label: bool = True,
+        no_result_on_retry: bool = True,
+        default_delay: float = 5,
+        use_jitter: bool = True,
+        use_delay_exponent: bool = True,
+        max_delay_exponent: float = 60,
+        schedule_source: Any | None = None,
+        types_of_exceptions: Iterable[type[BaseException]] | None = None,
+    ) -> None:
+        super().__init__(
+            default_retry_count=default_retry_count,
+            default_retry_label=default_retry_label,
+            no_result_on_retry=no_result_on_retry,
+            default_delay=default_delay,
+            use_jitter=use_jitter,
+            use_delay_exponent=use_delay_exponent,
+            max_delay_exponent=max_delay_exponent,
+            schedule_source=schedule_source,
+            types_of_exceptions=types_of_exceptions,
+        )
+
+    async def on_error(
+        self,
+        message: TaskiqMessage,
+        result: TaskiqResult[Any],
+        exception: BaseException,
+    ) -> None:
+        if isinstance(exception, self.PERMANENT_ERROR_TYPES):
+            return
+
+        await super().on_error(message, result, exception)

--- a/tests/unit/_apps/worker/test_bootstrap.py
+++ b/tests/unit/_apps/worker/test_bootstrap.py
@@ -1,0 +1,33 @@
+from taskiq import InMemoryBroker, TaskiqMiddleware
+
+from src._apps.worker.bootstrap import _install_middleware
+from src._core.infrastructure.logging.taskiq_middleware import (
+    PermanentAwareSmartRetryMiddleware,
+    StructlogContextMiddleware,
+    TaskErrorLoggingMiddleware,
+)
+
+
+def _middleware_index(
+    middlewares: list[TaskiqMiddleware],
+    middleware_type: type[TaskiqMiddleware],
+) -> int:
+    return next(
+        index
+        for index, middleware in enumerate(middlewares)
+        if isinstance(middleware, middleware_type)
+    )
+
+
+def test_install_middleware_registers_taskiq_error_handling_order() -> None:
+    broker = InMemoryBroker()
+
+    _install_middleware(broker)
+
+    structlog_index = _middleware_index(broker.middlewares, StructlogContextMiddleware)
+    retry_index = _middleware_index(
+        broker.middlewares,
+        PermanentAwareSmartRetryMiddleware,
+    )
+    logging_index = _middleware_index(broker.middlewares, TaskErrorLoggingMiddleware)
+    assert structlog_index < retry_index < logging_index

--- a/tests/unit/_core/infrastructure/logging/test_taskiq_middleware.py
+++ b/tests/unit/_core/infrastructure/logging/test_taskiq_middleware.py
@@ -234,6 +234,7 @@ class TestPermanentAwareSmartRetryMiddleware:
         exception = RuntimeError("still failing")
         result = _make_result(exception)
 
+        # _retries is SmartRetryMiddleware's retry-counter label.
         await mw.on_error(
             _make_message(labels={"_retries": 2, "max_retries": 3}),
             result,

--- a/tests/unit/_core/infrastructure/logging/test_taskiq_middleware.py
+++ b/tests/unit/_core/infrastructure/logging/test_taskiq_middleware.py
@@ -2,12 +2,20 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 import structlog
-from taskiq import TaskiqMessage, TaskiqResult
+from pydantic import BaseModel, ValidationError
+from structlog.testing import capture_logs
+from taskiq import InMemoryBroker, TaskiqMessage, TaskiqResult
+from taskiq.exceptions import NoResultError
 
+from src._core.exceptions.base_exception import BaseCustomException
 from src._core.infrastructure.logging.taskiq_middleware import (
+    PermanentAwareSmartRetryMiddleware,
     StructlogContextMiddleware,
+    TaskErrorLoggingMiddleware,
 )
 
 
@@ -21,7 +29,7 @@ def _make_message(
     *,
     task_id: str = "t_1",
     task_name: str = "sample_task",
-    labels: dict[str, str] | None = None,
+    labels: dict[str, Any] | None = None,
 ) -> TaskiqMessage:
     return TaskiqMessage(
         task_id=task_id,
@@ -31,6 +39,40 @@ def _make_message(
         args=[],
         kwargs={},
     )
+
+
+def _make_result(error: BaseException | None = None) -> TaskiqResult[Any]:
+    return TaskiqResult(
+        is_err=error is not None,
+        return_value=None,
+        execution_time=0.0,
+        labels={},
+        error=error,
+        log=None,
+    )
+
+
+def _make_validation_error() -> ValidationError:
+    class ProbeModel(BaseModel):
+        count: int
+
+    with pytest.raises(ValidationError) as exc_info:
+        ProbeModel.model_validate({"count": "not-an-int"})
+    return exc_info.value
+
+
+class RecordingRetryMiddleware(PermanentAwareSmartRetryMiddleware):
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.sent: list[tuple[TaskiqMessage, float]] = []
+
+    async def on_send(
+        self,
+        kicker: Any,
+        message: TaskiqMessage,
+        delay: float,
+    ) -> None:
+        self.sent.append((message, delay))
 
 
 class TestStructlogContextMiddleware:
@@ -89,3 +131,114 @@ class TestStructlogContextMiddleware:
         )
 
         assert structlog.contextvars.get_contextvars() == {}
+
+
+class TestTaskErrorLoggingMiddleware:
+    @pytest.mark.asyncio
+    async def test_on_error_emits_structured_failure_event(self):
+        mw = TaskErrorLoggingMiddleware()
+        message = _make_message(task_id="task-123", task_name="docs.ingest")
+        exception = RuntimeError("boom")
+        result = _make_result(exception)
+
+        structlog.contextvars.bind_contextvars(correlation_id="corr-123")
+
+        with capture_logs(processors=[structlog.contextvars.merge_contextvars]) as logs:
+            await mw.on_error(message, result, exception)
+
+        assert len(logs) == 1
+        event = logs[0]
+        assert event["event"] == "taskiq_task_failed"
+        assert event["taskiq_task_id"] == "task-123"
+        assert event["taskiq_task_name"] == "docs.ingest"
+        assert event["correlation_id"] == "corr-123"
+        assert event["exc_info"] is exception
+        assert event["exception_type"] == "RuntimeError"
+        assert "args" not in event
+        assert "kwargs" not in event
+        assert "labels" not in event
+        assert "payload" not in event
+
+
+class TestPermanentAwareSmartRetryMiddleware:
+    @pytest.mark.asyncio
+    async def test_transient_exception_schedules_retry_and_suppresses_result(self):
+        mw = RecordingRetryMiddleware()
+        mw.set_broker(InMemoryBroker())
+        exception = RuntimeError("temporary outage")
+        result = _make_result(exception)
+
+        await mw.on_error(_make_message(), result, exception)
+
+        assert len(mw.sent) == 1
+        assert isinstance(result.error, NoResultError)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "exception",
+        [
+            BaseCustomException(message="domain error"),
+            ValueError("bad value"),
+            TypeError("bad type"),
+            _make_validation_error(),
+        ],
+    )
+    async def test_permanent_exception_does_not_schedule_retry(
+        self, exception: BaseException
+    ):
+        mw = RecordingRetryMiddleware()
+        mw.set_broker(InMemoryBroker())
+        result = _make_result(exception)
+
+        await mw.on_error(_make_message(), result, exception)
+
+        assert mw.sent == []
+        assert result.error is exception
+
+    @pytest.mark.asyncio
+    async def test_retry_on_error_false_disables_retry(self):
+        mw = RecordingRetryMiddleware()
+        mw.set_broker(InMemoryBroker())
+        exception = RuntimeError("do not retry")
+        result = _make_result(exception)
+
+        await mw.on_error(
+            _make_message(labels={"retry_on_error": False}),
+            result,
+            exception,
+        )
+
+        assert mw.sent == []
+        assert result.error is exception
+
+    @pytest.mark.asyncio
+    async def test_max_retries_label_overrides_default_retry_count(self):
+        mw = RecordingRetryMiddleware(default_retry_count=1)
+        mw.set_broker(InMemoryBroker())
+        exception = RuntimeError("temporary outage")
+        result = _make_result(exception)
+
+        await mw.on_error(
+            _make_message(labels={"max_retries": 3}),
+            result,
+            exception,
+        )
+
+        assert len(mw.sent) == 1
+        assert isinstance(result.error, NoResultError)
+
+    @pytest.mark.asyncio
+    async def test_retries_threshold_stops_scheduling(self):
+        mw = RecordingRetryMiddleware()
+        mw.set_broker(InMemoryBroker())
+        exception = RuntimeError("still failing")
+        result = _make_result(exception)
+
+        await mw.on_error(
+            _make_message(labels={"_retries": 2, "max_retries": 3}),
+            result,
+            exception,
+        )
+
+        assert mw.sent == []
+        assert result.error is exception


### PR DESCRIPTION
## Related Issue
- Fixes #120

## Change Summary
- Added Taskiq worker failure logging middleware that emits one structured `taskiq_task_failed` event per failed execution attempt.
- Added permanent-aware SmartRetry middleware defaults for transient retries with jitter/backoff and permanent-error exclusions.
- Wired worker bootstrap middleware order so context binding happens before task execution and failure logging runs before retry handling.
- Added focused unit coverage for log shape, retry behavior, permanent skip behavior, per-task overrides, and bootstrap registration order.

## Type of Change
- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] refactor: Code restructuring
- [ ] docs: Documentation
- [ ] chore: Build/tooling
- [x] test: Tests
- [ ] ci: CI/CD
- [ ] perf: Performance
- [ ] style: Code style

## Checklist
- [x] Architecture rules followed (no Domain -> Infrastructure imports)
- [x] Tests pass
- [x] Linting passes (`ruff check src/`)

## How to Test
- `uv run pytest tests/unit/_core/infrastructure/logging/test_taskiq_middleware.py tests/unit/_apps/worker/test_bootstrap.py`
- `uv run ruff check src/`
- `make test`

## Cross Review
- Local completion-gate review: Findings none, Drift Candidates none, Sync Required false.
- Claude cross-review follow-up: open findings none, Final Verdict `APPROVE`, Sync Required `No`.
- Deferred with rationale: `.claude/rules/project-status.md` can receive a #120 status row in a separate `/sync-guidelines` pass because editing it would turn this feature PR into a governor-path change.
