### PR TITLE
feat(#10): add CRUD data validation

### DIFF
--- a/.claude/rules/architecture-conventions.md
+++ b/.claude/rules/architecture-conventions.md
@@ -1,6 +1,6 @@
 # Architecture Conventions
 
-> Last synced: 2026-04-27 via /sync-guidelines (translated Structured Logging section to English under Tier 1 Language Policy, #131)
+> Last synced: 2026-04-30 via /sync-guidelines (#10 CRUD write validation hooks and repository validation primitives)
 > For Absolute Prohibitions, Conversion Patterns, Write DTO criteria, Responsibility Matrix, Error Translation, Optional AI Infra Pattern, Admin Service Contract, and **Default Coding Flow** (process layer, ADR 045), refer to AGENTS.md.
 > This file only contains **structural context** that supplements AGENTS.md for Claude.
 
@@ -40,12 +40,13 @@ Key differences from RDB/DynamoDB:
 
 ## BaseService Generic Structure
 - `BaseService(Generic[CreateDTO, UpdateDTO, ReturnDTO])` — 3 TypeVars (ADR 011 update, 2026-04-09)
-- `BaseRepositoryProtocol(Generic[ReturnDTO])` / `BaseRepository(Generic[ReturnDTO])` — 1 TypeVar (Repository only calls model_dump, no field-specific access)
+- `BaseRepositoryProtocol(Protocol, Generic[ReturnDTO])` / `BaseRepository(Generic[ReturnDTO])` — 1 TypeVar plus read primitives for Service-owned validation
 - `BaseDynamoService(Generic[CreateDTO, UpdateDTO, ReturnDTO])` — mirrors BaseService
 - `BaseDynamoRepositoryProtocol(Generic[ReturnDTO])` / `BaseDynamoRepository(Generic[ReturnDTO])` — mirrors BaseRepository
 - `BaseVectorStoreProtocol(Generic[ReturnDTO])` / `BaseS3VectorStore(Generic[ReturnDTO])` — vector store pattern
 - Domain Service example: `UserService(BaseService[CreateUserRequest, UpdateUserRequest, UserDTO])`
 - DO NOT simplify back to 1 TypeVar — this was tried and reverted (see ADR 011 Post-decision Update)
+- Service-owned CRUD write validation hooks are canonical in `AGENTS.md` § CRUD Write Validation; keep rule details there.
 
 ## Broker Selection
 - providers.Selector in CoreContainer: SQS/RabbitMQ/InMemory by BROKER_TYPE env var

--- a/.claude/rules/commands.md
+++ b/.claude/rules/commands.md
@@ -1,6 +1,6 @@
 # Suggested Commands
 
-> Last synced: 2026-04-27 via /sync-guidelines (translated Korean prose to English under Tier 1 Language Policy, #131; no command surface changes)
+> Last synced: 2026-04-30 via /sync-guidelines (#10 reviewed; no command surface changes)
 > Purpose: Quick reference for Claude Code when executing shell commands.
 > Also referenced when running Skills.
 > Default Flow context: see [`AGENTS.md` § Default Coding Flow](../../AGENTS.md#default-coding-flow). The commands below are consulted by the `implement` and `verify` steps; this file is **not** a primary entry point in the Default Flow.

--- a/.claude/rules/project-overview.md
+++ b/.claude/rules/project-overview.md
@@ -1,6 +1,6 @@
 # Project Overview
 
-> Last synced: 2026-04-27 via /sync-guidelines (translated extras and logging notes to English under Tier 1 Language Policy, #131)
+> Last synced: 2026-04-30 via /sync-guidelines (#10 reviewed; no project-overview surface changes)
 > For tech stack, refer to project-dna.md §8; for layer structure, refer to §1.
 > For the Optional infra toggle surface (env var → disabled behavior per infra), see AGENTS.md "Optional Infrastructure" + [ADR 042](../../docs/history/042-optional-infrastructure-di-pattern.md).
 > This file only contains **project-level context** not covered in project-dna.md.

--- a/.claude/rules/project-status.md
+++ b/.claude/rules/project-status.md
@@ -1,6 +1,6 @@
 # Project Status
 
-> Last synced: 2026-04-29 via /sync-guidelines cross-review pass
+> Last synced: 2026-04-30 via /sync-guidelines (#10 CRUD data validation sync)
 
 ## Current Version Context
 - Latest release: v0.4.0 (2026-04-21)
@@ -17,6 +17,7 @@
 | DynamoDB Support | #13 | BaseDynamoRepository, DynamoModel, DynamoDBClient |
 | Broker Abstraction | #8 | providers.Selector for SQS/RabbitMQ/InMemory |
 | BaseService 3-TypeVar | ADR 011 | Generic[CreateDTO, UpdateDTO, ReturnDTO] restoration |
+| CRUD Write Validation | #10 | BaseService pre-write validation hooks, `_core/domain/validation.py` helpers, repository existence primitives, and User username/email uniqueness constraints |
 | Password Hashing | - | hash_password/verify_password in _core.common.security |
 | Serena Removal & Pyright Adoption | #63 | pyright-lsp as the default code-intelligence layer, PostToolUse formatting hook, transition to tool-agnostic skills |
 | Codex CLI Harness & Hybrid C Skills | #66 | Shared AGENTS.md, docs/ai/shared/ reference layer, 14 Hybrid C skill migrations |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -388,6 +388,20 @@ Logging is always-on (unlike Optional Infrastructure) and shared across server +
 - When fields differ (auth context injection, derived fields, etc.): create a separate DTO in `domain/dtos/`
   - Example: `CreateUserDTO(**item.model_dump(), created_by=current_user.id)`
 
+## CRUD Write Validation
+
+RDB CRUD writes use Service-owned validation hooks, not Router checks, Repository business rules, or a central validation registry.
+
+- `BaseService` calls protected async hooks before all write paths:
+  - `_validate_create(entity)`
+  - `_validate_create_many(entities)`
+  - `_validate_update(data_id, entity)`
+  - `_validate_delete(data_id)`
+- Default hooks are no-ops. Domain Services override only the hooks that have explicit business rules.
+- Reusable helpers live in `_core/domain/validation.py`; domain-specific composition belongs in `{domain}/domain/validators.py` when the rules are non-trivial.
+- Repository read primitives used by validation belong on `BaseRepositoryProtocol` / `BaseRepository`: `exists_by_id`, `exists_by_fields`, and `existing_values_by_field`.
+- Database constraints remain the final integrity guard, but user-facing field validation should run in the Service layer first.
+
 ## Security Principles
 
 - Do not expose internal details (traceback, DB schema, raw query) in production error responses

--- a/docs/ai/shared/governor-review-log/README.md
+++ b/docs/ai/shared/governor-review-log/README.md
@@ -131,3 +131,4 @@ specialisations in
 | #147 | Cross-tool prompt template standardisation for review skills | #144 | [pr-147-cross-tool-prompt-standardisation.md](pr-147-cross-tool-prompt-standardisation.md) |
 | #148 | G closure linter for governor review-log entries | #145 | [pr-148-g-closure-linter.md](pr-148-g-closure-linter.md) |
 | #151 | Architecture review follow-up | — | [pr-151-architecture-review-followup.md](pr-151-architecture-review-followup.md) |
+| #152 | CRUD Data Validation Sync | #10 | [pr-152-crud-data-validation-sync.md](pr-152-crud-data-validation-sync.md) |

--- a/docs/ai/shared/governor-review-log/pr-152-crud-data-validation-sync.md
+++ b/docs/ai/shared/governor-review-log/pr-152-crud-data-validation-sync.md
@@ -1,0 +1,87 @@
+# PR #152 — CRUD Data Validation Sync
+
+## Summary
+
+PR #152 ([GitHub PR](https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/152)) implements issue #10 CRUD data validation for RDB writes. The code change added Service-owned validation hooks, reusable core validation helpers, repository read primitives for validation, User username/email uniqueness enforcement, DB unique constraints, and targeted tests. The follow-up `/sync-guidelines` pass updates shared references so future agents see the new BaseService and BaseRepositoryProtocol surfaces.
+
+## Review Rounds
+
+### Round 1 — Implementation Review Drift Signal
+
+- **Target:** issue #10 implementation diff before shared-doc sync.
+- **Prompt focus:** architecture/security correctness, User uniqueness semantics, DB conflict translation, and whether shared docs drifted.
+- **Surfaced points:**
+  - **R1.1:** `docs/ai/shared/project-dna.md` still described the old `BaseRepositoryProtocol` and `BaseService` method surface.
+  - **R1.2:** `docs/ai/shared/scaffolding-layers.md` still showed the old repository protocol skeleton and did not mention Service validation hooks.
+  - **R1.3:** Skill guidance might over-expand if endpoint skills were updated for Service-internal validation.
+- **Final Verdict:** implementation can proceed, but Sync Required is true.
+
+### Round 2 — Claude `/sync-guidelines` Scope Challenge
+
+- **Reviewer:** Claude Opus, xhigh effort, no-tools summary review after read-tool mode was unavailable.
+- **Target:** proposed `/sync-guidelines` closure plan for PR #152.
+- **Prompt focus:** challenge whether the sync scope was too broad and whether governor artefacts were required.
+- **Surfaced points:**
+  - **R2.1:** Verify `project-dna.md` before editing; do not assume drift.
+  - **R2.2:** `scaffolding-layers.md` is the highest-confidence drift because future domains copy it.
+  - **R2.3:** Reject broad `add-api` wrapper edits; validation hooks are Service lifecycle, not endpoint authoring.
+  - **R2.4:** Avoid duplicating rule details in `.claude/rules/architecture-conventions.md`; keep rule details canonical.
+  - **R2.5:** Add the upstream AGENTS.md hook section if validation hooks are a shared rule.
+  - **R2.6:** Check whether ADR 043 needs a protocol addendum.
+  - **R2.7:** If any Tier A file lands, add governor-review-log and PR Governor section.
+- **Final Verdict:** sync required, but keep scope narrow.
+
+### Round 3 — Claude Gate-on-Gate Review
+
+- **Reviewer:** Claude Opus, xhigh effort, no-tools summary review after the sync patch.
+- **Target:** applied `/sync-guidelines` result for PR #152.
+- **Prompt focus:** missed drift, overreach, governor artefacts, and whether Sync Required remains true.
+- **Surfaced points:**
+  - **R3.1:** Requiring a new ADR for the validation hook pattern would be overreach while the hooks are additive and no-op by default.
+  - **R3.2:** Leaving `add-api` and wrappers unchanged is correct because endpoint authoring should not duplicate Service lifecycle guidance.
+  - **R3.3:** Generic validation-hook test pattern documentation can wait until a second domain adopts hook overrides.
+- **Final Verdict:** approved; Sync Required is false after this pass.
+
+## Inherited Constraints
+
+- AGENTS.md § Language Policy: all new Tier 1 prose is English-only; no hidden Korean rationale.
+- AGENTS.md § Default Coding Flow: Tier A/B/C changes require cross-tool review and a governor-review-log entry.
+- AGENTS.md guard G: every cross-review point must close as `Fixed`, `Deferred-with-rationale`, or `Rejected`.
+- `docs/ai/shared/governor-paths.md`: `docs/ai/shared/**`, `AGENTS.md`, and `.claude/**` make this PR governor-changing.
+
+## Self-Application Proof
+
+### `/review-pr` Equivalent
+
+- **Findings:** no blocking code/security finding remained after update unique conflict translation was added.
+- **Drift Candidates:** `project-dna.md`, `scaffolding-layers.md`, Service validation guidance, and governor artefacts.
+- **Sync Required:** true.
+
+### `/sync-guidelines` Equivalent
+
+- **Mode:** review follow-up.
+- **Input Drift Candidates:** consumed from `/review-pr` and Claude Round 2.
+- **project-dna:** updated for `Protocol`, repository validation primitives, and BaseService validation hooks.
+- **AUTO-FIX:** AGENTS.md CRUD write validation rule, `project-dna.md`, `scaffolding-layers.md`, Claude rule sync (`architecture-conventions.md`, `project-status.md`, reviewed timestamps for overview/commands), governor-review-log entry, README index.
+- **REVIEW:** generic validation-hook test-pattern documentation is deferred until another domain adopts hook overrides.
+- **Remaining:** none for current shared guideline drift after verification.
+- **Next Actions:** keep PR #152 Governor-Changing PR section filled and re-run pre-commit.
+
+## R-points Closure Table
+
+| Source | R-point | Closure | Note |
+|---|---|---|---|
+| Round 1 | R1.1: `project-dna.md` stale BaseRepositoryProtocol/BaseService surface | Fixed | Verified live stale method tables and updated them. |
+| Round 1 | R1.2: `scaffolding-layers.md` stale protocol skeleton and missing validation hook guidance | Fixed | Updated repository protocol example and Service validation hook guidance. |
+| Round 1 | R1.3: endpoint skill guidance could over-expand | Rejected | `add-api` stayed unchanged because validation hooks are Service lifecycle, not endpoint authoring. |
+| Round 2 | R2.1: verify `project-dna.md` before editing | Fixed | Verified stale `Generic` example and missing primitive rows before patching. |
+| Round 2 | R2.2: update `scaffolding-layers.md` narrowly | Fixed | Applied targeted scaffold guidance only. |
+| Round 2 | R2.3: reject broad `add-api` wrapper edits | Rejected | No `add-api` shared or wrapper files were changed. |
+| Round 2 | R2.4: avoid duplicating validation rule details in Claude rules | Fixed | `.claude/rules/architecture-conventions.md` now contains only a one-line pointer to AGENTS.md. |
+| Round 2 | R2.5: add upstream AGENTS.md hook section | Fixed | Added AGENTS.md § CRUD Write Validation. |
+| Round 2 | R2.6: evaluate ADR 043 addendum | Rejected | ADR 043 is about provider/AI responsibility refactor, not RDB base repository protocols. |
+| Round 2 | R2.7: governor artefacts required after Tier A edits | Fixed | Added this entry and README index row; PR body must keep the Governor section filled. |
+| Claude wrapper | C1: update Claude rule post-step surfaces | Fixed | Updated architecture conventions, project status, and reviewed rule timestamps without duplicating AGENTS.md details. |
+| Round 3 | R3.1: require a new ADR for validation hooks | Rejected | Additive no-op hooks and AGENTS.md canonical guidance are sufficient for the first domain adoption. |
+| Round 3 | R3.2: update `add-api` and wrappers | Rejected | Endpoint authoring should not duplicate Service lifecycle guidance. |
+| Round 3 | R3.3: document generic validation-hook test patterns now | Deferred-with-rationale | Defer until a second domain adopts hook overrides and the reusable test pattern is clearer. |

--- a/docs/ai/shared/project-dna.md
+++ b/docs/ai/shared/project-dna.md
@@ -112,6 +112,8 @@ src/{name}/
 |---------|------------|
 | BaseRepositoryProtocol | `src._core.domain.protocols.repository_protocol.BaseRepositoryProtocol` |
 | BaseService | `src._core.domain.services.base_service.BaseService` |
+| ValidationErrorDetail | `src._core.domain.validation.ValidationErrorDetail` |
+| ValidationFailed | `src._core.domain.validation.ValidationFailed` |
 | BaseRepository | `src._core.infrastructure.persistence.rdb.base_repository.BaseRepository` |
 | Base (ORM DeclarativeBase) | `src._core.infrastructure.persistence.rdb.database.Base` |
 | Database | `src._core.infrastructure.persistence.rdb.database.Database` |
@@ -171,14 +173,14 @@ src/{name}/
 
 ```python
 # BaseRepositoryProtocol / BaseRepository — 1 TypeVar (ReturnDTO only)
-# Repository only calls entity.model_dump(), no field-specific access needed
+# Repository write inputs stay BaseModel; read primitives support Service-owned validation.
 ReturnDTO = TypeVar("ReturnDTO", bound=BaseModel)
 
-class BaseRepositoryProtocol(Generic[ReturnDTO]): ...
+class BaseRepositoryProtocol(Protocol, Generic[ReturnDTO]): ...
 class BaseRepository(Generic[ReturnDTO], ABC): ...
 
 # BaseService — 3 TypeVars (CreateDTO, UpdateDTO, ReturnDTO)
-# Service overrides access specific fields (e.g., entity.password), so typed inputs are required
+# Service overrides access specific fields and validation hooks, so typed inputs are required
 # Background: ADR 011 Post-decision Update (2026-04-09)
 CreateDTO = TypeVar("CreateDTO", bound=BaseModel)
 UpdateDTO = TypeVar("UpdateDTO", bound=BaseModel)
@@ -190,7 +192,7 @@ ReturnType = TypeVar("ReturnType")
 class SuccessResponse(ApiConfig, Generic[ReturnType]): ...
 
 # Reference domain (user) usage example:
-class UserRepositoryProtocol(BaseRepositoryProtocol[UserDTO]): pass
+class UserRepositoryProtocol(BaseRepositoryProtocol[UserDTO], Protocol): pass
 class UserRepository(BaseRepository[UserDTO]): ...
 class UserService(BaseService[CreateUserRequest, UpdateUserRequest, UserDTO]): ...
 ```
@@ -260,6 +262,9 @@ def __init__(
 | select_datas | `async (page: int, page_size: int) -> list[ReturnDTO]` |
 | select_data_by_id | `async (data_id: int) -> ReturnDTO` |
 | select_datas_by_ids | `async (data_ids: list[int]) -> list[ReturnDTO]` |
+| exists_by_id | `async (data_id: int) -> bool` |
+| exists_by_fields | `async (filters: Mapping[str, Any], *, exclude_id: int \| None = None) -> bool` |
+| existing_values_by_field | `async (field: str, values: list[Any], *, exclude_id: int \| None = None) -> set[Any]` |
 | select_datas_with_count | `async (page: int, page_size: int, query_filter: QueryFilter \| None = None) -> tuple[list[ReturnDTO], int]` |
 | update_data_by_data_id | `async (data_id: int, entity: BaseModel) -> ReturnDTO` |
 | delete_data_by_data_id | `async (data_id: int) -> bool` |
@@ -272,14 +277,31 @@ def __init__(
 
 | BaseService Method | Signature | Repository Call |
 |-------------------|-----------|----------------|
-| create_data | `(entity: CreateDTO) -> ReturnDTO` | insert_data(entity=entity) |
-| create_datas | `(entities: list[CreateDTO]) -> list[ReturnDTO]` | insert_datas(entities=entities) |
+| create_data | `(entity: CreateDTO) -> ReturnDTO` | `_validate_create(entity)` then `insert_data(entity=entity)` |
+| create_datas | `(entities: list[CreateDTO]) -> list[ReturnDTO]` | `_validate_create_many(entities)` then `insert_datas(entities=entities)` |
 | get_datas | `(page, page_size, query_filter) -> (list[ReturnDTO], PaginationInfo)` | select_datas_with_count(...) |
 | get_data_by_data_id | `(data_id: int) -> ReturnDTO` | select_data_by_id(data_id=data_id) |
 | get_datas_by_data_ids | `(data_ids: list[int]) -> list[ReturnDTO]` | select_datas_by_ids(data_ids=data_ids) |
-| update_data_by_data_id | `(data_id: int, entity: UpdateDTO) -> ReturnDTO` | update_data_by_data_id(data_id, entity) |
-| delete_data_by_data_id | `(data_id: int) -> bool` | delete_data_by_data_id(data_id=data_id) |
+| update_data_by_data_id | `(data_id: int, entity: UpdateDTO) -> ReturnDTO` | `_validate_update(data_id, entity)` then `update_data_by_data_id(data_id, entity)` |
+| delete_data_by_data_id | `(data_id: int) -> bool` | `_validate_delete(data_id)` then `delete_data_by_data_id(data_id=data_id)` |
 | count_datas | `() -> int` | count_datas() |
+
+### BaseService Validation Hooks
+
+`BaseService` owns pre-write validation. Hooks are protected async methods with
+no-op defaults; domain Services override only the hooks that have explicit
+business rules.
+
+| Hook | Signature | Default |
+|------|-----------|---------|
+| _validate_create | `async (entity: CreateDTO) -> None` | no-op |
+| _validate_create_many | `async (entities: list[CreateDTO]) -> None` | no-op |
+| _validate_update | `async (data_id: int, entity: UpdateDTO) -> None` | no-op |
+| _validate_delete | `async (data_id: int) -> None` | no-op |
+
+Reusable validation helpers live in `_core/domain/validation.py`. Domain-specific
+composition belongs in `{domain}/domain/validators.py` when the rule set is
+non-trivial.
 
 ### BaseDynamoRepositoryProtocol Methods
 

--- a/docs/ai/shared/scaffolding-layers.md
+++ b/docs/ai/shared/scaffolding-layers.md
@@ -10,6 +10,7 @@
 
 ## Reference
 - Follow `src/user/` exactly. Read the corresponding user file before creating each file and replicate the pattern.
+- `src/user/domain/validators.py` is a validation reference, not a default scaffold file; add `{name}/domain/validators.py` only when explicit Service-layer write rules exist.
 - For **Base class import paths, Generic signatures, DI patterns**,
   refer to `docs/ai/shared/project-dna.md`.
 
@@ -39,15 +40,18 @@ src/{name}/
    - `class {Name}DTO(BaseModel)` — id, user-defined fields, created_at, updated_at
    - Use `Field(..., description="...")` for all fields
 2. `src/{name}/domain/protocols/{name}_repository_protocol.py`
+   - `from typing import Protocol`
    - `from src._core.domain.protocols.repository_protocol import BaseRepositoryProtocol`
    - Generic: `BaseRepositoryProtocol[{Name}DTO]` (see project-dna.md section 3)
-   - `class {Name}RepositoryProtocol(BaseRepositoryProtocol[{Name}DTO]): pass`
+   - `class {Name}RepositoryProtocol(BaseRepositoryProtocol[{Name}DTO], Protocol): pass`
 3. `src/{name}/domain/services/{name}_service.py`
    - `from src._core.domain.services.base_service import BaseService`
    - `class {Name}Service(BaseService[Create{Name}Request, Update{Name}Request, {Name}DTO])`
    - BaseService uses 3 TypeVars: `Generic[CreateDTO, UpdateDTO, ReturnDTO]` (background: ADR 011 update)
    - CRUD methods (create_data, get_datas, get_data_by_data_id, etc.) are inherited from BaseService
-   - Override methods only when custom business logic is needed
+   - Override CRUD methods only when custom business logic changes the write/read payload flow
+   - Override protected validation hooks (`_validate_create`, `_validate_create_many`, `_validate_update`, `_validate_delete`) only when explicit write validation rules exist
+   - For non-trivial validation rules, place domain composition in `src/{name}/domain/validators.py` and reuse `_core/domain/validation.py` helpers
    - Import Request types from `src/{name}/interface/server/schemas/{name}_schema.py`
 4. `src/{name}/domain/exceptions/{name}_exceptions.py`
    - `from src._core.exceptions.base_exception import BaseCustomException`

--- a/examples/todo/domain/protocols/todo_repository_protocol.py
+++ b/examples/todo/domain/protocols/todo_repository_protocol.py
@@ -1,6 +1,8 @@
+from typing import Protocol
+
 from examples.todo.domain.dtos.todo_dto import TodoDTO
 from src._core.domain.protocols.repository_protocol import BaseRepositoryProtocol
 
 
-class TodoRepositoryProtocol(BaseRepositoryProtocol[TodoDTO]):
+class TodoRepositoryProtocol(BaseRepositoryProtocol[TodoDTO], Protocol):
     pass

--- a/migrations/versions/0003_add_user_unique_constraints.py
+++ b/migrations/versions/0003_add_user_unique_constraints.py
@@ -1,0 +1,29 @@
+"""user: add unique username and email constraints
+
+Revision ID: 0003_user_unique_constraints
+Revises: 0002_ai_usage_log
+Create Date: 2026-04-30
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0003_user_unique_constraints"
+down_revision: Union[str, None] = "0002_ai_usage_log"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("user") as batch_op:
+        batch_op.create_unique_constraint("uq_user_username", ["username"])
+        batch_op.create_unique_constraint("uq_user_email", ["email"])
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("user") as batch_op:
+        batch_op.drop_constraint("uq_user_email", type_="unique")
+        batch_op.drop_constraint("uq_user_username", type_="unique")

--- a/src/_core/domain/protocols/repository_protocol.py
+++ b/src/_core/domain/protocols/repository_protocol.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Generic, TypeVar
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar
 
 from pydantic import BaseModel
 
@@ -10,7 +11,7 @@ if TYPE_CHECKING:
 ReturnDTO = TypeVar("ReturnDTO", bound=BaseModel)
 
 
-class BaseRepositoryProtocol(Generic[ReturnDTO]):
+class BaseRepositoryProtocol(Protocol, Generic[ReturnDTO]):
     async def insert_data(self, entity: BaseModel) -> ReturnDTO: ...
 
     async def insert_datas(self, entities: list[BaseModel]) -> list[ReturnDTO]: ...
@@ -20,6 +21,23 @@ class BaseRepositoryProtocol(Generic[ReturnDTO]):
     async def select_data_by_id(self, data_id: int) -> ReturnDTO: ...
 
     async def select_datas_by_ids(self, data_ids: list[int]) -> list[ReturnDTO]: ...
+
+    async def exists_by_id(self, data_id: int) -> bool: ...
+
+    async def exists_by_fields(
+        self,
+        filters: Mapping[str, Any],
+        *,
+        exclude_id: int | None = None,
+    ) -> bool: ...
+
+    async def existing_values_by_field(
+        self,
+        field: str,
+        values: list[Any],
+        *,
+        exclude_id: int | None = None,
+    ) -> set[Any]: ...
 
     async def select_datas_with_count(
         self,

--- a/src/_core/domain/services/base_service.py
+++ b/src/_core/domain/services/base_service.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Generic, TypeVar
+from typing import TYPE_CHECKING, Generic, TypeVar, cast
 
 from pydantic import BaseModel
 
@@ -21,10 +21,14 @@ class BaseService(Generic[CreateDTO, UpdateDTO, ReturnDTO]):
         self.repository = repository
 
     async def create_data(self, entity: CreateDTO) -> ReturnDTO:
+        await self._validate_create(entity)
         return await self.repository.insert_data(entity=entity)
 
     async def create_datas(self, entities: list[CreateDTO]) -> list[ReturnDTO]:
-        return await self.repository.insert_datas(entities=entities)
+        await self._validate_create_many(entities)
+        return await self.repository.insert_datas(
+            entities=cast(list[BaseModel], entities)
+        )
 
     async def get_datas(
         self,
@@ -51,12 +55,26 @@ class BaseService(Generic[CreateDTO, UpdateDTO, ReturnDTO]):
     async def update_data_by_data_id(
         self, data_id: int, entity: UpdateDTO
     ) -> ReturnDTO:
+        await self._validate_update(data_id, entity)
         return await self.repository.update_data_by_data_id(
             data_id=data_id, entity=entity
         )
 
     async def delete_data_by_data_id(self, data_id: int) -> bool:
+        await self._validate_delete(data_id)
         return await self.repository.delete_data_by_data_id(data_id=data_id)
 
     async def count_datas(self) -> int:
         return await self.repository.count_datas()
+
+    async def _validate_create(self, entity: CreateDTO) -> None:
+        return None
+
+    async def _validate_create_many(self, entities: list[CreateDTO]) -> None:
+        return None
+
+    async def _validate_update(self, data_id: int, entity: UpdateDTO) -> None:
+        return None
+
+    async def _validate_delete(self, data_id: int) -> None:
+        return None

--- a/src/_core/domain/validation.py
+++ b/src/_core/domain/validation.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from pydantic import BaseModel
+
+from src._core.domain.protocols.repository_protocol import BaseRepositoryProtocol
+from src._core.exceptions.base_exception import BaseCustomException
+
+BUSINESS_VALIDATION_ERROR = "BUSINESS_VALIDATION_ERROR"
+BUSINESS_CONFLICT = "BUSINESS_CONFLICT"
+
+
+class ValidationErrorDetail(BaseModel):
+    field: str
+    message: str
+    type: str
+
+
+class ValidationFailed(BaseCustomException):
+    def __init__(
+        self,
+        errors: Sequence[ValidationErrorDetail | Mapping[str, Any]],
+        *,
+        status_code: int = 422,
+        message: str = "Validation failed",
+        error_code: str | None = None,
+    ) -> None:
+        normalized_errors = [_coerce_error(error) for error in errors]
+        resolved_error_code = error_code or (
+            BUSINESS_CONFLICT if status_code == 409 else BUSINESS_VALIDATION_ERROR
+        )
+        super().__init__(
+            status_code=status_code,
+            message=message,
+            error_code=resolved_error_code,
+            details={"errors": [error.model_dump() for error in normalized_errors]},
+        )
+        self.errors = tuple(normalized_errors)
+
+
+def validation_error(
+    field: str,
+    message: str,
+    error_type: str,
+) -> ValidationErrorDetail:
+    return ValidationErrorDetail(field=field, message=message, type=error_type)
+
+
+def raise_if_errors(
+    errors: Sequence[ValidationErrorDetail],
+    *,
+    status_code: int = 422,
+    message: str = "Validation failed",
+    error_code: str | None = None,
+) -> None:
+    if errors:
+        raise ValidationFailed(
+            errors,
+            status_code=status_code,
+            message=message,
+            error_code=error_code,
+        )
+
+
+def collect_conditionally_required_errors(
+    entity: BaseModel,
+    fields: Sequence[str],
+    *,
+    condition: bool,
+    message: str = "Field is required",
+) -> list[ValidationErrorDetail]:
+    if not condition:
+        return []
+    data = entity.model_dump()
+    return [
+        validation_error(field, message, "conditional_required")
+        for field in fields
+        if data.get(field) is None
+    ]
+
+
+def ensure_conditionally_required(
+    entity: BaseModel,
+    fields: Sequence[str],
+    *,
+    condition: bool,
+    message: str = "Field is required",
+) -> None:
+    raise_if_errors(
+        collect_conditionally_required_errors(
+            entity,
+            fields,
+            condition=condition,
+            message=message,
+        )
+    )
+
+
+def collect_duplicate_field_errors(
+    entities: Sequence[BaseModel],
+    fields: Sequence[str],
+) -> list[ValidationErrorDetail]:
+    errors: list[ValidationErrorDetail] = []
+    for field in fields:
+        seen: set[Any] = set()
+        duplicate_found = False
+        for entity in entities:
+            value = entity.model_dump().get(field)
+            if value is None:
+                continue
+            if value in seen:
+                duplicate_found = True
+                break
+            seen.add(value)
+        if duplicate_found:
+            errors.append(
+                validation_error(
+                    field,
+                    f"Duplicate {field} in request payload",
+                    "duplicate",
+                )
+            )
+    return errors
+
+
+def ensure_no_duplicate_field_values(
+    entities: Sequence[BaseModel],
+    fields: Sequence[str],
+) -> None:
+    raise_if_errors(collect_duplicate_field_errors(entities, fields))
+
+
+async def collect_unique_field_errors(
+    repository: BaseRepositoryProtocol[Any],
+    entity: BaseModel,
+    fields: Sequence[str],
+    *,
+    exclude_id: int | None = None,
+    message_template: str = "{field} already exists",
+) -> list[ValidationErrorDetail]:
+    errors: list[ValidationErrorDetail] = []
+    data = entity.model_dump()
+    for field in fields:
+        value = data.get(field)
+        if value is None:
+            continue
+        if await repository.exists_by_fields({field: value}, exclude_id=exclude_id):
+            errors.append(
+                validation_error(
+                    field,
+                    message_template.format(field=field),
+                    "unique",
+                )
+            )
+    return errors
+
+
+async def ensure_unique_field_values(
+    repository: BaseRepositoryProtocol[Any],
+    entity: BaseModel,
+    fields: Sequence[str],
+    *,
+    exclude_id: int | None = None,
+    message: str = "Validation failed",
+    error_code: str | None = None,
+) -> None:
+    errors = await collect_unique_field_errors(
+        repository,
+        entity,
+        fields,
+        exclude_id=exclude_id,
+    )
+    raise_if_errors(
+        errors,
+        status_code=409,
+        message=message,
+        error_code=error_code,
+    )
+
+
+async def collect_existing_unique_field_errors(
+    repository: BaseRepositoryProtocol[Any],
+    entities: Sequence[BaseModel],
+    fields: Sequence[str],
+    *,
+    exclude_id: int | None = None,
+    message_template: str = "{field} already exists",
+) -> list[ValidationErrorDetail]:
+    errors: list[ValidationErrorDetail] = []
+    for field in fields:
+        values = [
+            entity.model_dump().get(field)
+            for entity in entities
+            if entity.model_dump().get(field) is not None
+        ]
+        existing_values = await repository.existing_values_by_field(
+            field,
+            values,
+            exclude_id=exclude_id,
+        )
+        if existing_values:
+            errors.append(
+                validation_error(
+                    field,
+                    message_template.format(field=field),
+                    "unique",
+                )
+            )
+    return errors
+
+
+async def ensure_unique_field_values_for_batch(
+    repository: BaseRepositoryProtocol[Any],
+    entities: Sequence[BaseModel],
+    fields: Sequence[str],
+    *,
+    message: str = "Validation failed",
+    error_code: str | None = None,
+) -> None:
+    errors = await collect_existing_unique_field_errors(repository, entities, fields)
+    raise_if_errors(
+        errors,
+        status_code=409,
+        message=message,
+        error_code=error_code,
+    )
+
+
+async def collect_existing_reference_errors(
+    repository: BaseRepositoryProtocol[Any],
+    field: str,
+    values: Sequence[int],
+    *,
+    message: str = "Referenced resource does not exist",
+) -> list[ValidationErrorDetail]:
+    missing = False
+    for value in set(values):
+        if not await repository.exists_by_id(value):
+            missing = True
+            break
+    if not missing:
+        return []
+    return [validation_error(field, message, "exists")]
+
+
+async def ensure_existing_references(
+    repository: BaseRepositoryProtocol[Any],
+    field: str,
+    values: Sequence[int],
+    *,
+    message: str = "Referenced resource does not exist",
+) -> None:
+    raise_if_errors(
+        await collect_existing_reference_errors(
+            repository,
+            field,
+            values,
+            message=message,
+        )
+    )
+
+
+def _coerce_error(
+    error: ValidationErrorDetail | Mapping[str, Any],
+) -> ValidationErrorDetail:
+    if isinstance(error, ValidationErrorDetail):
+        return error
+    return ValidationErrorDetail.model_validate(error)

--- a/src/_core/infrastructure/persistence/rdb/base_repository.py
+++ b/src/_core/infrastructure/persistence/rdb/base_repository.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from abc import ABC
-from typing import TYPE_CHECKING, Generic, TypeVar
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from pydantic import BaseModel
 from sqlalchemy import String, func, or_, select
@@ -67,9 +68,10 @@ class BaseRepository(Generic[ReturnDTO], ABC):
             ]
 
     async def select_data_by_id(self, data_id: int) -> ReturnDTO:
+        id_column = self._id_column()
         async with self.database.session() as session:
             result = await session.execute(
-                select(self.model).filter(self.model.id == data_id)
+                select(self.model).filter(id_column == data_id)
             )
             data = result.scalar_one_or_none()
             if not data:
@@ -81,15 +83,64 @@ class BaseRepository(Generic[ReturnDTO], ABC):
     async def select_datas_by_ids(self, data_ids: list[int]) -> list[ReturnDTO]:
         if not data_ids:
             return []
+        id_column = self._id_column()
         async with self.database.session() as session:
             result = await session.execute(
-                select(self.model).where(self.model.id.in_(data_ids))
+                select(self.model).where(id_column.in_(data_ids))
             )
             datas = result.scalars().all()
             return [
                 self.return_entity.model_validate(data, from_attributes=True)
                 for data in datas
             ]
+
+    async def exists_by_id(self, data_id: int) -> bool:
+        id_column = self._id_column()
+        async with self.database.session() as session:
+            result = await session.execute(
+                select(id_column).where(id_column == data_id).limit(1)
+            )
+            return result.scalar_one_or_none() is not None
+
+    async def exists_by_fields(
+        self,
+        filters: Mapping[str, Any],
+        *,
+        exclude_id: int | None = None,
+    ) -> bool:
+        if not filters:
+            return False
+        id_column = self._id_column()
+        async with self.database.session() as session:
+            query = select(id_column).where(
+                *[
+                    self._column_for_field(field) == value
+                    for field, value in filters.items()
+                ]
+            )
+            if exclude_id is not None:
+                query = query.where(id_column != exclude_id)
+            result = await session.execute(query.limit(1))
+            return result.scalar_one_or_none() is not None
+
+    async def existing_values_by_field(
+        self,
+        field: str,
+        values: list[Any],
+        *,
+        exclude_id: int | None = None,
+    ) -> set[Any]:
+        value_set = {value for value in values if value is not None}
+        if not value_set:
+            return set()
+        column = self._column_for_field(field)
+        id_column = self._id_column()
+        async with self.database.session() as session:
+            query = select(column).where(column.in_(value_set))
+            if exclude_id is not None:
+                query = query.where(id_column != exclude_id)
+            result = await session.execute(query)
+            return set(result.scalars().all())
 
     async def select_datas_with_count(
         self,
@@ -149,9 +200,10 @@ class BaseRepository(Generic[ReturnDTO], ABC):
     async def update_data_by_data_id(
         self, data_id: int, entity: BaseModel
     ) -> ReturnDTO:
+        id_column = self._id_column()
         async with self.database.session() as session:
             result = await session.execute(
-                select(self.model).filter(self.model.id == data_id)
+                select(self.model).filter(id_column == data_id)
             )
             data = result.scalar_one_or_none()
             if not data:
@@ -165,9 +217,10 @@ class BaseRepository(Generic[ReturnDTO], ABC):
             return self.return_entity.model_validate(data, from_attributes=True)
 
     async def delete_data_by_data_id(self, data_id: int) -> bool:
+        id_column = self._id_column()
         async with self.database.session() as session:
             result = await session.execute(
-                select(self.model).filter(self.model.id == data_id)
+                select(self.model).filter(id_column == data_id)
             )
             data = result.scalar_one_or_none()
             if not data:
@@ -182,3 +235,12 @@ class BaseRepository(Generic[ReturnDTO], ABC):
         async with self.database.session() as session:
             result = await session.execute(select(func.count()).select_from(self.model))
             return result.scalar_one()
+
+    def _column_for_field(self, field: str) -> InstrumentedAttribute:
+        column = getattr(self.model, field, None)
+        if not isinstance(column, InstrumentedAttribute):
+            raise ValueError(f"Unknown model field: {field}")
+        return column
+
+    def _id_column(self) -> InstrumentedAttribute:
+        return self._column_for_field("id")

--- a/src/ai_usage/domain/protocols/ai_usage_repository_protocol.py
+++ b/src/ai_usage/domain/protocols/ai_usage_repository_protocol.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Protocol
 
 from src._core.domain.protocols.repository_protocol import BaseRepositoryProtocol
 from src.ai_usage.domain.dtos.ai_usage_dto import (
@@ -11,7 +12,7 @@ from src.ai_usage.domain.dtos.ai_usage_dto import (
 from src.ai_usage.interface.server.schemas.ai_usage_schema import CreateAiUsageRequest
 
 
-class AiUsageRepositoryProtocol(BaseRepositoryProtocol[AiUsageDTO]):
+class AiUsageRepositoryProtocol(BaseRepositoryProtocol[AiUsageDTO], Protocol):
     async def insert_usage_once(self, entity: CreateAiUsageRequest) -> AiUsageDTO: ...
 
     async def select_usage_logs(

--- a/src/docs/domain/protocols/document_repository_protocol.py
+++ b/src/docs/domain/protocols/document_repository_protocol.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from typing import Protocol
+
 from src._core.domain.protocols.repository_protocol import BaseRepositoryProtocol
 from src.docs.domain.dtos.document_dto import DocumentDTO
 
 
-class DocumentRepositoryProtocol(BaseRepositoryProtocol[DocumentDTO]):
+class DocumentRepositoryProtocol(BaseRepositoryProtocol[DocumentDTO], Protocol):
     pass

--- a/src/user/domain/exceptions/user_exceptions.py
+++ b/src/user/domain/exceptions/user_exceptions.py
@@ -1,3 +1,6 @@
+from collections.abc import Sequence
+
+from src._core.domain.validation import ValidationErrorDetail, ValidationFailed
 from src._core.exceptions.base_exception import BaseCustomException
 
 
@@ -10,10 +13,29 @@ class UserNotFoundException(BaseCustomException):
         )
 
 
-class UserAlreadyExistsException(BaseCustomException):
-    def __init__(self, username: str) -> None:
+class UserAlreadyExistsException(ValidationFailed):
+    def __init__(
+        self,
+        username: str | None = None,
+        *,
+        errors: Sequence[ValidationErrorDetail] | None = None,
+    ) -> None:
+        if errors is None:
+            errors = (
+                ValidationErrorDetail(
+                    field="username",
+                    message="username already exists",
+                    type="unique",
+                ),
+            )
+        message = (
+            f"User with username [ {username} ] already exists"
+            if username
+            else "User already exists"
+        )
         super().__init__(
+            errors,
             status_code=409,
-            message=f"User with username [ {username} ] already exists",
+            message=message,
             error_code="USER_ALREADY_EXISTS",
         )

--- a/src/user/domain/protocols/user_repository_protocol.py
+++ b/src/user/domain/protocols/user_repository_protocol.py
@@ -1,6 +1,8 @@
+from typing import Protocol
+
 from src._core.domain.protocols.repository_protocol import BaseRepositoryProtocol
 from src.user.domain.dtos.user_dto import UserDTO
 
 
-class UserRepositoryProtocol(BaseRepositoryProtocol[UserDTO]):
+class UserRepositoryProtocol(BaseRepositoryProtocol[UserDTO], Protocol):
     pass

--- a/src/user/domain/services/user_service.py
+++ b/src/user/domain/services/user_service.py
@@ -2,6 +2,11 @@ from src._core.common.security import hash_password
 from src._core.domain.services.base_service import BaseService
 from src.user.domain.dtos.user_dto import UserDTO
 from src.user.domain.protocols.user_repository_protocol import UserRepositoryProtocol
+from src.user.domain.validators import (
+    ensure_user_unique_for_batch_create,
+    ensure_user_unique_for_create,
+    ensure_user_unique_for_update,
+)
 from src.user.interface.server.schemas.user_schema import (
     CreateUserRequest,
     UpdateUserRequest,
@@ -11,10 +16,18 @@ from src.user.interface.server.schemas.user_schema import (
 class UserService(BaseService[CreateUserRequest, UpdateUserRequest, UserDTO]):
     def __init__(self, user_repository: UserRepositoryProtocol) -> None:
         super().__init__(repository=user_repository)
+        self._user_repository = user_repository
 
     async def create_data(self, entity: CreateUserRequest) -> UserDTO:
         entity = entity.model_copy(update={"password": hash_password(entity.password)})
         return await super().create_data(entity=entity)
+
+    async def create_datas(self, entities: list[CreateUserRequest]) -> list[UserDTO]:
+        hashed_entities = [
+            entity.model_copy(update={"password": hash_password(entity.password)})
+            for entity in entities
+        ]
+        return await super().create_datas(entities=hashed_entities)
 
     async def update_data_by_data_id(
         self, data_id: int, entity: UpdateUserRequest
@@ -24,3 +37,16 @@ class UserService(BaseService[CreateUserRequest, UpdateUserRequest, UserDTO]):
                 update={"password": hash_password(entity.password)}
             )
         return await super().update_data_by_data_id(data_id=data_id, entity=entity)
+
+    async def _validate_create(self, entity: CreateUserRequest) -> None:
+        await ensure_user_unique_for_create(self._user_repository, entity)
+
+    async def _validate_create_many(self, entities: list[CreateUserRequest]) -> None:
+        await ensure_user_unique_for_batch_create(self._user_repository, entities)
+
+    async def _validate_update(
+        self,
+        data_id: int,
+        entity: UpdateUserRequest,
+    ) -> None:
+        await ensure_user_unique_for_update(self._user_repository, data_id, entity)

--- a/src/user/domain/validators.py
+++ b/src/user/domain/validators.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from src._core.domain.validation import (
+    collect_duplicate_field_errors,
+    collect_existing_unique_field_errors,
+    collect_unique_field_errors,
+    raise_if_errors,
+)
+from src.user.domain.exceptions.user_exceptions import UserAlreadyExistsException
+from src.user.domain.protocols.user_repository_protocol import UserRepositoryProtocol
+from src.user.interface.server.schemas.user_schema import (
+    CreateUserRequest,
+    UpdateUserRequest,
+)
+
+USER_UNIQUE_FIELDS = ("username", "email")
+
+
+async def ensure_user_unique_for_create(
+    repository: UserRepositoryProtocol,
+    entity: CreateUserRequest,
+) -> None:
+    errors = await collect_unique_field_errors(repository, entity, USER_UNIQUE_FIELDS)
+    if errors:
+        raise UserAlreadyExistsException(errors=errors)
+
+
+async def ensure_user_unique_for_batch_create(
+    repository: UserRepositoryProtocol,
+    entities: list[CreateUserRequest],
+) -> None:
+    payload_errors = collect_duplicate_field_errors(entities, USER_UNIQUE_FIELDS)
+    raise_if_errors(payload_errors)
+
+    existing_errors = await collect_existing_unique_field_errors(
+        repository,
+        entities,
+        USER_UNIQUE_FIELDS,
+    )
+    if existing_errors:
+        raise UserAlreadyExistsException(errors=existing_errors)
+
+
+async def ensure_user_unique_for_update(
+    repository: UserRepositoryProtocol,
+    data_id: int,
+    entity: UpdateUserRequest,
+) -> None:
+    errors = await collect_unique_field_errors(
+        repository,
+        entity,
+        USER_UNIQUE_FIELDS,
+        exclude_id=data_id,
+    )
+    if errors:
+        raise UserAlreadyExistsException(errors=errors)

--- a/src/user/infrastructure/database/models/user_model.py
+++ b/src/user/infrastructure/database/models/user_model.py
@@ -1,4 +1,4 @@
-from sqlalchemy import DateTime, Integer, String, func
+from sqlalchemy import DateTime, Integer, String, UniqueConstraint, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from src._core.infrastructure.persistence.rdb.database import Base
@@ -6,6 +6,10 @@ from src._core.infrastructure.persistence.rdb.database import Base
 
 class UserModel(Base):
     __tablename__ = "user"
+    __table_args__ = (
+        UniqueConstraint("username", name="uq_user_username"),
+        UniqueConstraint("email", name="uq_user_email"),
+    )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     username: Mapped[str] = mapped_column(String(20), nullable=False)

--- a/src/user/infrastructure/repositories/user_repository.py
+++ b/src/user/infrastructure/repositories/user_repository.py
@@ -34,13 +34,31 @@ class UserRepository(BaseRepository[UserDTO]):
                 await self._raise_user_unique_conflict_if_present(entity, exc)
             raise
 
+    async def update_data_by_data_id(self, data_id: int, entity: BaseModel) -> UserDTO:
+        try:
+            return await super().update_data_by_data_id(data_id=data_id, entity=entity)
+        except DatabaseException as exc:
+            await self._raise_user_unique_conflict_if_present(
+                entity,
+                exc,
+                exclude_id=data_id,
+            )
+            raise
+
     async def _raise_user_unique_conflict_if_present(
         self,
         entity: BaseModel,
         exc: DatabaseException,
+        *,
+        exclude_id: int | None = None,
     ) -> None:
         if exc.error_code != "DB_INTEGRITY_ERROR":
             return
-        errors = await collect_unique_field_errors(self, entity, _USER_UNIQUE_FIELDS)
+        errors = await collect_unique_field_errors(
+            self,
+            entity,
+            _USER_UNIQUE_FIELDS,
+            exclude_id=exclude_id,
+        )
         if errors:
             raise UserAlreadyExistsException(errors=errors) from exc

--- a/src/user/infrastructure/repositories/user_repository.py
+++ b/src/user/infrastructure/repositories/user_repository.py
@@ -1,7 +1,14 @@
+from pydantic import BaseModel
+
+from src._core.domain.validation import collect_unique_field_errors
 from src._core.infrastructure.persistence.rdb.base_repository import BaseRepository
 from src._core.infrastructure.persistence.rdb.database import Database
+from src._core.infrastructure.persistence.rdb.exceptions import DatabaseException
 from src.user.domain.dtos.user_dto import UserDTO
+from src.user.domain.exceptions.user_exceptions import UserAlreadyExistsException
 from src.user.infrastructure.database.models.user_model import UserModel
+
+_USER_UNIQUE_FIELDS = ("username", "email")
 
 
 class UserRepository(BaseRepository[UserDTO]):
@@ -11,3 +18,29 @@ class UserRepository(BaseRepository[UserDTO]):
             model=UserModel,
             return_entity=UserDTO,
         )
+
+    async def insert_data(self, entity: BaseModel) -> UserDTO:
+        try:
+            return await super().insert_data(entity=entity)
+        except DatabaseException as exc:
+            await self._raise_user_unique_conflict_if_present(entity, exc)
+            raise
+
+    async def insert_datas(self, entities: list[BaseModel]) -> list[UserDTO]:
+        try:
+            return await super().insert_datas(entities=entities)
+        except DatabaseException as exc:
+            for entity in entities:
+                await self._raise_user_unique_conflict_if_present(entity, exc)
+            raise
+
+    async def _raise_user_unique_conflict_if_present(
+        self,
+        entity: BaseModel,
+        exc: DatabaseException,
+    ) -> None:
+        if exc.error_code != "DB_INTEGRITY_ERROR":
+            return
+        errors = await collect_unique_field_errors(self, entity, _USER_UNIQUE_FIELDS)
+        if errors:
+            raise UserAlreadyExistsException(errors=errors) from exc

--- a/tests/e2e/user/test_user_router.py
+++ b/tests/e2e/user/test_user_router.py
@@ -35,3 +35,119 @@ async def test_get_users():
     data = response.json()
     assert data["success"] is True
     assert isinstance(data["data"], list)
+
+
+@pytest.mark.asyncio
+async def test_create_user_duplicate_returns_field_errors():
+    payload = {
+        "username": "e2edup",
+        "fullName": "E2E Duplicate",
+        "email": "e2edup@example.com",
+        "password": "secret",
+    }
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://localhost"
+    ) as client:
+        first = await client.post("/v1/user", json=payload)
+        second = await client.post("/v1/user", json=payload)
+
+    assert first.status_code == 200
+    assert second.status_code == 409
+    body = second.json()
+    assert body["success"] is False
+    assert body["errorCode"] == "USER_ALREADY_EXISTS"
+    assert body["errorDetails"]["errors"] == [
+        {
+            "field": "username",
+            "message": "username already exists",
+            "type": "unique",
+        },
+        {
+            "field": "email",
+            "message": "email already exists",
+            "type": "unique",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_create_users_duplicate_payload_is_all_or_nothing():
+    payload = [
+        {
+            "username": "e2ebatchdup",
+            "fullName": "E2E Batch One",
+            "email": "e2ebatch-one@example.com",
+            "password": "secret",
+        },
+        {
+            "username": "e2ebatchdup",
+            "fullName": "E2E Batch Two",
+            "email": "e2ebatch-two@example.com",
+            "password": "secret",
+        },
+    ]
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://localhost"
+    ) as client:
+        response = await client.post("/v1/users", json=payload)
+        list_response = await client.get("/v1/users?pageSize=100")
+
+    assert response.status_code == 422
+    body = response.json()
+    assert body["errorCode"] == "BUSINESS_VALIDATION_ERROR"
+    assert body["errorDetails"]["errors"] == [
+        {
+            "field": "username",
+            "message": "Duplicate username in request payload",
+            "type": "duplicate",
+        }
+    ]
+    usernames = {item["username"] for item in list_response.json()["data"]}
+    assert "e2ebatchdup" not in usernames
+
+
+@pytest.mark.asyncio
+async def test_update_user_allows_own_email_and_rejects_another_users_email():
+    first_payload = {
+        "username": "e2eupdateone",
+        "fullName": "E2E Update One",
+        "email": "e2eupdateone@example.com",
+        "password": "secret",
+    }
+    second_payload = {
+        "username": "e2eupdatetwo",
+        "fullName": "E2E Update Two",
+        "email": "e2eupdatetwo@example.com",
+        "password": "secret",
+    }
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://localhost"
+    ) as client:
+        first = await client.post("/v1/user", json=first_payload)
+        second = await client.post("/v1/user", json=second_payload)
+        first_id = first.json()["data"]["id"]
+        second_id = second.json()["data"]["id"]
+
+        own_email = await client.put(
+            f"/v1/user/{first_id}",
+            json={"email": first_payload["email"]},
+        )
+        conflicting_email = await client.put(
+            f"/v1/user/{second_id}",
+            json={"email": first_payload["email"]},
+        )
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert own_email.status_code == 200
+    assert conflicting_email.status_code == 409
+    assert conflicting_email.json()["errorDetails"]["errors"] == [
+        {
+            "field": "email",
+            "message": "email already exists",
+            "type": "unique",
+        }
+    ]

--- a/tests/integration/user/infrastructure/test_user_repository.py
+++ b/tests/integration/user/infrastructure/test_user_repository.py
@@ -123,3 +123,37 @@ async def test_unique_constraints_reject_duplicate_username_and_email(test_db):
             },
         ]
     }
+
+
+@pytest.mark.asyncio
+async def test_unique_constraint_update_conflict_returns_user_exception(test_db):
+    repo = UserRepository(database=test_db)
+    first = await repo.insert_data(
+        entity=make_create_user_request(
+            username="repo_upd_one",
+            email="repo_unique_update_one@example.com",
+        )
+    )
+    second = await repo.insert_data(
+        entity=make_create_user_request(
+            username="repo_upd_two",
+            email="repo_unique_update_two@example.com",
+        )
+    )
+
+    with pytest.raises(UserAlreadyExistsException) as exc_info:
+        await repo.update_data_by_data_id(
+            data_id=second.id,
+            entity=UpdateUserRequest(email=first.email),
+        )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.details == {
+        "errors": [
+            {
+                "field": "email",
+                "message": "email already exists",
+                "type": "unique",
+            }
+        ]
+    }

--- a/tests/integration/user/infrastructure/test_user_repository.py
+++ b/tests/integration/user/infrastructure/test_user_repository.py
@@ -1,5 +1,6 @@
 import pytest
 
+from src.user.domain.exceptions.user_exceptions import UserAlreadyExistsException
 from src.user.infrastructure.repositories.user_repository import UserRepository
 from src.user.interface.server.schemas.user_schema import UpdateUserRequest
 from tests.factories.user_factory import make_create_user_request
@@ -8,7 +9,10 @@ from tests.factories.user_factory import make_create_user_request
 @pytest.mark.asyncio
 async def test_insert_and_select(test_db):
     repo = UserRepository(database=test_db)
-    request = make_create_user_request()
+    request = make_create_user_request(
+        username="repo_insert",
+        email="repo_insert@example.com",
+    )
 
     created = await repo.insert_data(entity=request)
     assert created.id is not None
@@ -22,7 +26,12 @@ async def test_insert_and_select(test_db):
 @pytest.mark.asyncio
 async def test_update(test_db):
     repo = UserRepository(database=test_db)
-    created = await repo.insert_data(entity=make_create_user_request())
+    created = await repo.insert_data(
+        entity=make_create_user_request(
+            username="repo_update",
+            email="repo_update@example.com",
+        )
+    )
 
     updated = await repo.update_data_by_data_id(
         data_id=created.id,
@@ -35,7 +44,12 @@ async def test_update(test_db):
 @pytest.mark.asyncio
 async def test_delete(test_db):
     repo = UserRepository(database=test_db)
-    created = await repo.insert_data(entity=make_create_user_request())
+    created = await repo.insert_data(
+        entity=make_create_user_request(
+            username="repo_delete",
+            email="repo_delete@example.com",
+        )
+    )
 
     result = await repo.delete_data_by_data_id(data_id=created.id)
     assert result is True
@@ -46,8 +60,66 @@ async def test_count(test_db):
     repo = UserRepository(database=test_db)
     for i in range(3):
         await repo.insert_data(
-            entity=make_create_user_request(username=f"countuser{i}")
+            entity=make_create_user_request(
+                username=f"countuser{i}",
+                email=f"countuser{i}@example.com",
+            )
         )
 
     count = await repo.count_datas()
     assert count >= 3
+
+
+@pytest.mark.asyncio
+async def test_exists_primitives(test_db):
+    repo = UserRepository(database=test_db)
+    request = make_create_user_request(
+        username="repo_exists",
+        email="repo_exists@example.com",
+    )
+    created = await repo.insert_data(entity=request)
+
+    assert await repo.exists_by_id(created.id) is True
+    assert await repo.exists_by_id(created.id + 1000) is False
+    assert await repo.exists_by_fields({"username": request.username}) is True
+    assert (
+        await repo.exists_by_fields(
+            {"username": request.username},
+            exclude_id=created.id,
+        )
+        is False
+    )
+    assert await repo.existing_values_by_field(
+        "email",
+        [request.email, "missing@example.com"],
+    ) == {request.email}
+
+
+@pytest.mark.asyncio
+async def test_unique_constraints_reject_duplicate_username_and_email(test_db):
+    repo = UserRepository(database=test_db)
+    request = make_create_user_request(
+        username="repo_unique",
+        email="repo_unique@example.com",
+    )
+    await repo.insert_data(entity=request)
+
+    with pytest.raises(UserAlreadyExistsException) as exc_info:
+        await repo.insert_data(entity=request)
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.error_code == "USER_ALREADY_EXISTS"
+    assert exc_info.value.details == {
+        "errors": [
+            {
+                "field": "username",
+                "message": "username already exists",
+                "type": "unique",
+            },
+            {
+                "field": "email",
+                "message": "email already exists",
+                "type": "unique",
+            },
+        ]
+    }

--- a/tests/unit/_core/domain/services/test_base_service.py
+++ b/tests/unit/_core/domain/services/test_base_service.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from pydantic import BaseModel
+
+from src._core.application.dtos.base_response import PaginationInfo
+from src._core.domain.services.base_service import BaseService
+
+
+class CreateItem(BaseModel):
+    name: str
+
+
+class UpdateItem(BaseModel):
+    name: str | None = None
+
+
+class ItemDTO(BaseModel):
+    id: int
+    name: str
+
+
+class FakeRepository:
+    def __init__(self) -> None:
+        self.items: dict[int, ItemDTO] = {}
+        self.next_id = 1
+        self.deleted: list[int] = []
+
+    async def insert_data(self, entity: BaseModel) -> ItemDTO:
+        item = ItemDTO(id=self.next_id, name=entity.model_dump()["name"])
+        self.items[item.id] = item
+        self.next_id += 1
+        return item
+
+    async def insert_datas(self, entities: list[BaseModel]) -> list[ItemDTO]:
+        return [await self.insert_data(entity) for entity in entities]
+
+    async def select_datas(self, page: int, page_size: int) -> list[ItemDTO]:
+        return list(self.items.values())
+
+    async def select_data_by_id(self, data_id: int) -> ItemDTO:
+        return self.items[data_id]
+
+    async def select_datas_by_ids(self, data_ids: list[int]) -> list[ItemDTO]:
+        return [self.items[data_id] for data_id in data_ids]
+
+    async def exists_by_id(self, data_id: int) -> bool:
+        return data_id in self.items
+
+    async def exists_by_fields(
+        self,
+        filters: Mapping[str, Any],
+        *,
+        exclude_id: int | None = None,
+    ) -> bool:
+        return False
+
+    async def existing_values_by_field(
+        self,
+        field: str,
+        values: list[Any],
+        *,
+        exclude_id: int | None = None,
+    ) -> set[Any]:
+        return set()
+
+    async def select_datas_with_count(
+        self,
+        page: int,
+        page_size: int,
+        query_filter=None,
+    ) -> tuple[list[ItemDTO], int]:
+        items = list(self.items.values())
+        return items, len(items)
+
+    async def update_data_by_data_id(
+        self,
+        data_id: int,
+        entity: BaseModel,
+    ) -> ItemDTO:
+        item = self.items[data_id].model_copy(
+            update=entity.model_dump(exclude_none=True)
+        )
+        self.items[data_id] = item
+        return item
+
+    async def delete_data_by_data_id(self, data_id: int) -> bool:
+        self.deleted.append(data_id)
+        self.items.pop(data_id, None)
+        return True
+
+    async def count_datas(self) -> int:
+        return len(self.items)
+
+
+class HookedService(BaseService[CreateItem, UpdateItem, ItemDTO]):
+    def __init__(self, repository: FakeRepository) -> None:
+        super().__init__(repository=repository)
+        self.events: list[str] = []
+
+    async def _validate_create(self, entity: CreateItem) -> None:
+        self.events.append(f"create:{entity.name}")
+
+    async def _validate_create_many(self, entities: list[CreateItem]) -> None:
+        self.events.append(f"create_many:{len(entities)}")
+
+    async def _validate_update(self, data_id: int, entity: UpdateItem) -> None:
+        self.events.append(f"update:{data_id}")
+
+    async def _validate_delete(self, data_id: int) -> None:
+        self.events.append(f"delete:{data_id}")
+
+
+async def test_base_service_default_validation_hooks_are_noop():
+    service = BaseService[CreateItem, UpdateItem, ItemDTO](repository=FakeRepository())
+
+    created = await service.create_data(CreateItem(name="one"))
+    updated = await service.update_data_by_data_id(
+        created.id,
+        UpdateItem(name="two"),
+    )
+    deleted = await service.delete_data_by_data_id(created.id)
+
+    assert updated.name == "two"
+    assert deleted is True
+
+
+async def test_base_service_calls_validation_hooks_for_write_paths():
+    service = HookedService(repository=FakeRepository())
+
+    created = await service.create_data(CreateItem(name="one"))
+    await service.create_datas([CreateItem(name="two"), CreateItem(name="three")])
+    await service.update_data_by_data_id(created.id, UpdateItem(name="updated"))
+    await service.delete_data_by_data_id(created.id)
+
+    assert service.events == [
+        "create:one",
+        "create_many:2",
+        "update:1",
+        "delete:1",
+    ]
+
+
+async def test_base_service_read_paths_still_return_pagination():
+    service = BaseService[CreateItem, UpdateItem, ItemDTO](repository=FakeRepository())
+    await service.create_data(CreateItem(name="one"))
+
+    items, pagination = await service.get_datas(page=1, page_size=10)
+
+    assert len(items) == 1
+    assert isinstance(pagination, PaginationInfo)
+    assert pagination.total_items == 1

--- a/tests/unit/_core/domain/test_validation.py
+++ b/tests/unit/_core/domain/test_validation.py
@@ -1,0 +1,116 @@
+from typing import Any, cast
+
+import pytest
+from pydantic import BaseModel
+
+from src._core.domain.protocols.repository_protocol import BaseRepositoryProtocol
+from src._core.domain.validation import (
+    ValidationErrorDetail,
+    ValidationFailed,
+    collect_conditionally_required_errors,
+    collect_duplicate_field_errors,
+    collect_unique_field_errors,
+    ensure_conditionally_required,
+)
+
+
+class SampleRequest(BaseModel):
+    email: str | None = None
+    name: str | None = None
+
+
+class FakeRepository:
+    def __init__(self, existing: dict[str, set[str]] | None = None) -> None:
+        self.existing = existing or {}
+
+    async def exists_by_fields(
+        self,
+        filters,
+        *,
+        exclude_id=None,
+    ) -> bool:
+        return any(
+            value in self.existing.get(field, set()) for field, value in filters.items()
+        )
+
+
+def test_validation_failed_uses_stable_error_details_shape():
+    exc = ValidationFailed(
+        [
+            ValidationErrorDetail(
+                field="email",
+                message="email already exists",
+                type="unique",
+            )
+        ],
+        status_code=409,
+        error_code="USER_ALREADY_EXISTS",
+    )
+
+    assert exc.status_code == 409
+    assert exc.error_code == "USER_ALREADY_EXISTS"
+    assert exc.details == {
+        "errors": [
+            {
+                "field": "email",
+                "message": "email already exists",
+                "type": "unique",
+            }
+        ]
+    }
+
+
+def test_collect_duplicate_field_errors_reports_each_duplicated_field_once():
+    entities = [
+        SampleRequest(email="a@example.com", name="one"),
+        SampleRequest(email="a@example.com", name="two"),
+        SampleRequest(email="b@example.com", name="two"),
+    ]
+
+    errors = collect_duplicate_field_errors(entities, ("email", "name"))
+
+    assert [error.field for error in errors] == ["email", "name"]
+    assert all(error.type == "duplicate" for error in errors)
+
+
+def test_conditionally_required_helpers_return_field_errors():
+    entity = SampleRequest(email=None, name="Name")
+
+    errors = collect_conditionally_required_errors(
+        entity,
+        ("email",),
+        condition=True,
+    )
+
+    assert errors == [
+        ValidationErrorDetail(
+            field="email",
+            message="Field is required",
+            type="conditional_required",
+        )
+    ]
+    with pytest.raises(ValidationFailed) as exc_info:
+        ensure_conditionally_required(entity, ("email",), condition=True)
+    assert exc_info.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_collect_unique_field_errors_uses_repository_primitives():
+    repo = cast(
+        BaseRepositoryProtocol[Any],
+        FakeRepository(existing={"email": {"taken@example.com"}}),
+    )
+
+    errors = await collect_unique_field_errors(
+        repo,
+        SampleRequest(email="taken@example.com"),
+        ("email",),
+    )
+
+    assert errors == [
+        ValidationErrorDetail(
+            field="email",
+            message="email already exists",
+            type="unique",
+        )
+    ]

--- a/tests/unit/user/domain/test_user_service.py
+++ b/tests/unit/user/domain/test_user_service.py
@@ -1,9 +1,14 @@
+from collections.abc import Mapping
+from typing import Any
+
 import pytest
 from pydantic import BaseModel
 
 from src._core.application.dtos.base_response import PaginationInfo
 from src._core.common.security import verify_password
+from src._core.domain.validation import ValidationFailed
 from src.user.domain.dtos.user_dto import UserDTO
+from src.user.domain.exceptions.user_exceptions import UserAlreadyExistsException
 from src.user.domain.services.user_service import UserService
 from src.user.interface.server.schemas.user_schema import UpdateUserRequest
 from tests.factories.user_factory import make_create_user_request, make_user_dto
@@ -37,6 +42,37 @@ class MockUserRepository:
 
     async def select_datas_by_ids(self, data_ids: list[int]) -> list[UserDTO]:
         return [self._store[i] for i in data_ids if i in self._store]
+
+    async def exists_by_id(self, data_id: int) -> bool:
+        return data_id in self._store
+
+    async def exists_by_fields(
+        self,
+        filters: Mapping[str, Any],
+        *,
+        exclude_id: int | None = None,
+    ) -> bool:
+        for data_id, dto in self._store.items():
+            if exclude_id is not None and data_id == exclude_id:
+                continue
+            if all(getattr(dto, field) == value for field, value in filters.items()):
+                return True
+        return False
+
+    async def existing_values_by_field(
+        self,
+        field: str,
+        values: list[Any],
+        *,
+        exclude_id: int | None = None,
+    ) -> set[Any]:
+        value_set = set(values)
+        return {
+            getattr(dto, field)
+            for data_id, dto in self._store.items()
+            if (exclude_id is None or data_id != exclude_id)
+            and getattr(dto, field) in value_set
+        }
 
     async def select_datas_with_count(
         self,
@@ -117,7 +153,10 @@ async def test_delete_user(user_service):
 async def test_get_datas_returns_pagination(user_service):
     for i in range(3):
         await user_service.create_data(
-            entity=make_create_user_request(username=f"user{i}")
+            entity=make_create_user_request(
+                username=f"user{i}",
+                email=f"user{i}@example.com",
+            )
         )
 
     datas, pagination = await user_service.get_datas(page=1, page_size=2)
@@ -128,3 +167,127 @@ async def test_get_datas_returns_pagination(user_service):
     assert pagination.total_pages == 2
     assert pagination.has_next is True
     assert pagination.has_previous is False
+
+
+@pytest.mark.asyncio
+async def test_create_user_rejects_duplicate_username_or_email(user_service):
+    await user_service.create_data(
+        entity=make_create_user_request(
+            username="duplicate",
+            email="duplicate@example.com",
+        )
+    )
+
+    with pytest.raises(UserAlreadyExistsException) as exc_info:
+        await user_service.create_data(
+            entity=make_create_user_request(
+                username="duplicate",
+                email="duplicate@example.com",
+            )
+        )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.error_code == "USER_ALREADY_EXISTS"
+    assert exc_info.value.details == {
+        "errors": [
+            {
+                "field": "username",
+                "message": "username already exists",
+                "type": "unique",
+            },
+            {
+                "field": "email",
+                "message": "email already exists",
+                "type": "unique",
+            },
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_update_user_allows_own_unique_values(user_service):
+    created = await user_service.create_data(
+        entity=make_create_user_request(
+            username="selfuser",
+            email="self@example.com",
+        )
+    )
+
+    result = await user_service.update_data_by_data_id(
+        data_id=created.id,
+        entity=UpdateUserRequest(email="self@example.com"),
+    )
+
+    assert result.email == "self@example.com"
+
+
+@pytest.mark.asyncio
+async def test_update_user_rejects_another_users_email(user_service):
+    first = await user_service.create_data(
+        entity=make_create_user_request(
+            username="firstuser",
+            email="first@example.com",
+        )
+    )
+    second = await user_service.create_data(
+        entity=make_create_user_request(
+            username="seconduser",
+            email="second@example.com",
+        )
+    )
+
+    with pytest.raises(UserAlreadyExistsException):
+        await user_service.update_data_by_data_id(
+            data_id=second.id,
+            entity=UpdateUserRequest(email=first.email),
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_users_rejects_payload_duplicates_without_insert(user_service):
+    with pytest.raises(ValidationFailed) as exc_info:
+        await user_service.create_datas(
+            [
+                make_create_user_request(
+                    username="batchdup",
+                    email="batch-one@example.com",
+                ),
+                make_create_user_request(
+                    username="batchdup",
+                    email="batch-two@example.com",
+                ),
+            ]
+        )
+
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.details == {
+        "errors": [
+            {
+                "field": "username",
+                "message": "Duplicate username in request payload",
+                "type": "duplicate",
+            }
+        ]
+    }
+    assert await user_service.count_datas() == 0
+
+
+@pytest.mark.asyncio
+async def test_create_users_hashes_passwords(user_service):
+    requests = [
+        make_create_user_request(
+            username="batchuser1",
+            email="batchuser1@example.com",
+            password="plain-one",
+        ),
+        make_create_user_request(
+            username="batchuser2",
+            email="batchuser2@example.com",
+            password="plain-two",
+        ),
+    ]
+
+    results = await user_service.create_datas(entities=requests)
+
+    assert verify_password("plain-one", results[0].password)
+    assert verify_password("plain-two", results[1].password)


### PR DESCRIPTION
## Related Issue
- Fixes #10

## Change Summary
- Add service-layer CRUD validation hooks and reusable field-level validation helpers.
- Add RDB repository existence primitives for uniqueness and reference checks.
- Enforce User username/email uniqueness with DB constraints, migration, and DB-integrity safety-net translation.
- Add unit, integration, and e2e coverage for validation behavior.
- Sync shared guidance for the new CRUD validation pattern and add the governor review trail.

## Type of Change
- [x] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code restructuring
- [x] docs: Documentation
- [ ] chore: Build/tooling
- [x] test: Tests
- [ ] ci: CI/CD
- [ ] perf: Performance
- [ ] style: Code style

## Checklist
- [x] Architecture rules followed (no Domain -> Infrastructure imports)
- [x] Tests pass
- [x] Linting passes (`ruff check src/`)

## How to Test
- `uv run pytest tests/unit/_core/domain/test_validation.py tests/unit/_core/domain/services/test_base_service.py tests/unit/user/domain/test_user_service.py tests/integration/user/infrastructure/test_user_repository.py tests/e2e/user/test_user_router.py tests/unit/docs/domain tests/unit/ai_usage/domain tests/unit/todo/domain tests/integration/docs/infrastructure tests/integration/ai_usage/infrastructure -q`
  - Result: 53 passed.
- `uv run pyright src/_core/domain/protocols/repository_protocol.py src/_core/domain/services/base_service.py src/_core/domain/validation.py src/_core/infrastructure/persistence/rdb/base_repository.py src/user/domain/exceptions/user_exceptions.py src/user/domain/protocols/user_repository_protocol.py src/user/domain/services/user_service.py src/user/domain/validators.py src/user/infrastructure/database/models/user_model.py src/user/infrastructure/repositories/user_repository.py tests/unit/_core/domain/test_validation.py tests/unit/_core/domain/services/test_base_service.py tests/unit/user/domain/test_user_service.py tests/integration/user/infrastructure/test_user_repository.py tests/e2e/user/test_user_router.py`
  - Result: 0 errors.
- `python3 tools/check_language_policy.py`
  - Result: 0 violations across 170 scanned files.
- `python3 tools/check_g_closure.py`
  - Result: 0 violations across 14 entries.
- `uv run pre-commit run --all-files`
  - Result: passed.

## Cross Review
- Claude implementation review surfaced R-points R1-R8. R2/R3/R7 were fixed; R1 was rejected with repo-specific rationale; R4/R8 were deferred with rationale; R5 became the `/sync-guidelines` follow-up.
- Claude Opus xhigh implementation follow-up challenged the review with six points; update unique conflict translation was fixed, while migration backfill, normalization, and enumeration were recorded as product/security tradeoffs.
- Claude Opus xhigh `/sync-guidelines` scope challenge narrowed the shared-doc sync and rejected broad `add-api` wrapper edits.
- Claude Opus xhigh gate-on-gate review approved the sync result; Sync Required is now false.

## Review State
- `/review-pr` result: no open blocking code/security findings after the update conflict safety-net fix.
- `/sync-guidelines` result: closed. Shared architecture/scaffolding guidance now matches the new BaseService hook and BaseRepositoryProtocol primitive surfaces.

---

## Governor-Changing PR

This PR became governor-changing after the `/sync-guidelines` follow-up touched `AGENTS.md`, `docs/ai/shared/**`, and `.claude/rules/**`.

Source of truth: [`AGENTS.md` § Default Coding Flow](../AGENTS.md#default-coding-flow) + [`docs/ai/shared/governor-paths.md`](../docs/ai/shared/governor-paths.md) + [`docs/ai/shared/governor-review-log/README.md`](../docs/ai/shared/governor-review-log/README.md).

### Triggered files

- [x] At least one file in `changed_files` matches a Tier A / B / C path in `governor-paths.md`, and no full-set exclusion applies.

### Cross-tool review

- [x] Claude Opus xhigh review completed as the cross-tool reviewer.
- [x] All R-points addressed or explicitly deferred with rationale.
- [x] Final Verdict captured: approved / Sync Required false.

### Self-application proof

- [x] `/review-pr` output captured in this PR body and promoted drift candidates into `/sync-guidelines`.
- [x] `/sync-guidelines` output captured in `docs/ai/shared/governor-review-log/pr-152-crud-data-validation-sync.md`.

### Review trail artifact

- [x] `docs/ai/shared/governor-review-log/pr-152-crud-data-validation-sync.md` added with Summary, Review Rounds, Inherited Constraints, Self-Application Proof, and R-points Closure Table.
- [x] `governor-review-log/README.md` Index table updated.
- [x] Not applicable: this PR creates no follow-up issues that need inherited review constraints.

### Doc-only escape hygiene

- [x] This PR is not using the doc-only auto-escape; Tier A/B governance files were intentionally changed.

### Phase context (Phase 2~5 of #117 only)

- [x] Not applicable: this PR is not a Phase 2~5 hybrid-harness migration PR.
