### PR TITLE
feat: revamp /docs selector and add frontend handoff guide

### DIFF
--- a/.agents/skills/sync-guidelines/SKILL.md
+++ b/.agents/skills/sync-guidelines/SKILL.md
@@ -12,13 +12,15 @@ metadata:
 - Routes after: end of work
 - Recursion guard: do not invoke `/sync-guidelines` recursively, do not invoke `/plan-feature` from inside
 
-## Procedure
-1. Read `AGENTS.md` and `docs/ai/shared/skills/sync-guidelines.md` for the full procedure.
-   Also refer to `docs/ai/shared/drift-checklist.md` for detailed inspection items.
-2. Determine the sync mode, gather incoming `Drift Candidates`, and load the governing sources (Phase 0).
-3. Reconcile drift candidates with code, shared references, harness docs, and wrappers (Phase 1).
-4. Refresh `project-dna` and dependent shared references as needed (Phase 2).
-5. Verify Hybrid C parity for both Claude and Codex wrappers, then close with the sync contract (Phase 3).
+## Procedure Overview
+1. Determine the sync mode, gather incoming `Drift Candidates`, and load the governing sources (Phase 0)
+2. Reconcile drift candidates with code, shared references, harness docs, and wrappers (Phase 1)
+3. Refresh `project-dna` and dependent shared references as needed (Phase 2)
+4. Verify Hybrid C parity for both Claude and Codex wrappers, then close with the sync contract (Phase 3)
 
-For cross-tool review prompts, use the `Cross-Tool Review Prompt Template`
-section in `docs/ai/shared/skills/sync-guidelines.md`; do not duplicate it here.
+Read `AGENTS.md` and `docs/ai/shared/skills/sync-guidelines.md` for detailed steps.
+Also refer to `docs/ai/shared/drift-checklist.md` for inspection items.
+
+Closing summary must include: `Mode`, `Input Drift Candidates`, `project-dna`, `AUTO-FIX`, `REVIEW`, `Remaining`, `Next Actions` - see "Sync Contract" in the shared procedure.
+For cross-tool review prompts, use the shared procedure's
+`Cross-Tool Review Prompt Template` section; do not duplicate the template here.

--- a/.claude/rules/architecture-conventions.md
+++ b/.claude/rules/architecture-conventions.md
@@ -1,6 +1,6 @@
 # Architecture Conventions
 
-> Last synced: 2026-04-30 via /sync-guidelines (#10 CRUD write validation hooks and repository validation primitives)
+> Last synced: 2026-05-01 via /sync-guidelines (#154 admin JWT RBAC + #156 /docs selector revamp reviewed; neither touches the data flow / object roles / generic signatures surface, so the body is unchanged.)
 > For Absolute Prohibitions, Conversion Patterns, Write DTO criteria, Responsibility Matrix, Error Translation, Optional AI Infra Pattern, Admin Service Contract, and **Default Coding Flow** (process layer, ADR 045), refer to AGENTS.md.
 > This file only contains **structural context** that supplements AGENTS.md for Claude.
 

--- a/.claude/rules/commands.md
+++ b/.claude/rules/commands.md
@@ -1,6 +1,6 @@
 # Suggested Commands
 
-> Last synced: 2026-04-30 via /sync-guidelines (#10 reviewed; no command surface changes)
+> Last synced: 2026-05-01 via /sync-guidelines (#154 admin JWT RBAC + #156 /docs selector revamp reviewed; no `make` / pytest / lint / migration command surface changes.)
 > Purpose: Quick reference for Claude Code when executing shell commands.
 > Also referenced when running Skills.
 > Default Flow context: see [`AGENTS.md` § Default Coding Flow](../../AGENTS.md#default-coding-flow). The commands below are consulted by the `implement` and `verify` steps; this file is **not** a primary entry point in the Default Flow.
@@ -140,7 +140,10 @@ STORAGE_TYPE=s3 python run_server_local.py --env local
 ```bash
 # The admin dashboard mounts only when the `admin` extra is installed (#104)
 uv sync --extra admin            # install nicegui
-# → http://127.0.0.1:8001/admin (ADMIN_ID / ADMIN_PASSWORD from .env)
+# → http://127.0.0.1:8001/admin
+# Login uses auth-domain credentials (POST /v1/auth/login) plus a `user.role` admin
+# check (#154 / PR #155). Seed an admin via `ADMIN_BOOTSTRAP_USERNAME`,
+# `ADMIN_BOOTSTRAP_EMAIL`, `ADMIN_BOOTSTRAP_PASSWORD` env vars (idempotent on boot).
 
 # When not installed, the server boots normally and emits a structured log line:
 #   event="admin_mount_skipped" reason="nicegui_not_installed"

--- a/.claude/rules/project-overview.md
+++ b/.claude/rules/project-overview.md
@@ -1,6 +1,6 @@
 # Project Overview
 
-> Last synced: 2026-04-30 via /sync-guidelines (#10 reviewed; no project-overview surface changes)
+> Last synced: 2026-05-01 via /sync-guidelines (#154 admin JWT RBAC + #156 /docs selector revamp reviewed; no Infrastructure / Environment / App Entrypoint surface changes — admin login provider transitioned from env-var to auth-domain JWT but the entrypoint `src/_apps/admin/` is unchanged.)
 > For tech stack, refer to project-dna.md §8; for layer structure, refer to §1.
 > For the Optional infra toggle surface (env var → disabled behavior per infra), see AGENTS.md "Optional Infrastructure" + [ADR 042](../../docs/history/042-optional-infrastructure-di-pattern.md).
 > This file only contains **project-level context** not covered in project-dna.md.

--- a/.claude/rules/project-status.md
+++ b/.claude/rules/project-status.md
@@ -1,12 +1,12 @@
 # Project Status
 
-> Last synced: 2026-04-30 via /sync-guidelines (#4 JWT authentication domain)
+> Last synced: 2026-05-01 via /sync-guidelines (#154 NiceGUI admin JWT RBAC backfill, #156 /docs selector revamp + frontend handoff)
 
 ## Current Version Context
 - Latest release: v0.4.0 (2026-04-21)
-- Active domains: auth (JWT access/refresh token API, #4), user (reference domain), classification (prototype), docs (RAG consumer example, #80), ai_usage (usage ledger, #75)
+- Active domains: auth (JWT access/refresh token API, #4), user (reference domain — now carries `User.role` for minimal RBAC, #154), classification (prototype), docs (RAG consumer example, #80), ai_usage (usage ledger, #75)
 - Contributor examples: `examples/todo/` (minimal CRUD, mirrors `src/user/` layout, copy into `src/` to run — see [`examples/README.md`](../../examples/README.md))
-- Infrastructure: RDB (PostgreSQL/MySQL/SQLite), DynamoDB, Storage (S3/MinIO), S3 Vectors, InMemory Vectors (quickstart), Embedding (PydanticAI + StubEmbedder fallback), LLM (PydanticAI Agent + TestModel stub fallback via `build_stub_llm_model`), RagPipeline (+ StubAnswerAgent), Broker (SQS/RabbitMQ/InMemory), Structured logging (structlog + asgi-correlation-id), JWT auth (HS256 v1). All non-DB infras are optional via `providers.Selector` + lazy factories (ADR 042). `nicegui` lives in the `admin` extra, `boto3`/`aioboto3` in the `aws` extra (#104). NiceGUI admin still uses the existing env-var login provider.
+- Infrastructure: RDB (PostgreSQL/MySQL/SQLite), DynamoDB, Storage (S3/MinIO), S3 Vectors, InMemory Vectors (quickstart), Embedding (PydanticAI + StubEmbedder fallback), LLM (PydanticAI Agent + TestModel stub fallback via `build_stub_llm_model`), RagPipeline (+ StubAnswerAgent), Broker (SQS/RabbitMQ/InMemory), Structured logging (structlog + asgi-correlation-id), JWT auth (HS256 v1). All non-DB infras are optional via `providers.Selector` + lazy factories (ADR 042). `nicegui` lives in the `admin` extra, `boto3`/`aioboto3` in the `aws` extra (#104). NiceGUI admin login is now backed by auth-domain JWT verification + DB-backed `User.role` checks (#154); the legacy env-var provider was removed.
 
 ## Recent Major Changes (since v0.3.0)
 | Feature | Issue | Impact |
@@ -55,7 +55,9 @@
 | G Closure Linter | #145 (PR #148) | Adds `tools/check_g_closure.py` plus pre-commit / CI enforcement for governor-review-log `R-points Closure Table` shape and the three canonical closure labels from AGENTS.md guard G. |
 | AI Usage Ledger | #75 (PR #149) | Adds the `ai_usage` domain, usage recording protocol, `AgentUsageRecord` / `PromptSnapshot` value objects, RDB migrations, admin and server surfaces, and coverage for usage accounting. |
 | Taskiq Error Handling | #120 (PR #150) | Adds task-scoped structlog context binding, structured task failure logging, and permanent-aware smart retry middleware wired through worker bootstrap. |
-| JWT Authentication Domain | #4 | Adds `src/auth/` with HS256 access/refresh tokens, DB-backed refresh-token rotation/revocation, `/v1/auth/register`, `/v1/auth/login`, `/v1/auth/refresh`, `/v1/auth/logout`, `/v1/auth/me`, and Bearer protection for existing `user` API routes. NiceGUI admin auth remains env-var based pending a later RBAC/admin-auth issue. |
+| JWT Authentication Domain | #4 | Adds `src/auth/` with HS256 access/refresh tokens, DB-backed refresh-token rotation/revocation, `/v1/auth/register`, `/v1/auth/login`, `/v1/auth/refresh`, `/v1/auth/logout`, `/v1/auth/me`, and Bearer protection for existing `user` API routes. NiceGUI admin auth was env-var based at #4 landing time; superseded by #154 (PR #155) which migrated NiceGUI admin to the same auth-domain JWT credential check plus DB-backed `User.role` admin gating. |
+| NiceGUI Admin JWT + Minimal RBAC | #154 (PR #155) | Migrates the NiceGUI admin login from `ADMIN_ID` / `ADMIN_PASSWORD` to the auth-domain credential check plus DB-backed admin role checks. Adds a minimal `user.role` field (`UserRole` enum, default `USER_ROLE_USER`) and idempotent `ADMIN_BOOTSTRAP_*` admin seeding. Token-free NiceGUI session metadata (refresh tokens stay out of NiceGUI storage) preserves the #4 JWT claim shape. Server-route RBAC (per-endpoint role gating beyond admin/user) is still pending; see "Not Yet Implemented". |
+| /docs Selector Revamp + Frontend Handoff | #156 | Replaces the purple AI-styled selector with a GitHub-flavoured Minimal layout (large list rows + emoji cue + primary card accent strip) and adds a built-in light/dark toggle (`prefers-color-scheme` fallback + `localStorage` persistence + pre-paint inline script for FOUC). Adds `GET /openapi-download.json` (Content-Disposition: attachment) and `docs/frontend-handoff.md` describing the operating contract (camelCase serialization, `SuccessResponse` envelope, RDB / cursor pagination shapes, JWT auth flow, CORS, breaking-change signals, plus Postman / Bruno / Hey API / Orval recipes). Quickstart, demo scripts, and tutorial copy now point at `/docs` (selector) instead of `/docs-swagger`. The five viewer mounts (Swagger / ReDoc / Scalar / Stoplight Elements / RapiDoc) are unchanged but now guarded by `test_docs_ui_routes_serve_html`. |
 
 ## Architecture Violation Status
 - Domain → Infrastructure import: CLEAN
@@ -63,7 +65,7 @@
 - Entity pattern: CLEAN
 
 ## Not Yet Implemented
-- RBAC/Permissions
+- Server-route RBAC (per-endpoint role gating; minimal `User.role` + NiceGUI admin-only check landed in #154 (PR #155), but FastAPI route-level role enforcement / permission policy is still pending)
 - File Upload (UploadFile)
 - Rate Limiting (slowapi)
 - WebSocket

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ quickstart:
 	@echo "→ Syncing dependencies (includes admin extra for the dashboard)"
 	@uv sync --extra admin
 	@echo "→ Starting FastAPI server on http://127.0.0.1:8001"
-	@echo "  Docs:       http://127.0.0.1:8001/docs-swagger"
+	@echo "  API docs:   http://127.0.0.1:8001/docs"
 	@echo "  Admin:      http://127.0.0.1:8001/admin (admin / admin)"
 	@echo "  Run demo:   make demo  (in another terminal)"
 	@uv run python run_server_local.py --env quickstart

--- a/README.md
+++ b/README.md
@@ -68,12 +68,13 @@ In a second terminal, `make demo` exercises the `user` domain and
                   "hasNext": false, ... } }
 
 → Update the user    → Delete the user
-→ Done. Swagger UI: http://127.0.0.1:8001/docs-swagger
+→ Done. API docs: http://127.0.0.1:8001/docs
 ```
 
-- Swagger: <http://127.0.0.1:8001/docs-swagger>
+- API docs: <http://127.0.0.1:8001/docs> (Stoplight Elements & Scalar recommended; spec download + frontend handoff link on the same page)
 - Admin UI: <http://127.0.0.1:8001/admin> (`admin` / `admin`)
 - Full walkthrough: [`docs/quickstart.md`](docs/quickstart.md)
+- Frontend handoff: [`docs/frontend-handoff.md`](docs/frontend-handoff.md)
 - Real dev stack (PostgreSQL + migrations): [`docs/reference.md`](docs/reference.md#local-development-with-postgresql)
 
 ---

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -66,12 +66,13 @@ make quickstart   # :8001 에 FastAPI 기동, SQLite 스키마 자동 생성
                   "hasNext": false, ... } }
 
 → Update the user    → Delete the user
-→ Done. Swagger UI: http://127.0.0.1:8001/docs-swagger
+→ Done. API docs: http://127.0.0.1:8001/docs
 ```
 
-- Swagger: <http://127.0.0.1:8001/docs-swagger>
+- API 문서: <http://127.0.0.1:8001/docs> (Stoplight Elements / Scalar 추천; 같은 페이지에 spec download + 프론트엔드 핸드오프 링크)
 - Admin UI: <http://127.0.0.1:8001/admin> (`admin` / `admin`)
 - 전체 안내: [`docs/quickstart.md`](quickstart.md)
+- 프론트엔드 핸드오프: [`docs/frontend-handoff.md`](frontend-handoff.md)
 - 실제 개발 환경 (PostgreSQL + 마이그레이션): [`docs/reference.md`](reference.md#local-development-with-postgresql)
 
 ---

--- a/docs/ai/shared/governor-review-log/README.md
+++ b/docs/ai/shared/governor-review-log/README.md
@@ -134,3 +134,4 @@ specialisations in
 | #152 | CRUD Data Validation Sync | #10 | [pr-152-crud-data-validation-sync.md](pr-152-crud-data-validation-sync.md) |
 | #153 | JWT authentication domain | #4 | [pr-153-jwt-auth-domain.md](pr-153-jwt-auth-domain.md) |
 | #155 | NiceGUI admin JWT RBAC migration | #154 | [pr-155-nicegui-admin-jwt-rbac.md](pr-155-nicegui-admin-jwt-rbac.md) |
+| #156 | `/docs` selector revamp + frontend handoff guide + closing-gate sync | — | [pr-156-docs-selector-revamp-handoff.md](pr-156-docs-selector-revamp-handoff.md) |

--- a/docs/ai/shared/governor-review-log/pr-156-docs-selector-revamp-handoff.md
+++ b/docs/ai/shared/governor-review-log/pr-156-docs-selector-revamp-handoff.md
@@ -1,0 +1,114 @@
+# PR #156 — `/docs` Selector Revamp + Frontend Handoff Guide
+
+## Summary
+
+PR [#156](https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/156) replaces the AI-styled purple `/docs` selector with a GitHub-flavoured Minimal layout (large list rows + emoji recognition cue + primary card accent strip + light/dark toggle), adds a `GET /openapi-download.json` route returning the live spec with `Content-Disposition: attachment`, ships `docs/frontend-handoff.md` describing the operating contract that the OpenAPI spec alone cannot communicate (camelCase serialization, `SuccessResponse` envelope, JWT auth flow, RDB / cursor pagination shapes, CORS, breaking-change signals, plus Postman / Bruno / Hey API / Orval recipes), and syncs every quickstart / demo / tutorial trail (`README.md`, `docs/README.ko.md`, `docs/quickstart.md`, `docs/reference.md`, `docs/tutorial/first-domain.md`, `examples/README.md`, `Makefile`, `scripts/demo.sh`, `scripts/demo-rag.sh`) so they point at `/docs` (selector) instead of `/docs-swagger` directly. Production guard tests added: `Settings.docs_url` gating, selector body assertions, attachment download, legacy `?theme=` graceful fallthrough, and all five CDN-mounted docs UI routes.
+
+The PR is governor-changing because the closing `/sync-guidelines` step also updated `.claude/rules/architecture-conventions.md`, `.claude/rules/project-status.md`, `.claude/rules/project-overview.md`, and `.claude/rules/commands.md` (Tier A/B per `docs/ai/shared/governor-paths.md`).
+
+## Review Rounds
+
+1. **Round 0 — Design plan cross-review (codex CLI)**
+   - Target: v1 plan for the selector revamp + handoff guide before any code edits.
+   - Prompt focus: contract scope sources, dependency surfaces, security gates, route layering.
+   - Surfaced points:
+     - R0.1: PyYAML was transitive-only — adding `/openapi.yaml` would silently break unless `pyproject.toml` declared the direct dep.
+     - R0.2: Selector card pointing at `docs/frontend-handoff.md` would 404 until merged because the server does not statically serve `docs/`.
+     - R0.3: `?download=1` on the FastAPI built-in `/openapi.json` cannot flip to `Content-Disposition: attachment`.
+   - Final Verdict: minor fixes recommended → v2 plan dropped the YAML route, switched to a dedicated `/openapi-download.json`, pinned the handoff link to GitHub `main`.
+
+2. **Round 1 — First implementation cross-review (codex CLI, read-only)**
+   - Target: initial `frontend-handoff.md` draft + `/openapi-download.json` route + selector card reorder.
+   - Surfaced points:
+     - R1.1: Login response example was un-wrapped and snake_case (`access_token` at top level), but the live response is `SuccessResponse(data={"accessToken": ...})` due to the `to_camel` alias generator.
+     - R1.2: Error envelope and pagination shapes had the same camelCase / wrapper drift.
+     - R1.3: Smoke-test `jq -r '.access_token'` would not capture the token from the wrapped envelope.
+     - R1.4: Register payload was missing the required `fullName` field, so the curl example would 422.
+   - Final Verdict: block until R1.1–R1.4 fixed. Rewrote §2 of the handoff guide to mirror the actual `ApiConfig` (`alias_generator=to_camel`, `populate_by_name=True`).
+
+3. **Round 2 — Refined preview legibility cross-review (codex CLI, read-only)**
+   - Target: 4 preview themes (Brutalist / Editorial / Minimal / Mac) + Refined v1 + dispatch.
+   - Surfaced points:
+     - R2.1: Refined v1 stripped emoji because they were lumped under "AI cliché", but emoji glyphs were the actual recognition cue carrying legibility — Refined v2 must restore them.
+     - R2.2: Editorial `_editorial_row()` ignored `kind`, so primary and secondary rows rendered identically (silent hierarchy bug).
+     - R2.3: Toolbar mixed preview links + theme toggle in one helper, making cleanup ambiguous.
+     - R2.4: Container background and card background were both `var(--card)` in dark mode, flattening the surface contrast.
+   - Final Verdict: conditional pass after fixes → v2 reintroduces emoji, primary card accent strip, dark `--surface` variable, and `aria-hidden` on the icon spans.
+
+4. **Round 3 — Cleanup cross-review (codex CLI, read-only)**
+   - Target: PR after Minimal was promoted to production tone and the four preview themes plus Refined were deleted.
+   - Surfaced points:
+     - R3.1: `?theme=brutalist` URLs would silently fall through to default rather than hard-failing — graceful but should be locked by a regression test.
+     - R3.2: Five docs UI mounts (Swagger / ReDoc / Scalar / Stoplight Elements / RapiDoc) had no route guard; cleanup risk would leave one orphaned.
+     - R3.3: `frontend-handoff.md` §3 listed only four browser viewers (ReDoc missing) — drift against the live selector.
+   - Final Verdict: conditional pass → added `test_legacy_theme_query_falls_through_to_default`, parametrized `test_docs_ui_routes_serve_html`, and ReDoc back into the handoff guide.
+
+5. **Round 4 — `/sync-guidelines` cross-review (codex CLI, read-only)**
+   - Target: closing-gate sync of `.claude/rules/*` plus `project-dna` §8 evaluation against the PR #156 + #155 surface.
+   - Surfaced points:
+     - R4.1: `.claude/rules/project-status.md` #4 JWT row still claimed "NiceGUI admin auth remains env-var based" — superseded by #154 (PR #155).
+     - R4.2: `.agents/skills/sync-guidelines/SKILL.md` shipped a 5-item `Procedure` block (with the reading instruction merged into step 1) while the Claude wrapper had a 4-item `Procedure Overview` — Hybrid C drift.
+     - R4.3: Committing the sync edits onto PR #156 changes its classification from "non-governor-changing" to governor-changing because `.claude/rules/**` is Tier A/B.
+   - Final Verdict: block merge until #4 row is corrected, the agents wrapper is reshaped to match the Claude `Procedure Overview` pattern, and the governor-review-log entry plus PR template Governor section land. All three were closed in the same sync push (this entry is part of R4.3 closure).
+
+## R-points Closure Table
+
+| Source | R-point | Closure | Note |
+|---|---|---|---|
+| Round 0 | R0.1: PyYAML is transitive-only — adding `/openapi.yaml` would break unless `pyproject.toml` declared it directly | Fixed | v2 plan dropped the YAML route entirely. |
+| Round 0 | R0.2: selector card pointing at `docs/frontend-handoff.md` would 404 because the server does not statically serve `docs/` | Fixed | Card link pinned to a GitHub `main` URL. |
+| Round 0 | R0.3: `?download=1` cannot flip the FastAPI built-in `/openapi.json` to `Content-Disposition: attachment` | Fixed | Added a dedicated `/openapi-download.json` route. |
+| Round 1 | R1.1: handoff guide login example was un-wrapped + snake_case while the live response is `SuccessResponse(data={"accessToken": ...})` via `to_camel` alias | Fixed | Rewrote `frontend-handoff.md` §2 to mirror the actual `ApiConfig`. |
+| Round 1 | R1.2: error envelope and pagination shapes had the same wrapper / camelCase drift | Fixed | Fields normalised to camelCase (`errorCode`, `currentPage`, `nextCursor`). |
+| Round 1 | R1.3: smoke-test `jq -r '.access_token'` would not capture the wrapped token | Fixed | Updated to `jq -r '.data.accessToken'`. |
+| Round 1 | R1.4: register payload was missing the required `fullName` field | Fixed | Curl example completed. |
+| Round 2 | R2.1: Refined v1 stripped emoji as "AI cliché" but emoji glyphs were the actual recognition cue | Fixed | Refined v2 restored emoji + introduced `icon` field on `DOCS_CARDS` / `_handoff_cards`. |
+| Round 2 | R2.2: Editorial `_editorial_row()` ignored `kind`, so primary and secondary rendered identically | Fixed | Helper now reads `kind` and applies primary serif accent. |
+| Round 2 | R2.3: toolbar mixed preview links with theme toggle in one helper, ambiguating cleanup | Deferred-with-rationale | Cleanup removed the preview toolbar entirely; the surviving production toggle is its own concern. |
+| Round 2 | R2.4: `.container` and `.docs-card` shared `var(--card)` so dark surface contrast was flat | Fixed | Added a `--surface` variable; dark card now lifts off the canvas. |
+| Round 3 | R3.1: legacy `?theme=brutalist` URLs silently fall through to default — graceful but unguarded | Fixed | `test_legacy_theme_query_falls_through_to_default` locks the contract. |
+| Round 3 | R3.2: five docs UI mounts had no route guard; cleanup risk would orphan one | Fixed | Added parametrized `test_docs_ui_routes_serve_html`. |
+| Round 3 | R3.3: `frontend-handoff.md` §3 listed only four browser viewers (ReDoc missing) | Fixed | Browser viewer list completed. |
+| Round 4 | R4.1: `.claude/rules/project-status.md` #4 JWT row still claimed env-var admin auth, superseded by #154 | Fixed | Row updated with a superseded note. |
+| Round 4 | R4.2: `.agents/skills/sync-guidelines/SKILL.md` had a 5-item `Procedure` while Claude wrapper had a 4-item `Procedure Overview` (Hybrid C drift) | Fixed | Agents wrapper reshaped to match the Claude `Procedure Overview` pattern. |
+| Round 4 | R4.3: committing the sync edits onto PR #156 changes its classification to governor-changing | Fixed | This entry, the README index row, and the PR body Governor section closed the gate. |
+
+## Inherited Constraints
+
+- IC-156-1: The selector renderer is a single `_render_selector` helper. Theme toggle JS / FOUC-prevention inline script / aria attributes belong to the production surface; they are not preview-time scaffolding.
+- IC-156-2: `DOCS_CARDS` and `_handoff_cards()` carry an `icon` field. Renderers that omit the field MUST fall back via `.get("icon", "")` so a future card definition cannot raise `KeyError` in production traffic.
+- IC-156-3: `kind` discrimination (`primary` / `secondary`) is the canonical Recommended-vs-rest hierarchy carrier. Helpers that ignore `kind` (the Editorial regression in R2.2) are a regression class — every list-row helper must read `kind`.
+- IC-156-4: `/openapi-download.json` is dev-only by design (gated indirectly through `docs_router` registration in `bootstrap.py`). Exposing the spec in stg/prod requires an ADR — `TestDocsUrlGating` is the regression guard.
+- IC-156-5: AI-pattern clichés (`linear-gradient`, `-webkit-background-clip`, `backdrop-filter`, ChatGPT-style purple gradient palettes) MUST stay out of the selector renderer. `test_docs_selector_returns_html` greps for the three CSS clichés.
+- IC-156-6: The browser docs UI list (Swagger / ReDoc / Scalar / Stoplight Elements / RapiDoc) is referenced in three places: `docs_router.py` mounts, `docs/frontend-handoff.md` §3, and the selector card list. All three must agree — `test_docs_ui_routes_serve_html` is the route guard, but the doc and selector card list still need manual sync on every viewer addition.
+- IC-156-7 (carried from #155 IC-155-3): `ADMIN_BOOTSTRAP_*` is seed-only. Quickstart `admin / admin` is the seeded `User`, not a runtime credential channel — `commands.md` admin section MUST describe both the seed env vars and the auth-domain login path.
+
+## Self-Application Proof
+
+### `/review-architecture` equivalent (manual, not the slash skill)
+
+- Scope: `src/_core/application/routers/api/docs_router.py`, `tests/e2e/test_docs_routes.py`, `tests/unit/_core/test_config.py`, `docs/frontend-handoff.md`
+- Sources Loaded: AGENTS.md, project-dna.md §1 + §8, drift-checklist.md
+- Findings: no Domain → Infrastructure imports (selector lives in `_core/application/`), no Mapper class, no Entity pattern, no AI-pattern CSS clichés in the production renderer.
+- Drift Candidates: see Round 4 entries.
+- Sync Required: true (closed in this entry).
+
+### `/sync-guidelines` (this run)
+
+- Mode: standalone inspection
+- Input Drift Candidates: none
+- project-dna: unchanged (§8 evaluated, docs UX out of scope for the active-features axis)
+- AUTO-FIX (5 items): `project-status.md` adds rows for #154 (PR #155) and #156, refines RBAC wording, supersedes the stale `#4` admin-auth sentence; `commands.md` admin login note replaced env-var reference with auth-domain JWT + `ADMIN_BOOTSTRAP_*` seed; all four `.claude/rules/*` files have `Last synced: 2026-05-01`.
+- REVIEW (1 item): no `project-dna` §8 entry for docs selector / handoff guide — `§8` lists infra and domain capabilities, not docs UX copy. Resolution: not added.
+- Remaining: none after R4 closure.
+- Next Actions: PR #156 ready to merge once this entry, the README index row, and the PR template Governor section land in the same push.
+
+### Cross-tool review trail
+
+- 4 codex CLI reviews completed (`codex exec --sandbox read-only --skip-git-repo-check`): design plan, first implementation pass, cleanup pass, /sync-guidelines closure pass. All R-points closed via the table above; final verdict from R4 is merge-ready conditional on this artifact landing.
+
+### Verification
+
+- `uv run pytest tests/ -q --ignore=tests/unit/_core/infrastructure/persistence/nosql --ignore=tests/integration` → 651 passed / 13 skipped (the skipped surface is the AWS-extra suite that the dev shell does not have installed; the new tests are 9 of the passing count).
+- `uv run pre-commit run --all-files` → all hooks green (ruff format + check, mypy boundaries, Tier 1 language policy via `tools/check_language_policy.py`, governor closure via `tools/check_g_closure.py`).
+- `python3 tools/check_language_policy.py` → 0 violations.

--- a/docs/ai/shared/governor-review-log/pr-156-docs-selector-revamp-handoff.md
+++ b/docs/ai/shared/governor-review-log/pr-156-docs-selector-revamp-handoff.md
@@ -51,6 +51,14 @@ The PR is governor-changing because the closing `/sync-guidelines` step also upd
      - R4.3: Committing the sync edits onto PR #156 changes its classification from "non-governor-changing" to governor-changing because `.claude/rules/**` is Tier A/B.
    - Final Verdict: block merge until #4 row is corrected, the agents wrapper is reshaped to match the Claude `Procedure Overview` pattern, and the governor-review-log entry plus PR template Governor section land. All three were closed in the same sync push (this entry is part of R4.3 closure).
 
+6. **Round 5 — closure-on-closure cross-review (codex CLI, read-only)**
+   - Target: this entry, the README index row, the PR body Governor section, and the four `.claude/rules/*` files after commit 9616511.
+   - Prompt focus: Round 4 R-point closures, Inherited Constraint shape (forward-looking vs descriptive), G closure linter conformance, Tier 1 language policy, Hybrid C phase parity, orphan claims.
+   - Surfaced points:
+     - R5.1: Self-Application Proof claimed "4 codex CLI reviews" while Review Rounds enumerated Round 0-4 (5 rounds) — internal count mismatch.
+   - Verified: G closure linter passes (4-column shape, canonical labels), Tier 1 language checker passes (0 violations), Hybrid C parity restored (shared procedure 4 phases / both wrappers 4-step Procedure Overview), R4.1 + R4.2 + local half of R4.3 closed.
+   - Final Verdict: closed after the R5.1 minor fix.
+
 ## R-points Closure Table
 
 | Source | R-point | Closure | Note |
@@ -72,6 +80,7 @@ The PR is governor-changing because the closing `/sync-guidelines` step also upd
 | Round 4 | R4.1: `.claude/rules/project-status.md` #4 JWT row still claimed env-var admin auth, superseded by #154 | Fixed | Row updated with a superseded note. |
 | Round 4 | R4.2: `.agents/skills/sync-guidelines/SKILL.md` had a 5-item `Procedure` while Claude wrapper had a 4-item `Procedure Overview` (Hybrid C drift) | Fixed | Agents wrapper reshaped to match the Claude `Procedure Overview` pattern. |
 | Round 4 | R4.3: committing the sync edits onto PR #156 changes its classification to governor-changing | Fixed | This entry, the README index row, and the PR body Governor section closed the gate. |
+| Round 5 | R5.1: Self-Application Proof claimed "4 codex CLI reviews" while Review Rounds enumerate Round 0-4 (5 rounds), an internal count mismatch | Fixed | Self-Application Proof now reads "5 codex CLI rounds completed" and explicitly enumerates Round 0-4 plus the Round 5 closure-on-closure verification. |
 
 ## Inherited Constraints
 
@@ -105,7 +114,7 @@ The PR is governor-changing because the closing `/sync-guidelines` step also upd
 
 ### Cross-tool review trail
 
-- 4 codex CLI reviews completed (`codex exec --sandbox read-only --skip-git-repo-check`): design plan, first implementation pass, cleanup pass, /sync-guidelines closure pass. All R-points closed via the table above; final verdict from R4 is merge-ready conditional on this artifact landing.
+- 5 codex CLI rounds completed (`codex exec --sandbox read-only --skip-git-repo-check`): Round 0 design plan, Round 1 first implementation pass, Round 2 Refined preview legibility, Round 3 cleanup, Round 4 `/sync-guidelines` closure. Round 5 closure-on-closure review verified the artefacts in this entry, the README index row, and the PR body Governor section. All R-points closed via the table above (16 Fixed + 1 Deferred-with-rationale).
 
 ### Verification
 

--- a/docs/frontend-handoff.md
+++ b/docs/frontend-handoff.md
@@ -1,0 +1,319 @@
+# Frontend Handoff Guide
+
+This guide is for frontend engineers consuming the FastAPI backend exposed by
+this blueprint. It is intentionally **scope first, tools second** — the docs UI
+in your browser is a viewer, not a workspace. For anything that needs persisted
+inputs, tokens, or environments, import the OpenAPI spec into a real client.
+
+---
+
+## 1. TL;DR
+
+1. **Get the spec**: open `/docs` and click `Download OpenAPI (JSON)` — or fetch
+   `/api/openapi.json` directly. Save it as `openapi.json`.
+2. **Pick a client**: Postman / Bruno / Insomnia / Hoppscotch / Scalar Client.
+   Bruno is recommended when you want to commit collections to git.
+3. **Import the spec**: most clients accept the JSON file directly and produce
+   a folder of requests, including auth headers and example bodies.
+4. **(Optional) Generate a typed SDK**: run `npx @hey-api/openapi-ts` once and
+   re-run on every spec diff to keep your TypeScript client in sync.
+
+If something below disagrees with what the spec actually returns, **trust the
+spec**. This document describes the operating contract; the spec is the source
+of truth for shape.
+
+---
+
+## 2. API Contract Scope
+
+These are the operating rules that the spec alone does not communicate.
+
+### 2.1 Base URL and path prefixes
+
+| Environment | Base URL |
+|-------------|----------|
+| Quickstart / dev | `http://127.0.0.1:8001` |
+| Staging / prod   | Not defined by the blueprint — set per deployment |
+
+The FastAPI app is mounted with `root_path="/api"` and each domain router adds
+a `/v1` prefix. Two consequences:
+
+- The OpenAPI spec exposes paths as `/v1/...` with `servers: [{url: "/api"}]`.
+  Client tools that import the spec join the two and call `/api/v1/...`.
+- The dev server also accepts the un-prefixed path (`/v1/...` directly), which
+  is what the bundled `make demo` / `make demo-rag` curl scripts use.
+
+When in doubt, **use `/api/v1/...`** — that matches the spec exactly and works
+in both dev and behind a proxy.
+
+### 2.2 Wire format conventions
+
+All Request / Response models inherit a Pydantic config that:
+
+- Serializes field names as **camelCase** via `alias_generator=to_camel`
+  (`accessToken`, `refreshToken`, `errorCode`, `currentPage`, `nextCursor`, …).
+- Accepts both camelCase **and** snake_case on input
+  (`populate_by_name=True`).
+
+When you read a response, expect camelCase. When you build a request body,
+prefer camelCase to stay consistent with the spec.
+
+### 2.3 Success envelope
+
+Every successful response wraps the payload in a `SuccessResponse`:
+
+```json
+{
+  "success": true,
+  "message": "Request processed successfully",
+  "data": { "...": "..." },
+  "pagination": null
+}
+```
+
+For collection endpoints, `data` is an array and `pagination` is populated
+(see §2.6). For single-item endpoints, `data` is the object itself and
+`pagination` is `null`.
+
+### 2.4 Authentication
+
+The blueprint ships JWT auth (HS256) on the `auth` domain.
+
+| Method | Path (spec) | External call | Purpose |
+|--------|-------------|--------------|---------|
+| POST | `/v1/auth/register` | `POST /api/v1/auth/register` | Create a user account, return tokens |
+| POST | `/v1/auth/login`    | `POST /api/v1/auth/login`    | Exchange username + password for tokens |
+| POST | `/v1/auth/refresh`  | `POST /api/v1/auth/refresh`  | Rotate refresh token, issue a new access token |
+| POST | `/v1/auth/logout`   | `POST /api/v1/auth/logout`   | Revoke a refresh token |
+| GET  | `/v1/auth/me`       | `GET /api/v1/auth/me`        | Return the current user (requires `Authorization`) |
+
+**Register / Login response shape** (camelCase, wrapped):
+
+```json
+{
+  "success": true,
+  "message": "Request processed successfully",
+  "data": {
+    "accessToken": "eyJhbGciOi...",
+    "refreshToken": "eyJhbGciOi...",
+    "tokenType": "bearer",
+    "expiresIn": 900,
+    "user": { "id": 1, "username": "alice", "fullName": "Alice", "email": "alice@example.com" }
+  },
+  "pagination": null
+}
+```
+
+**Calling protected endpoints**: include the access token as a Bearer header.
+
+```http
+GET /api/v1/auth/me
+Authorization: Bearer <access_token>
+```
+
+The access token expires (see `expiresIn`, in seconds). Use
+`/api/v1/auth/refresh` with `{ "refreshToken": "..." }` to obtain a new pair
+without re-entering credentials. Refresh tokens are stored server-side and
+can be revoked individually via `logout`.
+
+### 2.5 Error envelope
+
+Every error response — whether validation, business rule, or unhandled
+exception — follows the same shape:
+
+```json
+{
+  "success": false,
+  "message": "Internal server error",
+  "errorCode": "INTERNAL_SERVER_ERROR",
+  "errorDetails": null
+}
+```
+
+For 422 validation errors, `errorDetails.errors` is an array of field-level
+problems pulled from FastAPI / pydantic. Treat `success: false` as the sole
+discriminator — do not branch on HTTP status alone.
+
+### 2.6 Pagination
+
+Two patterns coexist depending on the storage backend.
+
+**RDB domains** (offset-based, page / pageSize):
+
+```json
+{
+  "success": true,
+  "message": "Request processed successfully",
+  "data": [ { "id": 1, "...": "..." } ],
+  "pagination": {
+    "currentPage": 1,
+    "pageSize": 10,
+    "totalItems": 42,
+    "totalPages": 5,
+    "hasPrevious": false,
+    "hasNext": true,
+    "nextPage": 2,
+    "previousPage": null
+  }
+}
+```
+
+**DynamoDB domains** (cursor-based):
+
+```json
+{
+  "success": true,
+  "message": "Request processed successfully",
+  "data": [ { "id": "abc", "...": "..." } ],
+  "pagination": {
+    "nextCursor": "eyJwayI6...",
+    "pageSize": 25,
+    "hasNext": true
+  }
+}
+```
+
+Cursor pagination cannot jump pages — feed `nextCursor` back as the `cursor`
+query parameter to fetch the next page. There is no `totalItems` for cursor
+responses by design (DynamoDB does not provide cheap counts).
+
+Which domain uses which pattern is documented in the OpenAPI spec per route.
+
+### 2.7 CORS
+
+CORS origins are controlled by the `ALLOW_ORIGINS` env var on the backend
+(default `["*"]` for the blueprint). For staging / prod, expect the backend
+team to lock this down to a specific frontend origin list. If you hit
+`No 'Access-Control-Allow-Origin' header is present`, ask for that env value to
+include your origin — do not reach for a proxy as the first step.
+
+### 2.8 Breaking change signals
+
+The blueprint does not yet publish a versioned changelog beyond git history.
+Watch for:
+
+- A bump in the `/v1/...` prefix (a new prefix means a parallel breaking version)
+- Removed or renamed fields in the OpenAPI spec — a CI job that diffs
+  `openapi.json` between PRs is the cheapest way to catch this
+- Backend release notes referencing `BREAKING:` in the commit subject
+
+If you import the spec into Postman or generate an SDK, regenerate after every
+backend release to surface drift early.
+
+---
+
+## 3. Test Client Choice
+
+The browser docs UIs (Swagger / Scalar / Stoplight Elements / RapiDoc) lose
+their state on reload. For any workflow where you need to keep tokens,
+environments, or saved request bodies, use a real client. Importing the
+OpenAPI spec gives you a starting collection in any of these tools.
+
+| Tool | Persistence | Git-friendly | Self-host | OpenAPI import | Pick when |
+|------|-------------|--------------|-----------|----------------|-----------|
+| Postman        | account / cloud | no (proprietary) | no | yes | Team standard already; you want the largest ecosystem |
+| Bruno          | local files (`.bru`) | yes | desktop only | yes | You want collections versioned alongside the frontend repo |
+| Insomnia       | local | partial | self-host paid | yes | Lightweight Postman alternative, single dev |
+| Hoppscotch     | local + self-host | partial | yes (OSS) | yes | You need a self-hosted OSS web client |
+| Scalar Client  | local | no | yes | yes (docs-integrated) | You want a try-it that lives next to the docs |
+
+**Recommendation**: Bruno for new teams. Collections are plain `.bru` files, so
+you can commit them to the frontend repo, share environments via dotenv-style
+files, and review request changes in PRs the same way you review code.
+
+---
+
+## 4. TypeScript SDK Generation
+
+For a typed client that stays in sync with the backend spec, generate it from
+`openapi.json` instead of writing fetch calls by hand.
+
+### Hey API (`@hey-api/openapi-ts`)
+
+The most active 2026 generator. Used by Vercel, PayPal, and OpenCode.
+
+```bash
+npx @hey-api/openapi-ts \
+  --input http://127.0.0.1:8001/api/openapi.json \
+  --output src/api/client
+```
+
+The output includes typed services, a fetch-based client, and request/response
+schemas. Pin the exact version in `package.json` and re-run on every backend
+release to catch breaking changes at compile time.
+
+### Orval
+
+Pick this if you want generated React Query / SWR / Vue Query hooks instead of
+a raw client.
+
+```bash
+npx orval --config ./orval.config.ts
+```
+
+`orval.config.ts` points at the spec URL or the local `openapi.json` and chooses
+the framework target (`react-query`, `swr`, `vue-query`, `angular`, …).
+
+---
+
+## 5. Getting the Spec
+
+Three ways, in order of preference:
+
+1. **Browser**: open `/docs` and click `Download OpenAPI (JSON)`. The download
+   route sets `Content-Disposition: attachment`, so your browser saves a
+   real `openapi.json` file rather than rendering it.
+2. **Live URL**: clients that accept a URL can pull
+   `http://127.0.0.1:8001/api/openapi.json` directly. Useful for SDK
+   generators run in CI against a running dev server.
+3. **Repo artifact (future)**: if the backend team adopts a CI step that
+   commits `docs/openapi/openapi.json` on every release, the frontend can
+   diff it in PRs and pin SDK regeneration to a specific commit. Not yet
+   wired into this blueprint.
+
+The spec is only exposed in dev environments by default
+(`Settings.openapi_url` is `None` when `ENV=stg|prod`). For environments
+beyond dev, ask the backend team how they intend to publish the spec —
+runtime exposure, CI artifact, or auth-gated internal route.
+
+---
+
+## 6. Mock Server (Optional)
+
+If the frontend needs to start before the backend route exists, the blueprint
+does not ship a mock server, but the spec works with external mock tools:
+
+- [`@stoplight/prism`](https://github.com/stoplightio/prism) — OSS, runs from
+  the spec file (`prism mock openapi.json`)
+- Apidog / Postman mock servers — hosted, paid above the free tier
+
+Mock-first development is a frontend choice and stays out of the backend repo.
+
+---
+
+## 7. Quick Smoke Test
+
+Once you have the spec imported, the following sequence verifies your tooling
+is wired correctly against a running `make quickstart` instance. Note the
+camelCase field names and the `data.` envelope on the responses:
+
+```bash
+BASE=http://127.0.0.1:8001/api/v1
+
+# 1. Register (returns the same shape as login — accessToken in data)
+curl -sS -X POST "$BASE/auth/register" \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"alice","fullName":"Alice","email":"alice@example.com","password":"alicepass"}'
+
+# 2. Login → capture access token from data.accessToken
+TOKEN=$(curl -sS -X POST "$BASE/auth/login" \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"alice","password":"alicepass"}' | jq -r '.data.accessToken')
+
+# 3. Call a protected route
+curl -sS "$BASE/auth/me" -H "Authorization: Bearer $TOKEN"
+```
+
+If step 3 returns a `success: true` envelope with the user payload under
+`data`, your auth flow is wired correctly and you are ready to import the
+spec into your client of choice.

--- a/docs/frontend-handoff.md
+++ b/docs/frontend-handoff.md
@@ -204,7 +204,7 @@ backend release to surface drift early.
 
 ## 3. Test Client Choice
 
-The browser docs UIs (Swagger / Scalar / Stoplight Elements / RapiDoc) lose
+The browser docs UIs (Swagger / ReDoc / Scalar / Stoplight Elements / RapiDoc) lose
 their state on reload. For any workflow where you need to keep tokens,
 environments, or saved request bodies, use a real client. Importing the
 OpenAPI spec gives you a starting collection in any of these tools.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -19,10 +19,15 @@ The server comes up on `http://127.0.0.1:8001`:
 
 | Endpoint | URL |
 |----------|-----|
-| Swagger docs | http://127.0.0.1:8001/docs-swagger |
-| ReDoc        | http://127.0.0.1:8001/docs-redoc |
-| Admin UI     | http://127.0.0.1:8001/admin (admin / admin) |
-| Health       | http://127.0.0.1:8001/health |
+| API docs (selector) | http://127.0.0.1:8001/docs — Stoplight Elements / Scalar recommended |
+| OpenAPI spec        | http://127.0.0.1:8001/openapi-download.json (attachment) |
+| Swagger UI          | http://127.0.0.1:8001/docs-swagger |
+| ReDoc               | http://127.0.0.1:8001/docs-redoc |
+| Admin UI            | http://127.0.0.1:8001/admin (admin / admin) |
+| Health              | http://127.0.0.1:8001/health |
+
+For sharing the API with frontend developers, see
+[`docs/frontend-handoff.md`](frontend-handoff.md).
 
 ## Exercise the API
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -37,7 +37,9 @@ cp _env/local.env.example _env/local.env
 make dev
 ```
 
-Open <http://localhost:8000/docs-swagger> to explore the API.
+Open <http://localhost:8000/docs> to explore the API. The selector recommends
+Stoplight Elements / Scalar and exposes a `Download OpenAPI (JSON)` button
+plus a link to the [frontend handoff guide](frontend-handoff.md).
 
 For the first Alembic rollout in an environment that already has tables
 created outside Alembic, see the

--- a/docs/tutorial/first-domain.md
+++ b/docs/tutorial/first-domain.md
@@ -414,7 +414,7 @@ curl -sS -X PUT http://127.0.0.1:8001/v1/order/1 \
 curl -sS -X DELETE http://127.0.0.1:8001/v1/order/1
 ```
 
-Open <http://127.0.0.1:8001/docs-swagger> — the `Order` tag is now
+Open <http://127.0.0.1:8001/docs> (pick Swagger from the selector) — the `Order` tag is now
 listed alongside `User`. **No edits were needed in `src/_apps/`**:
 domain auto-discovery picked the new folder up.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,8 +27,9 @@ rm -f ./quickstart.db         # so the new table is created at boot
 make quickstart
 ```
 
-Swagger at <http://127.0.0.1:8001/docs-swagger> will now list the new
-tag alongside `User`. Remove the example when you are done:
+Open <http://127.0.0.1:8001/docs> and pick Swagger from the selector;
+the new tag is now listed alongside `User`. Remove the example when you
+are done:
 
 ```bash
 rm -rf src/todo

--- a/scripts/demo-rag.sh
+++ b/scripts/demo-rag.sh
@@ -89,4 +89,4 @@ QUERY_BODY='{
 }'
 run "curl -sS -X POST '${BASE_URL}/v1/docs/query' -H 'Content-Type: application/json' -d '${QUERY_BODY}' | pretty"
 
-note "Done. Swagger UI: ${BASE_URL}/docs-swagger | Admin: ${BASE_URL}/admin/docs"
+note "Done. API docs: ${BASE_URL}/docs | Admin: ${BASE_URL}/admin/docs"

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -56,4 +56,4 @@ run "curl -sS -X PUT '${BASE_URL}/v1/user/${USER_ID}' -H 'Content-Type: applicat
 note "Delete the user"
 run "curl -sS -X DELETE '${BASE_URL}/v1/user/${USER_ID}' | pretty"
 
-note "Done. Swagger UI: ${BASE_URL}/docs-swagger"
+note "Done. API docs: ${BASE_URL}/docs"

--- a/src/_core/application/routers/api/docs_router.py
+++ b/src/_core/application/routers/api/docs_router.py
@@ -8,7 +8,7 @@ HANDOFF_GUIDE_URL = (
     "/blob/main/docs/frontend-handoff.md"
 )
 
-# Card data shared by every theme renderer. Keep order stable: the first two
+# Card data shared by the selector renderer. Keep order stable: the first two
 # entries are the recommended viewers, the rest are alternates.
 DOCS_CARDS: list[dict[str, str]] = [
     {
@@ -61,9 +61,7 @@ DOCS_CARDS: list[dict[str, str]] = [
 
 def _handoff_cards(download_url: str) -> list[dict[str, str]]:
     # `kind="secondary"` keeps the Recommended visual weight reserved for the
-    # two viewer cards. Themes that read `kind` (Brutalist / Minimal / Mac /
-    # Refined) treat handoff rows as quieter; themes that ignore it are
-    # unaffected.
+    # two viewer cards; handoff actions read as quieter rows.
     return [
         {
             "key": "download",
@@ -88,462 +86,92 @@ def _handoff_cards(download_url: str) -> list[dict[str, str]]:
     ]
 
 
-VALID_THEMES = {"brutalist", "editorial", "minimal", "mac", "refined"}
-
-
 @router.get(
     "/docs",
     include_in_schema=False,
-    description="API Docs Selector - Main page for choosing among various documentation UIs",
+    description="API Docs Selector - landing page for choosing among various documentation UIs",
 )
-def docs_selector(request: Request, theme: str | None = None):
+def docs_selector(request: Request):
     root_path = request.scope.get("root_path", "")
     download_url = f"{root_path}/openapi-download.json"
     handoff_cards = _handoff_cards(download_url)
-    docs_cards = DOCS_CARDS
-
-    selected = theme if theme in VALID_THEMES else None
-    if selected == "brutalist":
-        body = _render_brutalist(docs_cards, handoff_cards)
-    elif selected == "editorial":
-        body = _render_editorial(docs_cards, handoff_cards)
-    elif selected == "minimal":
-        body = _render_minimal(docs_cards, handoff_cards)
-    elif selected == "mac":
-        body = _render_mac(docs_cards, handoff_cards)
-    elif selected == "refined":
-        body = _render_refined(docs_cards, handoff_cards)
-    else:
-        body = _render_default(docs_cards, handoff_cards)
-
-    return HTMLResponse(body)
+    return HTMLResponse(_render_selector(DOCS_CARDS, handoff_cards))
 
 
 # ---------------------------------------------------------------------------
-# Default theme — kept as the production surface from PR #156. Purple gradient,
-# rounded cards, the original "AI-pattern" look. Future cleanup will replace
-# this with whichever preview theme the user picks.
+# Selector renderer — GitHub-flavoured minimal list with light/dark themes.
+# Recommended cards lean on a left accent strip + filled badge so the two
+# primary viewers read out of the page at a glance. Theme is user-toggleable
+# (top-right button), persists in localStorage, and falls back to the system
+# preference via prefers-color-scheme. The inline pre-paint script hydrates
+# the data-theme attribute before first paint to avoid FOUC.
 # ---------------------------------------------------------------------------
 
 
-def _render_default(
+def _render_selector(
     docs_cards: list[dict[str, str]],
     handoff_cards: list[dict[str, str]],
 ) -> str:
-    return f"""
-<!doctype html>
-<html>
-  <head>
-    <meta charset="utf-8" />
-    <title>API Documentation Selector</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <style>
-      * {{ margin: 0; padding: 0; box-sizing: border-box; }}
-      body {{
-        font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-        min-height: 100vh; padding: 20px;
-        display: flex; align-items: center; justify-content: center;
-      }}
-      .container {{
-        max-width: 1000px; width: 100%;
-        background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px);
-        border-radius: 24px; padding: 60px 40px;
-        box-shadow: 0 25px 50px rgba(0, 0, 0, 0.15);
-      }}
-      .header {{ text-align: center; margin-bottom: 50px; }}
-      h1 {{
-        font-size: 3.5rem; font-weight: 700;
-        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-        -webkit-background-clip: text; -webkit-text-fill-color: transparent;
-        background-clip: text; margin-bottom: 16px; letter-spacing: -0.02em;
-      }}
-      .subtitle {{ font-size: 1.2rem; color: #64748b; max-width: 600px; margin: 0 auto; line-height: 1.6; }}
-      .docs-grid {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 24px; margin-top: 40px; }}
-      .docs-card {{
-        background: white; border-radius: 16px; padding: 32px 24px;
-        text-decoration: none; color: inherit; display: block;
-        transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-        border: 1px solid #e2e8f0; position: relative; overflow: hidden;
-      }}
-      .docs-card::before {{
-        content: ''; position: absolute; top: 0; left: 0; right: 0; height: 4px;
-        background: linear-gradient(90deg, #667eea, #764ba2);
-        transform: scaleX(0); transition: transform 0.3s ease;
-      }}
-      .docs-card:hover {{ transform: translateY(-8px); box-shadow: 0 20px 40px rgba(0,0,0,0.1); border-color: #667eea; }}
-      .docs-card:hover::before {{ transform: scaleX(1); }}
-      .docs-title {{ font-size: 1.4rem; font-weight: 600; margin-bottom: 12px; color: #1e293b; line-height: 1.3; }}
-      .docs-desc {{ color: #64748b; margin: 0; font-size: 0.95rem; line-height: 1.6; }}
-      .badge {{
-        display: inline-block; background: linear-gradient(135deg, #667eea, #764ba2); color: white;
-        padding: 4px 12px; border-radius: 20px; font-size: 0.75rem; font-weight: 500;
-        margin-top: 16px; text-transform: uppercase; letter-spacing: 0.5px;
-      }}
-      .badge.muted {{ background: #e2e8f0; color: #475569; }}
-      .handoff-section {{ margin-top: 56px; padding-top: 40px; border-top: 1px solid #e2e8f0; }}
-      .handoff-section h2 {{ font-size: 1.6rem; font-weight: 600; color: #1e293b; text-align: center; margin-bottom: 8px; }}
-      .handoff-section p.handoff-subtitle {{ text-align: center; color: #64748b; max-width: 640px; margin: 0 auto 28px; line-height: 1.6; }}
-      .handoff-grid {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 16px; }}
-      .preview-bar {{
-        position: fixed; top: 16px; right: 16px; background: rgba(255,255,255,0.95);
-        padding: 8px 12px; border-radius: 8px; font-size: 0.78rem;
-        box-shadow: 0 4px 12px rgba(0,0,0,0.1); display: flex; gap: 8px; align-items: center;
-      }}
-      .preview-bar a {{ color: #4a5568; text-decoration: none; padding: 2px 6px; border-radius: 4px; }}
-      .preview-bar a:hover {{ background: #edf2f7; }}
-      .preview-bar a.active {{ background: #667eea; color: white; }}
-    </style>
-  </head>
-  <body>
-    {_preview_bar("default")}
-    <div class="container">
-      <div class="header">
-        <h1>🚀 API Documentation</h1>
-        <p class="subtitle">
-          Choose your preferred style of API documentation below.<br>
-          Each one offers a unique set of features and user experience.
-        </p>
-      </div>
-      <div class="docs-grid">
-        {"".join(_default_card(c) for c in docs_cards)}
-      </div>
-      <section class="handoff-section">
-        <h2>📦 Share with Frontend</h2>
-        <p class="handoff-subtitle">
-          For testing flows where inputs, tokens, or environments need to persist
-          (Postman / Bruno / Insomnia / Hoppscotch / Scalar Client), hand off the
-          OpenAPI spec and let the frontend import it into their tool of choice.
-        </p>
-        <div class="handoff-grid">
-          {"".join(_default_handoff_card(c) for c in handoff_cards)}
-        </div>
-      </section>
-    </div>
-  </body>
-</html>"""
-
-
-def _default_card(card: dict[str, str]) -> str:
-    badge_class = "badge" if card["kind"] == "primary" else "badge muted"
-    icon = card.get("icon", "")
-    return f"""
-    <a href="{card["href"]}" class="docs-card">
-      <span aria-hidden="true" style="font-size:3rem; display:block; text-align:center; margin-bottom:16px;">{icon}</span>
-      <div class="docs-title" style="text-align:center;">{card["title"]}</div>
-      <p class="docs-desc" style="text-align:center;">{card["tagline"]}</p>
-      <div style="text-align:center;"><span class="{badge_class}">{card["label"]}</span></div>
-    </a>"""
-
-
-def _default_handoff_card(card: dict[str, str]) -> str:
-    target = ' target="_blank" rel="noopener"' if card["external"] == "true" else ""
-    download = " download" if card["external"] == "false" else ""
-    icon = card.get("icon", "")
-    return f"""
-    <a href="{card["href"]}" class="docs-card"{target}{download}>
-      <span aria-hidden="true" style="font-size:3rem; display:block; text-align:center; margin-bottom:16px;">{icon}</span>
-      <div class="docs-title" style="text-align:center;">{card["title"]}</div>
-      <p class="docs-desc" style="text-align:center;">{card["tagline"]}</p>
-      <div style="text-align:center;"><span class="badge">{card["label"]}</span></div>
-    </a>"""
-
-
-def _preview_bar(active: str) -> str:
-    """Render a tiny floating bar that lets the reviewer hop between previews.
-
-    The bar is preview-only. Once the redesign is picked, this helper plus
-    `?theme=` dispatch will be removed and the chosen renderer becomes the
-    sole `_render` for `/docs`.
-    """
-    items = [
-        ("default", "Current"),
-        ("brutalist", "Brutalist"),
-        ("editorial", "Editorial"),
-        ("minimal", "Minimal"),
-        ("mac", "Mac"),
-        ("refined", "Refined"),
-    ]
-    rendered = []
-    for key, label in items:
-        href = "/docs" if key == "default" else f"/docs?theme={key}"
-        klass = "active" if key == active else ""
-        rendered.append(f'<a href="{href}" class="{klass}">{label}</a>')
-    return f'<div class="preview-bar">Preview · {" ".join(rendered)}</div>'
-
-
-# ---------------------------------------------------------------------------
-# Brutalist Terminal — black background, monospace, single-line frame, no
-# gradients / shadows / emojis. Reads like a TUI panel.
-# ---------------------------------------------------------------------------
-
-
-def _render_brutalist(
-    docs_cards: list[dict[str, str]],
-    handoff_cards: list[dict[str, str]],
-) -> str:
-    rows = "\n".join(_brutalist_row(c) for c in docs_cards)
-    handoff_rows = "\n".join(_brutalist_row(c) for c in handoff_cards)
-    return f"""
-<!doctype html>
-<html>
-  <head>
-    <meta charset="utf-8" />
-    <title>fastapi-agent-blueprint :: docs</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <style>
-      * {{ margin: 0; padding: 0; box-sizing: border-box; }}
-      :root {{
-        --bg: #0a0a0a;
-        --fg: #e6e6e6;
-        --muted: #7a7a7a;
-        --border: #2a2a2a;
-        --border-hover: #4a4a4a;
-        --accent: #e6c300;
-      }}
-      body {{
-        font-family: 'JetBrains Mono', 'SF Mono', 'Menlo', 'Consolas', monospace;
-        background: var(--bg); color: var(--fg);
-        min-height: 100vh; padding: 48px 24px; line-height: 1.55;
-        font-size: 14px;
-      }}
-      .frame {{ max-width: 760px; margin: 0 auto; }}
-      .head {{ border: 1px solid var(--border); padding: 20px 24px; margin-bottom: 0; }}
-      .head .title {{ color: var(--fg); font-weight: 600; }}
-      .head .meta {{ color: var(--muted); font-size: 12px; margin-top: 4px; }}
-      .section-head {{
-        border: 1px solid var(--border); border-top: none;
-        padding: 12px 24px; color: var(--muted); font-size: 12px;
-        text-transform: uppercase; letter-spacing: 0.1em;
-      }}
-      .row {{
-        display: block; padding: 18px 24px;
-        border: 1px solid var(--border); border-top: none;
-        text-decoration: none; color: var(--fg); transition: border-color 0.12s linear;
-        position: relative;
-      }}
-      .row:hover {{ border-color: var(--border-hover); }}
-      .row.primary {{
-        border-left: 3px solid var(--accent); padding-left: 22px;
-      }}
-      .row .marker {{ color: var(--muted); margin-right: 8px; }}
-      .row.primary .marker {{ color: var(--accent); }}
-      .row .name {{ font-weight: 600; }}
-      .row.primary .name {{ color: var(--accent); }}
-      .row .desc {{ color: var(--muted); margin-top: 4px; font-size: 13px; }}
-      .row .label {{ color: var(--accent); font-size: 11px; margin-top: 8px; display: inline-block; }}
-      .row .label.muted {{ color: var(--muted); }}
-      .row.last {{ border-bottom: 1px solid var(--border); }}
-      .preview-bar {{
-        position: fixed; top: 12px; right: 12px;
-        background: var(--bg); border: 1px solid var(--border);
-        padding: 6px 10px; font-size: 12px; display: flex; gap: 6px; align-items: center;
-      }}
-      .preview-bar .lbl {{ color: var(--muted); margin-right: 4px; }}
-      .preview-bar a {{ color: var(--muted); text-decoration: none; padding: 2px 6px; }}
-      .preview-bar a:hover {{ color: var(--fg); }}
-      .preview-bar a.active {{ color: var(--accent); }}
-    </style>
-  </head>
-  <body>
-    {_preview_bar("brutalist")}
-    <div class="frame">
-      <div class="head">
-        <div class="title">fastapi-agent-blueprint :: api docs</div>
-        <div class="meta">5 viewers · 2 handoff actions · selector @ /docs</div>
-      </div>
-      <div class="section-head">viewer</div>
-{rows}
-      <div class="section-head">handoff</div>
-{handoff_rows}
-    </div>
-  </body>
-</html>"""
-
-
-def _brutalist_row(card: dict[str, str]) -> str:
-    kind = card.get("kind", "primary")
-    row_class = "row primary" if kind == "primary" else "row"
-    label_class = "label" if kind == "primary" else "label muted"
-    is_external = card.get("external", "false") == "true"
-    target = ' target="_blank" rel="noopener"' if is_external else ""
-    download = (
-        " download"
-        if card.get("external") == "false" and card["key"] == "download"
-        else ""
-    )
-    marker = "*" if kind == "primary" else "&gt;"
-    return f"""      <a class="{row_class}" href="{card["href"]}"{target}{download}>
-        <div><span class="marker" aria-hidden="true">{marker}</span><span class="name">{card["title"]}</span></div>
-        <div class="desc">{card["tagline"]}</div>
-        <div class="{label_class}">[{card["label"].lower()}]</div>
-      </a>"""
-
-
-# ---------------------------------------------------------------------------
-# Editorial / Print — cream background, serif headings, horizontal rules
-# instead of cards. Reads like a magazine table of contents.
-# ---------------------------------------------------------------------------
-
-
-def _render_editorial(
-    docs_cards: list[dict[str, str]],
-    handoff_cards: list[dict[str, str]],
-) -> str:
-    rows = "\n".join(_editorial_row(c) for c in docs_cards)
-    handoff_rows = "\n".join(_editorial_row(c) for c in handoff_cards)
-    return f"""
-<!doctype html>
-<html>
-  <head>
-    <meta charset="utf-8" />
-    <title>FastAPI Agent Blueprint — API Documentation</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="https://fonts.googleapis.com/css2?family=Newsreader:opsz,wght@6..72,400;6..72,600&family=Inter:wght@400;500&display=swap" rel="stylesheet">
-    <style>
-      * {{ margin: 0; padding: 0; box-sizing: border-box; }}
-      :root {{
-        --bg: #f7f3ec;
-        --fg: #1a1a1a;
-        --muted: #6b6353;
-        --rule: #d4cdb8;
-        --link: #1a1a1a;
-        --link-hover: #5a3d1e;
-      }}
-      body {{
-        background: var(--bg); color: var(--fg);
-        font-family: 'Inter', -apple-system, system-ui, sans-serif;
-        min-height: 100vh; padding: 80px 24px 120px; line-height: 1.6;
-      }}
-      .frame {{ max-width: 720px; margin: 0 auto; }}
-      .masthead {{ border-bottom: 1px solid var(--rule); padding-bottom: 24px; margin-bottom: 32px; }}
-      .masthead .eyebrow {{
-        font-size: 11px; text-transform: uppercase; letter-spacing: 0.18em;
-        color: var(--muted); margin-bottom: 12px;
-      }}
-      .masthead h1 {{
-        font-family: 'Newsreader', Georgia, serif;
-        font-size: 2.6rem; font-weight: 600; line-height: 1.1; letter-spacing: -0.01em;
-      }}
-      .masthead .lede {{
-        margin-top: 12px; color: var(--muted); font-size: 1.05rem; max-width: 560px;
-      }}
-      .section-title {{
-        font-family: 'Newsreader', Georgia, serif;
-        font-size: 1.2rem; font-weight: 600; margin: 48px 0 16px;
-        color: var(--fg); padding-bottom: 8px; border-bottom: 1px solid var(--rule);
-      }}
-      .row {{
-        display: block; padding: 22px 0; border-bottom: 1px solid var(--rule);
-        text-decoration: none; color: var(--link); transition: color 0.15s ease;
-      }}
-      .row:hover {{ color: var(--link-hover); }}
-      .row .row-head {{ display: flex; align-items: baseline; justify-content: space-between; gap: 16px; }}
-      .row .row-leading {{ display: flex; align-items: baseline; gap: 14px; min-width: 0; flex: 1; }}
-      .row .row-icon {{
-        font-family: 'Newsreader', Georgia, serif;
-        font-size: 1.5rem; color: var(--muted); flex-shrink: 0;
-        font-style: italic; min-width: 24px; text-align: center;
-      }}
-      .row.primary .row-icon {{ color: var(--link); font-weight: 600; font-style: normal; }}
-      .row .row-title {{
-        font-family: 'Newsreader', Georgia, serif; font-size: 1.45rem; font-weight: 600; line-height: 1.2;
-      }}
-      .row.primary .row-title {{ font-size: 1.55rem; }}
-      .row .arrow {{ color: var(--muted); font-size: 1.1rem; }}
-      .row:hover .arrow {{ color: var(--link-hover); }}
-      .row .row-desc {{ color: var(--muted); margin-top: 6px; font-size: 0.98rem; }}
-      .row .row-label {{
-        margin-top: 10px; font-size: 10px; text-transform: uppercase; letter-spacing: 0.18em;
-        color: var(--muted);
-      }}
-      .row.primary .row-label {{ color: var(--link); font-weight: 600; }}
-      .preview-bar {{
-        position: fixed; top: 16px; right: 16px;
-        background: var(--bg); border: 1px solid var(--rule);
-        padding: 6px 10px; font-size: 12px; display: flex; gap: 6px; align-items: center;
-        font-family: 'Inter', sans-serif;
-      }}
-      .preview-bar .lbl {{ color: var(--muted); margin-right: 4px; }}
-      .preview-bar a {{ color: var(--muted); text-decoration: none; padding: 2px 6px; }}
-      .preview-bar a:hover {{ color: var(--fg); }}
-      .preview-bar a.active {{ color: var(--fg); font-weight: 500; }}
-    </style>
-  </head>
-  <body>
-    {_preview_bar("editorial")}
-    <div class="frame">
-      <div class="masthead">
-        <div class="eyebrow">FastAPI Agent Blueprint · API Documentation</div>
-        <h1>Five readers, two handoffs.</h1>
-        <p class="lede">
-          The browser viewers are for reading. For the parts that need persisted
-          state — tokens, environments, request bodies — hand off the spec.
-        </p>
-      </div>
-      <div class="section-title">Viewers</div>
-{rows}
-      <div class="section-title">Handoff</div>
-{handoff_rows}
-    </div>
-  </body>
-</html>"""
-
-
-def _editorial_row(card: dict[str, str]) -> str:
-    kind = card.get("kind", "primary")
-    row_class = "row primary" if kind == "primary" else "row"
-    is_external = card.get("external", "false") == "true"
-    target = ' target="_blank" rel="noopener"' if is_external else ""
-    download = (
-        " download"
-        if card.get("external") == "false" and card["key"] == "download"
-        else ""
-    )
-    icon = card.get("icon", "")
-    return f"""      <a class="{row_class}" href="{card["href"]}"{target}{download}>
-        <div class="row-head">
-          <div class="row-leading">
-            <span class="row-icon" aria-hidden="true">{icon}</span>
-            <div class="row-title">{card["title"]}</div>
-          </div>
-          <div class="arrow">&rarr;</div>
-        </div>
-        <div class="row-desc">{card["tagline"]}</div>
-        <div class="row-label">{card["label"]}</div>
-      </a>"""
-
-
-# ---------------------------------------------------------------------------
-# Minimal Native — white background, system fonts, GitHub-flavoured 1px boxes.
-# Quiet and forgettable in the best way.
-# ---------------------------------------------------------------------------
-
-
-def _render_minimal(
-    docs_cards: list[dict[str, str]],
-    handoff_cards: list[dict[str, str]],
-) -> str:
-    rows = "\n".join(_minimal_row(c) for c in docs_cards)
-    handoff_rows = "\n".join(_minimal_row(c) for c in handoff_cards)
-    return f"""
-<!doctype html>
-<html>
+    rows = "\n".join(_selector_row(c) for c in docs_cards)
+    handoff_rows = "\n".join(_selector_row(c) for c in handoff_cards)
+    return f"""<!doctype html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <title>API Documentation — fastapi-agent-blueprint</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script>
+      (function() {{
+        try {{
+          var stored = localStorage.getItem('docs-selector-theme');
+          if (stored === 'dark' || stored === 'light') {{
+            document.documentElement.setAttribute('data-theme', stored);
+          }}
+        }} catch (e) {{ /* ignore */ }}
+      }})();
+    </script>
     <style>
-      * {{ margin: 0; padding: 0; box-sizing: border-box; }}
       :root {{
         --bg: #ffffff;
+        --surface: #ffffff;
         --fg: #0e0e10;
         --muted: #57606a;
         --border: #d0d7de;
         --border-hover: #0969da;
         --accent: #0969da;
+        --accent-fg: #ffffff;
+        --accent-soft: #ddf4ff;
+        --focus-ring: #0969da;
       }}
+      :root[data-theme="dark"] {{
+        --bg: #0d1117;
+        --surface: #161b22;
+        --fg: #e6edf3;
+        --muted: #7d8590;
+        --border: #30363d;
+        --border-hover: #58a6ff;
+        --accent: #58a6ff;
+        --accent-fg: #0d1117;
+        --accent-soft: #121d2f;
+        --focus-ring: #58a6ff;
+      }}
+      @media (prefers-color-scheme: dark) {{
+        :root:not([data-theme]) {{
+          --bg: #0d1117;
+          --surface: #161b22;
+          --fg: #e6edf3;
+          --muted: #7d8590;
+          --border: #30363d;
+          --border-hover: #58a6ff;
+          --accent: #58a6ff;
+          --accent-fg: #0d1117;
+          --accent-soft: #121d2f;
+          --focus-ring: #58a6ff;
+        }}
+      }}
+
+      * {{ margin: 0; padding: 0; box-sizing: border-box; }}
+      html, body {{ background: var(--bg); }}
       body {{
         background: var(--bg); color: var(--fg);
         font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', sans-serif;
@@ -562,6 +190,7 @@ def _render_minimal(
         display: flex; align-items: center; justify-content: space-between; gap: 16px;
         padding: 14px 16px; border: 1px solid var(--border); border-radius: 6px;
         text-decoration: none; color: var(--fg); transition: border-color 0.12s ease;
+        background: var(--surface);
       }}
       .row:hover {{ border-color: var(--border-hover); }}
       .row.primary {{
@@ -581,23 +210,40 @@ def _render_minimal(
         padding: 2px 8px; border-radius: 999px; white-space: nowrap;
       }}
       .row .label.primary {{
-        color: white; background: var(--accent); border-color: var(--accent);
+        color: var(--accent-fg); background: var(--accent); border-color: var(--accent);
       }}
       .row .arrow {{ color: var(--muted); font-size: 14px; }}
       .row:hover .arrow {{ color: var(--accent); }}
-      .preview-bar {{
-        position: fixed; top: 12px; right: 12px;
-        background: var(--bg); border: 1px solid var(--border); border-radius: 6px;
-        padding: 6px 10px; font-size: 12px; display: flex; gap: 6px; align-items: center;
+
+      .toolbar {{
+        position: fixed; top: 14px; right: 14px;
+        display: flex; gap: 4px; align-items: center;
+        background: var(--surface); border: 1px solid var(--border);
+        border-radius: 6px; padding: 4px 6px;
+        font-size: 12px; z-index: 10;
       }}
-      .preview-bar .lbl {{ color: var(--muted); margin-right: 4px; }}
-      .preview-bar a {{ color: var(--muted); text-decoration: none; padding: 2px 6px; border-radius: 3px; }}
-      .preview-bar a:hover {{ color: var(--fg); }}
-      .preview-bar a.active {{ color: var(--accent); font-weight: 500; }}
+      .toolbar button {{
+        background: transparent; border: 0; cursor: pointer;
+        color: var(--muted); padding: 4px 8px; border-radius: 3px; font: inherit;
+      }}
+      .toolbar button:hover {{ color: var(--fg); background: var(--accent-soft); }}
+
+      .row:focus-visible,
+      .toolbar button:focus-visible {{
+        outline: 2px solid var(--focus-ring); outline-offset: 2px;
+      }}
+
+      @media (max-width: 720px) {{
+        body {{ padding: 32px 16px 64px; }}
+        .toolbar {{ top: 8px; right: 8px; }}
+      }}
     </style>
   </head>
   <body>
-    {_preview_bar("minimal")}
+    <nav class="toolbar" aria-label="Theme toggle">
+      <button id="theme-toggle" type="button"
+              aria-label="Toggle light or dark theme" aria-pressed="false">Dark</button>
+    </nav>
     <div class="frame">
       <div class="head">
         <h1>API Documentation</h1>
@@ -611,436 +257,6 @@ def _render_minimal(
       <div class="list">
 {handoff_rows}
       </div>
-    </div>
-  </body>
-</html>"""
-
-
-def _minimal_row(card: dict[str, str]) -> str:
-    kind = card.get("kind", "primary")
-    row_class = "row primary" if kind == "primary" else "row"
-    label_class = "label primary" if kind == "primary" else "label"
-    is_external = card.get("external", "false") == "true"
-    target = ' target="_blank" rel="noopener"' if is_external else ""
-    download = (
-        " download"
-        if card.get("external") == "false" and card["key"] == "download"
-        else ""
-    )
-    icon = card.get("icon", "")
-    return f"""        <a class="{row_class}" href="{card["href"]}"{target}{download}>
-          <div class="row-leading">
-            <span class="row-icon" aria-hidden="true">{icon}</span>
-            <div class="row-text">
-              <div class="name">{card["title"]}</div>
-              <div class="desc">{card["tagline"]}</div>
-            </div>
-          </div>
-          <div class="row-meta">
-            <span class="{label_class}">{card["label"]}</span>
-            <span class="arrow">&rsaquo;</span>
-          </div>
-        </a>"""
-
-
-# ---------------------------------------------------------------------------
-# Mac System Native — System Settings dialog inspired. Translucent panel,
-# SF font stack, traffic-light header, compact list rows with chevrons.
-# ---------------------------------------------------------------------------
-
-
-def _render_mac(
-    docs_cards: list[dict[str, str]],
-    handoff_cards: list[dict[str, str]],
-) -> str:
-    rows = "\n".join(_mac_row(c) for c in docs_cards)
-    handoff_rows = "\n".join(_mac_row(c) for c in handoff_cards)
-    return f"""
-<!doctype html>
-<html>
-  <head>
-    <meta charset="utf-8" />
-    <title>API Documentation</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <style>
-      * {{ margin: 0; padding: 0; box-sizing: border-box; }}
-      :root {{
-        --bg: #e6e6ec;
-        --panel: rgba(246, 246, 248, 0.92);
-        --panel-border: rgba(0,0,0,0.08);
-        --fg: #1d1d1f;
-        --muted: #6b6b70;
-        --row-border: rgba(0,0,0,0.06);
-        --accent: #007aff;
-        --row-bg: rgba(255,255,255,0.6);
-      }}
-      body {{
-        background: linear-gradient(180deg, #d8d8df 0%, #ececf2 100%); color: var(--fg);
-        font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Helvetica Neue', sans-serif;
-        min-height: 100vh; padding: 48px 24px;
-        display: flex; align-items: flex-start; justify-content: center;
-        font-size: 14px;
-      }}
-      .window {{
-        max-width: 640px; width: 100%;
-        background: var(--panel); backdrop-filter: blur(20px);
-        border: 1px solid var(--panel-border); border-radius: 12px;
-        box-shadow: 0 20px 50px rgba(0,0,0,0.18), 0 1px 0 rgba(255,255,255,0.6) inset;
-        overflow: hidden;
-      }}
-      .titlebar {{
-        display: flex; align-items: center; padding: 12px 16px;
-        border-bottom: 1px solid var(--row-border); background: rgba(255,255,255,0.4);
-      }}
-      .traffic {{ display: flex; gap: 8px; }}
-      .traffic span {{ width: 12px; height: 12px; border-radius: 50%; display: block; }}
-      .traffic .red {{ background: #ff5f57; }}
-      .traffic .yellow {{ background: #febc2e; }}
-      .traffic .green {{ background: #28c840; }}
-      .titlebar .title {{ flex: 1; text-align: center; font-weight: 600; font-size: 13px; color: var(--fg); }}
-      .titlebar .spacer {{ width: 52px; }}
-      .body {{ padding: 24px 24px 28px; }}
-      .body h2 {{ font-size: 1.5rem; font-weight: 600; margin-bottom: 4px; letter-spacing: -0.01em; }}
-      .body .subtitle {{ color: var(--muted); margin-bottom: 24px; font-size: 13px; }}
-      .group {{
-        background: var(--row-bg); border: 1px solid var(--row-border); border-radius: 10px;
-        overflow: hidden; margin-bottom: 16px;
-      }}
-      .group-label {{
-        font-size: 11px; font-weight: 500; color: var(--muted);
-        text-transform: uppercase; letter-spacing: 0.06em;
-        padding: 0 4px 6px; margin-top: 8px;
-      }}
-      .row {{
-        display: flex; align-items: center; gap: 12px;
-        padding: 11px 14px; border-bottom: 1px solid var(--row-border);
-        text-decoration: none; color: var(--fg); transition: background 0.1s ease;
-      }}
-      .row:last-child {{ border-bottom: none; }}
-      .row:hover {{ background: rgba(0,122,255,0.08); }}
-      .row .row-icon {{
-        font-size: 1.6rem; line-height: 1; flex-shrink: 0;
-        width: 32px; text-align: center;
-      }}
-      .row .row-text {{ flex: 1; min-width: 0; }}
-      .row .row-text .name {{ font-weight: 500; font-size: 14px; }}
-      .row.primary .row-text .name {{ font-weight: 700; color: var(--accent); }}
-      .row .row-text .desc {{ color: var(--muted); font-size: 12px; margin-top: 1px; }}
-      .row .label {{
-        font-size: 11px; color: var(--muted); padding: 2px 8px;
-        border-radius: 5px; background: rgba(0,0,0,0.05); white-space: nowrap;
-      }}
-      .row .label.primary {{ color: white; background: var(--accent); }}
-      .row .chevron {{ color: var(--muted); font-size: 14px; flex-shrink: 0; }}
-      .preview-bar {{
-        position: fixed; top: 14px; right: 14px;
-        background: rgba(255,255,255,0.85); backdrop-filter: blur(12px);
-        border: 1px solid var(--panel-border); border-radius: 8px;
-        padding: 6px 10px; font-size: 12px; display: flex; gap: 6px; align-items: center;
-      }}
-      .preview-bar .lbl {{ color: var(--muted); margin-right: 4px; }}
-      .preview-bar a {{ color: var(--muted); text-decoration: none; padding: 2px 6px; border-radius: 4px; }}
-      .preview-bar a:hover {{ color: var(--fg); }}
-      .preview-bar a.active {{ color: white; background: var(--accent); }}
-    </style>
-  </head>
-  <body>
-    {_preview_bar("mac")}
-    <div class="window">
-      <div class="titlebar">
-        <div class="traffic">
-          <span class="red"></span><span class="yellow"></span><span class="green"></span>
-        </div>
-        <div class="title">API Documentation</div>
-        <div class="spacer"></div>
-      </div>
-      <div class="body">
-        <h2>Pick a viewer</h2>
-        <p class="subtitle">Or hand the spec off to a real client below.</p>
-        <div class="group-label">Viewers</div>
-        <div class="group">
-{rows}
-        </div>
-        <div class="group-label">Handoff</div>
-        <div class="group">
-{handoff_rows}
-        </div>
-      </div>
-    </div>
-  </body>
-</html>"""
-
-
-def _mac_row(card: dict[str, str]) -> str:
-    kind = card.get("kind", "primary")
-    row_class = "row primary" if kind == "primary" else "row"
-    label_class = "label primary" if kind == "primary" else "label"
-    is_external = card.get("external", "false") == "true"
-    target = ' target="_blank" rel="noopener"' if is_external else ""
-    download = (
-        " download"
-        if card.get("external") == "false" and card["key"] == "download"
-        else ""
-    )
-    icon = card.get("icon", "")
-    return f"""          <a class="{row_class}" href="{card["href"]}"{target}{download}>
-            <span class="row-icon" aria-hidden="true">{icon}</span>
-            <div class="row-text">
-              <div class="name">{card["title"]}</div>
-              <div class="desc">{card["tagline"]}</div>
-            </div>
-            <span class="{label_class}">{card["label"]}</span>
-            <span class="chevron">&rsaquo;</span>
-          </a>"""
-
-
-# ---------------------------------------------------------------------------
-# Refined Modern — keeps the legibility tools of the original surface (large
-# rounded cards, emoji icons as visual cues, three-column grid, strong card /
-# background contrast, hierarchy via shadow + colour badge) but strips the
-# real AI-pattern clichés: purple gradient backgrounds, gradient text via
-# -webkit-background-clip, gradient badges, frosted glass `backdrop-filter`.
-# Light + dark variants share the same structure; theme is user-toggleable
-# and persists in localStorage with a prefers-color-scheme fallback.
-# ---------------------------------------------------------------------------
-
-
-def _render_refined(
-    docs_cards: list[dict[str, str]],
-    handoff_cards: list[dict[str, str]],
-) -> str:
-    docs_grid = "".join(_refined_card(c) for c in docs_cards)
-    handoff_grid = "".join(_refined_card(c) for c in handoff_cards)
-    return f"""<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <title>API Documentation — fastapi-agent-blueprint</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <!-- theme: refined-modern -->
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <script>
-      (function() {{
-        try {{
-          var stored = localStorage.getItem('docs-selector-theme');
-          if (stored === 'dark' || stored === 'light') {{
-            document.documentElement.setAttribute('data-theme', stored);
-          }}
-        }} catch (e) {{ /* ignore */ }}
-      }})();
-    </script>
-    <style>
-      :root {{
-        --bg: #f1f5f9;
-        --card: #ffffff;
-        --title: #0f172a;
-        --desc: #475569;
-        --muted: #64748b;
-        --border: #e2e8f0;
-        --border-strong: #cbd5e1;
-        --shadow: 0 4px 12px rgba(15,23,42,0.06), 0 1px 3px rgba(15,23,42,0.04);
-        --shadow-hover: 0 16px 36px rgba(15,23,42,0.12), 0 2px 6px rgba(15,23,42,0.06);
-        --accent: #0f172a;
-        --accent-fg: #ffffff;
-        --accent-soft: #e2e8f0;
-        --muted-bg: #e2e8f0;
-        --muted-text: #475569;
-        --section-rule: #e2e8f0;
-        --focus-ring: #0f172a;
-      }}
-      :root[data-theme="dark"] {{
-        --bg: #050a18;
-        --card: #131e36;
-        --title: #f8fafc;
-        --desc: #cbd5e1;
-        --muted: #94a3b8;
-        --border: #233152;
-        --border-strong: #334155;
-        --shadow: 0 4px 12px rgba(0,0,0,0.5), 0 1px 3px rgba(0,0,0,0.3);
-        --shadow-hover: 0 16px 36px rgba(0,0,0,0.65), 0 2px 6px rgba(0,0,0,0.4);
-        --accent: #f8fafc;
-        --accent-fg: #0b1220;
-        --accent-soft: #1e2a44;
-        --muted-bg: #1e2a44;
-        --muted-text: #94a3b8;
-        --section-rule: #233152;
-        --focus-ring: #f8fafc;
-      }}
-      @media (prefers-color-scheme: dark) {{
-        :root:not([data-theme]) {{
-          --bg: #050a18;
-          --card: #131e36;
-          --title: #f8fafc;
-          --desc: #cbd5e1;
-          --muted: #94a3b8;
-          --border: #233152;
-          --border-strong: #334155;
-          --shadow: 0 4px 12px rgba(0,0,0,0.5), 0 1px 3px rgba(0,0,0,0.3);
-          --shadow-hover: 0 16px 36px rgba(0,0,0,0.65), 0 2px 6px rgba(0,0,0,0.4);
-          --accent: #f8fafc;
-          --accent-fg: #0b1220;
-          --accent-soft: #1e2a44;
-          --muted-bg: #1e2a44;
-          --muted-text: #94a3b8;
-          --section-rule: #233152;
-          --focus-ring: #f8fafc;
-        }}
-      }}
-
-      * {{ margin: 0; padding: 0; box-sizing: border-box; }}
-      html, body {{ background: var(--bg); }}
-      body {{
-        font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-        color: var(--title);
-        min-height: 100vh; padding: 64px 24px 96px;
-        line-height: 1.6;
-        display: flex; align-items: flex-start; justify-content: center;
-      }}
-      .container {{
-        width: 100%; max-width: 1000px;
-        background: transparent;
-        padding: 0;
-      }}
-      .header {{ text-align: center; margin-bottom: 44px; }}
-      h1 {{
-        font-size: 2.6rem; font-weight: 700;
-        color: var(--title);
-        margin-bottom: 12px;
-      }}
-      .subtitle {{
-        font-size: 1.05rem; color: var(--muted);
-        max-width: 560px; margin: 0 auto; line-height: 1.6;
-      }}
-
-      .docs-grid {{
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-        gap: 20px;
-      }}
-
-      .docs-card {{
-        background: var(--card);
-        border: 1px solid var(--border);
-        border-radius: 16px;
-        padding: 28px 22px 24px;
-        text-decoration: none; color: inherit;
-        display: block; text-align: center;
-        box-shadow: var(--shadow);
-        transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
-      }}
-      .docs-card:hover {{
-        transform: translateY(-4px);
-        box-shadow: var(--shadow-hover);
-        border-color: var(--accent);
-      }}
-      .card-icon {{
-        display: block;
-        font-size: 2.6rem;
-        margin-bottom: 14px;
-        line-height: 1;
-      }}
-      .card-title {{
-        font-size: 1.2rem;
-        font-weight: 600;
-        color: var(--title);
-        margin-bottom: 8px;
-        line-height: 1.3;
-      }}
-      .card-desc {{
-        color: var(--desc);
-        font-size: 0.92rem;
-        line-height: 1.55;
-        margin-bottom: 14px;
-      }}
-      .card-badge {{
-        display: inline-block;
-        font-size: 11px; font-weight: 600;
-        padding: 4px 11px; border-radius: 999px;
-        text-transform: uppercase; letter-spacing: 0.06em;
-      }}
-      .docs-card.primary .card-badge {{
-        background: var(--accent);
-        color: var(--accent-fg);
-      }}
-      .docs-card.secondary .card-badge {{
-        background: var(--muted-bg);
-        color: var(--muted-text);
-      }}
-
-      .handoff-section {{
-        margin-top: 56px; padding-top: 36px;
-        border-top: 1px solid var(--section-rule);
-      }}
-      .handoff-section h2 {{
-        font-size: 1.4rem; font-weight: 600;
-        color: var(--title); text-align: center;
-        margin-bottom: 8px;
-      }}
-      .handoff-section .handoff-subtitle {{
-        text-align: center; color: var(--muted);
-        max-width: 600px; margin: 0 auto 24px; font-size: 0.95rem;
-      }}
-      .handoff-grid {{
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-        gap: 16px;
-      }}
-
-      .toolbar {{
-        position: fixed; top: 14px; right: 14px;
-        display: flex; gap: 4px; align-items: center;
-        background: var(--card); border: 1px solid var(--border);
-        border-radius: 8px; padding: 4px 6px;
-        box-shadow: var(--shadow);
-        font-size: 12px; z-index: 10;
-      }}
-      .toolbar a, .toolbar button {{
-        background: transparent; border: 0; cursor: pointer;
-        color: var(--muted); text-decoration: none;
-        padding: 4px 8px; border-radius: 5px; font: inherit;
-      }}
-      .toolbar a:hover, .toolbar button:hover {{ color: var(--title); background: var(--accent-soft); }}
-      .toolbar a.active {{ color: var(--accent-fg); background: var(--accent); }}
-      .toolbar .sep {{ width: 1px; height: 14px; background: var(--border); margin: 0 2px; }}
-
-      .docs-card:focus-visible,
-      .toolbar a:focus-visible,
-      .toolbar button:focus-visible {{
-        outline: 2px solid var(--focus-ring); outline-offset: 2px;
-      }}
-
-      @media (max-width: 720px) {{
-        body {{ padding: 32px 16px 64px; }}
-        h1 {{ font-size: 2.1rem; }}
-        .docs-grid, .handoff-grid {{ grid-template-columns: 1fr; }}
-        .toolbar {{ top: 8px; right: 8px; }}
-        .toolbar > a, .toolbar > .sep {{ display: none; }}
-      }}
-    </style>
-  </head>
-  <body>
-    {_refined_toolbar()}
-    <div class="container">
-      <div class="header">
-        <h1>API Documentation</h1>
-        <p class="subtitle">
-          fastapi-agent-blueprint &middot; Pick a viewer or hand off the spec.
-        </p>
-      </div>
-      <div class="docs-grid">
-{docs_grid}
-      </div>
-      <section class="handoff-section">
-        <h2>Share with Frontend</h2>
-        <p class="handoff-subtitle">
-          For workflows that need persisted tokens or environments, hand the
-          spec off to a real client (Postman, Bruno, Insomnia, Hoppscotch, or
-          Scalar Client) and import it there.
-        </p>
-        <div class="handoff-grid">
-{handoff_grid}
-        </div>
-      </section>
     </div>
     <script>
       (function() {{
@@ -1069,9 +285,10 @@ def _render_refined(
 </html>"""
 
 
-def _refined_card(card: dict[str, str]) -> str:
+def _selector_row(card: dict[str, str]) -> str:
     kind = card.get("kind", "primary")
-    klass = "docs-card primary" if kind == "primary" else "docs-card secondary"
+    row_class = "row primary" if kind == "primary" else "row"
+    label_class = "label primary" if kind == "primary" else "label"
     is_external = card.get("external", "false") == "true"
     target = ' target="_blank" rel="noopener"' if is_external else ""
     download = (
@@ -1080,47 +297,23 @@ def _refined_card(card: dict[str, str]) -> str:
         else ""
     )
     icon = card.get("icon", "")
-    return f"""        <a class="{klass}" href="{card["href"]}"{target}{download}>
-          <span class="card-icon" aria-hidden="true">{icon}</span>
-          <div class="card-title">{card["title"]}</div>
-          <p class="card-desc">{card["tagline"]}</p>
-          <span class="card-badge">{card["label"]}</span>
+    return f"""        <a class="{row_class}" href="{card["href"]}"{target}{download}>
+          <div class="row-leading">
+            <span class="row-icon" aria-hidden="true">{icon}</span>
+            <div class="row-text">
+              <div class="name">{card["title"]}</div>
+              <div class="desc">{card["tagline"]}</div>
+            </div>
+          </div>
+          <div class="row-meta">
+            <span class="{label_class}">{card["label"]}</span>
+            <span class="arrow">&rsaquo;</span>
+          </div>
         </a>"""
 
 
-def _refined_toolbar() -> str:
-    """Tiny top-right bar that hosts the preview links plus the theme toggle.
-
-    Once a redesign is picked, the preview-link cluster is dropped but the
-    theme toggle stays — it is part of the final UX, not the cleanup target.
-    """
-    items = [
-        ("default", "Current"),
-        ("brutalist", "Brutalist"),
-        ("editorial", "Editorial"),
-        ("minimal", "Minimal"),
-        ("mac", "Mac"),
-        ("refined", "Refined"),
-    ]
-    links = []
-    for key, label in items:
-        href = "/docs" if key == "default" else f"/docs?theme={key}"
-        is_active = key == "refined"
-        klass = "active" if is_active else ""
-        aria = ' aria-current="page"' if is_active else ""
-        links.append(f'<a href="{href}" class="{klass}"{aria}>{label}</a>')
-    return (
-        '<nav class="toolbar" aria-label="Theme preview">'
-        + "".join(links)
-        + '<span class="sep" aria-hidden="true"></span>'
-        + '<button id="theme-toggle" type="button"'
-        ' aria-label="Toggle light or dark theme" aria-pressed="false">Dark</button>'
-        + "</nav>"
-    )
-
-
 # ---------------------------------------------------------------------------
-# Spec download + individual UI mounts (unchanged from PR #156).
+# Spec download + individual UI mounts.
 # ---------------------------------------------------------------------------
 
 

--- a/src/_core/application/routers/api/docs_router.py
+++ b/src/_core/application/routers/api/docs_router.py
@@ -1,7 +1,12 @@
 from fastapi import APIRouter, Request
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, JSONResponse
 
 router = APIRouter()
+
+HANDOFF_GUIDE_URL = (
+    "https://github.com/Mr-DooSun/fastapi-agent-blueprint"
+    "/blob/main/docs/frontend-handoff.md"
+)
 
 
 @router.get(
@@ -9,9 +14,12 @@ router = APIRouter()
     include_in_schema=False,
     description="API Docs Selector - Main page for choosing among various documentation UIs",
 )
-def docs_selector():
+def docs_selector(request: Request):
+    root_path = request.scope.get("root_path", "")
+    download_url = f"{root_path}/openapi-download.json"
+
     return HTMLResponse(
-        """
+        f"""
 <!doctype html>
 <html>
   <head>
@@ -20,13 +28,13 @@ def docs_selector():
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
-      * {
+      * {{
         margin: 0;
         padding: 0;
         box-sizing: border-box;
-      }
+      }}
 
-      body {
+      body {{
         font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
         background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
         min-height: 100vh;
@@ -34,9 +42,9 @@ def docs_selector():
         display: flex;
         align-items: center;
         justify-content: center;
-      }
+      }}
 
-      .container {
+      .container {{
         max-width: 1000px;
         width: 100%;
         background: rgba(255, 255, 255, 0.95);
@@ -44,14 +52,14 @@ def docs_selector():
         border-radius: 24px;
         padding: 60px 40px;
         box-shadow: 0 25px 50px rgba(0, 0, 0, 0.15);
-      }
+      }}
 
-      .header {
+      .header {{
         text-align: center;
         margin-bottom: 50px;
-      }
+      }}
 
-      h1 {
+      h1 {{
         font-size: 3.5rem;
         font-weight: 700;
         background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
@@ -60,25 +68,25 @@ def docs_selector():
         background-clip: text;
         margin-bottom: 16px;
         letter-spacing: -0.02em;
-      }
+      }}
 
-      .subtitle {
+      .subtitle {{
         font-size: 1.2rem;
         color: #64748b;
         font-weight: 400;
         max-width: 600px;
         margin: 0 auto;
         line-height: 1.6;
-      }
+      }}
 
-      .docs-grid {
+      .docs-grid {{
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
         gap: 24px;
         margin-top: 40px;
-      }
+      }}
 
-      .docs-card {
+      .docs-card {{
         background: white;
         border-radius: 16px;
         padding: 32px 24px;
@@ -89,9 +97,9 @@ def docs_selector():
         border: 1px solid #e2e8f0;
         position: relative;
         overflow: hidden;
-      }
+      }}
 
-      .docs-card::before {
+      .docs-card::before {{
         content: '';
         position: absolute;
         top: 0;
@@ -101,43 +109,43 @@ def docs_selector():
         background: linear-gradient(90deg, #667eea, #764ba2);
         transform: scaleX(0);
         transition: transform 0.3s ease;
-      }
+      }}
 
-      .docs-card:hover {
+      .docs-card:hover {{
         transform: translateY(-8px);
         box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);
         border-color: #667eea;
-      }
+      }}
 
-      .docs-card:hover::before {
+      .docs-card:hover::before {{
         transform: scaleX(1);
-      }
+      }}
 
-      .card-icon {
+      .card-icon {{
         font-size: 3rem;
         margin-bottom: 16px;
         display: block;
         text-align: center;
-      }
+      }}
 
-      .docs-title {
+      .docs-title {{
         font-size: 1.4rem;
         font-weight: 600;
         margin-bottom: 12px;
         color: #1e293b;
         text-align: center;
         line-height: 1.3;
-      }
+      }}
 
-      .docs-desc {
+      .docs-desc {{
         color: #64748b;
         margin: 0;
         font-size: 0.95rem;
         line-height: 1.6;
         text-align: center;
-      }
+      }}
 
-      .badge {
+      .badge {{
         display: inline-block;
         background: linear-gradient(135deg, #667eea, #764ba2);
         color: white;
@@ -148,52 +156,90 @@ def docs_selector():
         margin-top: 16px;
         text-transform: uppercase;
         letter-spacing: 0.5px;
-      }
+      }}
 
-      @media (max-width: 768px) {
-        .container {
+      .badge.muted {{
+        background: #e2e8f0;
+        color: #475569;
+      }}
+
+      .handoff-section {{
+        margin-top: 56px;
+        padding-top: 40px;
+        border-top: 1px solid #e2e8f0;
+      }}
+
+      .handoff-section h2 {{
+        font-size: 1.6rem;
+        font-weight: 600;
+        color: #1e293b;
+        text-align: center;
+        margin-bottom: 8px;
+      }}
+
+      .handoff-section p.handoff-subtitle {{
+        text-align: center;
+        color: #64748b;
+        font-size: 1rem;
+        max-width: 640px;
+        margin: 0 auto 28px;
+        line-height: 1.6;
+      }}
+
+      .handoff-grid {{
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        gap: 16px;
+      }}
+
+      @media (max-width: 768px) {{
+        .container {{
           padding: 40px 24px;
           margin: 10px;
-        }
+        }}
 
-        h1 {
+        h1 {{
           font-size: 2.5rem;
-        }
+        }}
 
-        .subtitle {
+        .subtitle {{
           font-size: 1.1rem;
-        }
+        }}
 
-        .docs-grid {
+        .docs-grid {{
           grid-template-columns: 1fr;
           gap: 16px;
-        }
+        }}
 
-        .docs-card {
+        .docs-card {{
           padding: 24px 20px;
-        }
-      }
+        }}
 
-      @keyframes fadeInUp {
-        from {
+        .handoff-grid {{
+          grid-template-columns: 1fr;
+        }}
+      }}
+
+      @keyframes fadeInUp {{
+        from {{
           opacity: 0;
           transform: translateY(30px);
-        }
-        to {
+        }}
+        to {{
           opacity: 1;
           transform: translateY(0);
-        }
-      }
+        }}
+      }}
 
-      .docs-card {
+      .docs-card {{
         animation: fadeInUp 0.6s ease forwards;
-      }
+      }}
 
-      .docs-card:nth-child(1) { animation-delay: 0.1s; }
-      .docs-card:nth-child(2) { animation-delay: 0.2s; }
-      .docs-card:nth-child(3) { animation-delay: 0.3s; }
-      .docs-card:nth-child(4) { animation-delay: 0.4s; }
-      .docs-card:nth-child(5) { animation-delay: 0.5s; }
+      .docs-card:nth-child(1) {{ animation-delay: 0.1s; }}
+      .docs-card:nth-child(2) {{ animation-delay: 0.2s; }}
+      .docs-card:nth-child(3) {{ animation-delay: 0.3s; }}
+      .docs-card:nth-child(4) {{ animation-delay: 0.4s; }}
+      .docs-card:nth-child(5) {{ animation-delay: 0.5s; }}
     </style>
   </head>
   <body>
@@ -207,6 +253,26 @@ def docs_selector():
       </div>
 
       <div class="docs-grid">
+        <a href="/api/docs-elements" class="docs-card">
+          <span class="card-icon">🎨</span>
+          <div class="docs-title">Stoplight Elements</div>
+          <p class="docs-desc">
+            An interactive, visually appealing API documentation that
+            delivers a rich user experience.
+          </p>
+          <span class="badge">Recommended — Visual</span>
+        </a>
+
+        <a href="/api/docs-scalar" class="docs-card">
+          <span class="card-icon">✨</span>
+          <div class="docs-title">Scalar API Reference</div>
+          <p class="docs-desc">
+            A modern, sophisticated API documentation with built-in
+            try-it experience that bridges into a full client.
+          </p>
+          <span class="badge">Recommended — Try-it</span>
+        </a>
+
         <a href="/api/docs-swagger" class="docs-card">
           <span class="card-icon">📚</span>
           <div class="docs-title">FastAPI Swagger UI</div>
@@ -214,7 +280,7 @@ def docs_selector():
             The most widely used API documentation format, offering an
             intuitive interface with full-featured functionality.
           </p>
-          <span class="badge">Recommended</span>
+          <span class="badge muted">Compatibility</span>
         </a>
 
         <a href="/api/docs-redoc" class="docs-card">
@@ -224,27 +290,7 @@ def docs_selector():
             A clean, readable, documentation-focused design that lets
             you explore API specifications in a well-organized manner.
           </p>
-          <span class="badge">Clean</span>
-        </a>
-
-        <a href="/api/docs-scalar" class="docs-card">
-          <span class="card-icon">✨</span>
-          <div class="docs-title">Scalar API Reference</div>
-          <p class="docs-desc">
-            A modern, sophisticated API documentation with
-            developer-friendly features.
-          </p>
-          <span class="badge">Modern</span>
-        </a>
-
-        <a href="/api/docs-elements" class="docs-card">
-          <span class="card-icon">🎨</span>
-          <div class="docs-title">Stoplight Elements</div>
-          <p class="docs-desc">
-            An interactive, visually appealing API documentation that
-            delivers a rich user experience.
-          </p>
-          <span class="badge">Interactive</span>
+          <span class="badge muted">Clean</span>
         </a>
 
         <a href="/api/docs-rapidoc" class="docs-card">
@@ -254,12 +300,55 @@ def docs_selector():
             A fast, lightweight API documentation that provides
             a simple yet efficient interface.
           </p>
-          <span class="badge">Fast</span>
+          <span class="badge muted">Fast</span>
         </a>
       </div>
+
+      <section class="handoff-section">
+        <h2>📦 Share with Frontend</h2>
+        <p class="handoff-subtitle">
+          For testing flows where inputs, tokens, or environments need to persist
+          (Postman / Bruno / Insomnia / Hoppscotch / Scalar Client), hand off the
+          OpenAPI spec and let the frontend import it into their tool of choice.
+        </p>
+        <div class="handoff-grid">
+          <a href="{download_url}" class="docs-card" download>
+            <span class="card-icon">⬇️</span>
+            <div class="docs-title">Download OpenAPI (JSON)</div>
+            <p class="docs-desc">
+              Save the live spec as <code>openapi.json</code> and import it into
+              Postman, Bruno, or any OpenAPI-aware client.
+            </p>
+            <span class="badge">Spec</span>
+          </a>
+
+          <a href="{HANDOFF_GUIDE_URL}" class="docs-card" target="_blank" rel="noopener">
+            <span class="card-icon">🧭</span>
+            <div class="docs-title">Frontend Handoff Guide</div>
+            <p class="docs-desc">
+              Contract scope (auth, errors, pagination, CORS), test client
+              comparison, and TypeScript SDK generation recipes.
+            </p>
+            <span class="badge">Guide</span>
+          </a>
+        </div>
+      </section>
     </div>
   </body>
 </html>"""
+    )
+
+
+@router.get(
+    "/openapi-download.json",
+    include_in_schema=False,
+    description="OpenAPI spec download with attachment Content-Disposition for frontend handoff",
+)
+def openapi_download(request: Request):
+    spec = request.app.openapi()
+    return JSONResponse(
+        content=spec,
+        headers={"Content-Disposition": 'attachment; filename="openapi.json"'},
     )
 
 

--- a/src/_core/application/routers/api/docs_router.py
+++ b/src/_core/application/routers/api/docs_router.py
@@ -18,6 +18,7 @@ DOCS_CARDS: list[dict[str, str]] = [
         "tagline": "Interactive, three-pane reader. Best for browsing.",
         "label": "Recommended — Visual",
         "kind": "primary",
+        "icon": "🎨",
     },
     {
         "key": "scalar",
@@ -26,6 +27,7 @@ DOCS_CARDS: list[dict[str, str]] = [
         "tagline": "Modern reference with try-it that bridges into a client.",
         "label": "Recommended — Try-it",
         "kind": "primary",
+        "icon": "✨",
     },
     {
         "key": "swagger",
@@ -34,6 +36,7 @@ DOCS_CARDS: list[dict[str, str]] = [
         "tagline": "FastAPI's bundled default. Familiar to most teams.",
         "label": "Compatibility",
         "kind": "secondary",
+        "icon": "📚",
     },
     {
         "key": "redoc",
@@ -42,6 +45,7 @@ DOCS_CARDS: list[dict[str, str]] = [
         "tagline": "Documentation-first three-panel layout.",
         "label": "Clean",
         "kind": "secondary",
+        "icon": "📖",
     },
     {
         "key": "rapidoc",
@@ -50,6 +54,7 @@ DOCS_CARDS: list[dict[str, str]] = [
         "tagline": "Lightweight viewer. Fast initial load.",
         "label": "Fast",
         "kind": "secondary",
+        "icon": "⚡",
     },
 ]
 
@@ -68,6 +73,7 @@ def _handoff_cards(download_url: str) -> list[dict[str, str]]:
             "label": "Spec",
             "external": "false",
             "kind": "secondary",
+            "icon": "⬇️",
         },
         {
             "key": "handoff",
@@ -77,6 +83,7 @@ def _handoff_cards(download_url: str) -> list[dict[str, str]]:
             "label": "Guide",
             "external": "true",
             "kind": "secondary",
+            "icon": "🧭",
         },
     ]
 
@@ -200,11 +207,7 @@ def _render_default(
         </p>
       </div>
       <div class="docs-grid">
-        {_default_card(docs_cards[0], "🎨")}
-        {_default_card(docs_cards[1], "✨")}
-        {_default_card(docs_cards[2], "📚")}
-        {_default_card(docs_cards[3], "📖")}
-        {_default_card(docs_cards[4], "⚡")}
+        {"".join(_default_card(c) for c in docs_cards)}
       </div>
       <section class="handoff-section">
         <h2>📦 Share with Frontend</h2>
@@ -214,8 +217,7 @@ def _render_default(
           OpenAPI spec and let the frontend import it into their tool of choice.
         </p>
         <div class="handoff-grid">
-          {_default_handoff_card(handoff_cards[0], "⬇️")}
-          {_default_handoff_card(handoff_cards[1], "🧭")}
+          {"".join(_default_handoff_card(c) for c in handoff_cards)}
         </div>
       </section>
     </div>
@@ -223,23 +225,25 @@ def _render_default(
 </html>"""
 
 
-def _default_card(card: dict[str, str], icon: str) -> str:
+def _default_card(card: dict[str, str]) -> str:
     badge_class = "badge" if card["kind"] == "primary" else "badge muted"
+    icon = card.get("icon", "")
     return f"""
     <a href="{card["href"]}" class="docs-card">
-      <span style="font-size:3rem; display:block; text-align:center; margin-bottom:16px;">{icon}</span>
+      <span aria-hidden="true" style="font-size:3rem; display:block; text-align:center; margin-bottom:16px;">{icon}</span>
       <div class="docs-title" style="text-align:center;">{card["title"]}</div>
       <p class="docs-desc" style="text-align:center;">{card["tagline"]}</p>
       <div style="text-align:center;"><span class="{badge_class}">{card["label"]}</span></div>
     </a>"""
 
 
-def _default_handoff_card(card: dict[str, str], icon: str) -> str:
+def _default_handoff_card(card: dict[str, str]) -> str:
     target = ' target="_blank" rel="noopener"' if card["external"] == "true" else ""
     download = " download" if card["external"] == "false" else ""
+    icon = card.get("icon", "")
     return f"""
     <a href="{card["href"]}" class="docs-card"{target}{download}>
-      <span style="font-size:3rem; display:block; text-align:center; margin-bottom:16px;">{icon}</span>
+      <span aria-hidden="true" style="font-size:3rem; display:block; text-align:center; margin-bottom:16px;">{icon}</span>
       <div class="docs-title" style="text-align:center;">{card["title"]}</div>
       <p class="docs-desc" style="text-align:center;">{card["tagline"]}</p>
       <div style="text-align:center;"><span class="badge">{card["label"]}</span></div>
@@ -745,11 +749,13 @@ def _mac_row(card: dict[str, str]) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Refined Modern — keeps the legibility tools of a card grid (rounded card +
-# soft shadow + hierarchy + solid colour accent) but strips the AI-pattern
-# clichés (purple gradient, gradient text, emoji icons, frosted glass blur).
-# Light + dark variants, with a manual toggle that respects prefers-color-scheme
-# and persists to localStorage.
+# Refined Modern — keeps the legibility tools of the original surface (large
+# rounded cards, emoji icons as visual cues, three-column grid, strong card /
+# background contrast, hierarchy via shadow + colour badge) but strips the
+# real AI-pattern clichés: purple gradient backgrounds, gradient text via
+# -webkit-background-clip, gradient badges, frosted glass `backdrop-filter`.
+# Light + dark variants share the same structure; theme is user-toggleable
+# and persists in localStorage with a prefers-color-scheme fallback.
 # ---------------------------------------------------------------------------
 
 
@@ -757,74 +763,80 @@ def _render_refined(
     docs_cards: list[dict[str, str]],
     handoff_cards: list[dict[str, str]],
 ) -> str:
-    docs_rows = "\n".join(_refined_card(c) for c in docs_cards)
-    handoff_rows = "\n".join(_refined_card(c) for c in handoff_cards)
-    return f"""
-<!doctype html>
+    docs_grid = "".join(_refined_card(c) for c in docs_cards)
+    handoff_grid = "".join(_refined_card(c) for c in handoff_cards)
+    return f"""<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
     <title>API Documentation — fastapi-agent-blueprint</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- theme: refined-modern -->
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script>
-      // Run before paint to avoid flash of unstyled theme. Reads localStorage
-      // first; falls back to OS prefers-color-scheme. Mirrors the toggle JS
-      // below but kept inline-early because deferred listeners would flicker.
       (function() {{
         try {{
           var stored = localStorage.getItem('docs-selector-theme');
           if (stored === 'dark' || stored === 'light') {{
             document.documentElement.setAttribute('data-theme', stored);
           }}
-        }} catch (e) {{ /* localStorage blocked — fall back to media query */ }}
+        }} catch (e) {{ /* ignore */ }}
       }})();
     </script>
     <style>
       :root {{
         --bg: #f1f5f9;
-        --surface: #ffffff;
+        --card: #ffffff;
         --title: #0f172a;
         --desc: #475569;
         --muted: #64748b;
         --border: #e2e8f0;
         --border-strong: #cbd5e1;
-        --shadow: 0 1px 2px rgba(15,23,42,0.06), 0 4px 12px rgba(15,23,42,0.04);
-        --shadow-hover: 0 2px 4px rgba(15,23,42,0.08), 0 12px 24px rgba(15,23,42,0.08);
+        --shadow: 0 4px 12px rgba(15,23,42,0.06), 0 1px 3px rgba(15,23,42,0.04);
+        --shadow-hover: 0 16px 36px rgba(15,23,42,0.12), 0 2px 6px rgba(15,23,42,0.06);
         --accent: #0f172a;
         --accent-fg: #ffffff;
-        --accent-soft: #f1f5f9;
+        --accent-soft: #e2e8f0;
+        --muted-bg: #e2e8f0;
+        --muted-text: #475569;
+        --section-rule: #e2e8f0;
         --focus-ring: #0f172a;
       }}
       :root[data-theme="dark"] {{
-        --bg: #0b1220;
-        --surface: #111a2e;
+        --bg: #050a18;
+        --card: #131e36;
         --title: #f8fafc;
         --desc: #cbd5e1;
         --muted: #94a3b8;
-        --border: #1e2a44;
+        --border: #233152;
         --border-strong: #334155;
-        --shadow: 0 1px 2px rgba(0,0,0,0.4), 0 4px 12px rgba(0,0,0,0.25);
-        --shadow-hover: 0 2px 4px rgba(0,0,0,0.5), 0 12px 24px rgba(0,0,0,0.35);
+        --shadow: 0 4px 12px rgba(0,0,0,0.5), 0 1px 3px rgba(0,0,0,0.3);
+        --shadow-hover: 0 16px 36px rgba(0,0,0,0.65), 0 2px 6px rgba(0,0,0,0.4);
         --accent: #f8fafc;
         --accent-fg: #0b1220;
         --accent-soft: #1e2a44;
+        --muted-bg: #1e2a44;
+        --muted-text: #94a3b8;
+        --section-rule: #233152;
         --focus-ring: #f8fafc;
       }}
       @media (prefers-color-scheme: dark) {{
         :root:not([data-theme]) {{
-          --bg: #0b1220;
-          --surface: #111a2e;
+          --bg: #050a18;
+          --card: #131e36;
           --title: #f8fafc;
           --desc: #cbd5e1;
           --muted: #94a3b8;
-          --border: #1e2a44;
+          --border: #233152;
           --border-strong: #334155;
-          --shadow: 0 1px 2px rgba(0,0,0,0.4), 0 4px 12px rgba(0,0,0,0.25);
-          --shadow-hover: 0 2px 4px rgba(0,0,0,0.5), 0 12px 24px rgba(0,0,0,0.35);
+          --shadow: 0 4px 12px rgba(0,0,0,0.5), 0 1px 3px rgba(0,0,0,0.3);
+          --shadow-hover: 0 16px 36px rgba(0,0,0,0.65), 0 2px 6px rgba(0,0,0,0.4);
           --accent: #f8fafc;
           --accent-fg: #0b1220;
           --accent-soft: #1e2a44;
+          --muted-bg: #1e2a44;
+          --muted-text: #94a3b8;
+          --section-rule: #233152;
           --focus-ring: #f8fafc;
         }}
       }}
@@ -832,76 +844,108 @@ def _render_refined(
       * {{ margin: 0; padding: 0; box-sizing: border-box; }}
       html, body {{ background: var(--bg); }}
       body {{
-        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Inter', Roboto, sans-serif;
+        font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
         color: var(--title);
-        min-height: 100vh; padding: 64px 24px 96px; line-height: 1.5;
-        font-size: 15px;
+        min-height: 100vh; padding: 64px 24px 96px;
+        line-height: 1.6;
+        display: flex; align-items: flex-start; justify-content: center;
       }}
-      .frame {{ max-width: 960px; margin: 0 auto; }}
-      .head {{ margin-bottom: 32px; }}
-      .head h1 {{
-        font-size: 1.9rem; font-weight: 600; letter-spacing: -0.01em;
-        color: var(--title); margin-bottom: 6px;
+      .container {{
+        width: 100%; max-width: 1000px;
+        background: transparent;
+        padding: 0;
       }}
-      .head .meta {{ color: var(--muted); font-size: 0.95rem; }}
-
-      .section-label {{
-        font-size: 11px; font-weight: 600; color: var(--muted);
-        text-transform: uppercase; letter-spacing: 0.08em;
-        margin: 32px 0 12px;
-      }}
-      .grid {{
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-        gap: 16px;
-      }}
-
-      .card {{
-        position: relative;
-        display: block; padding: 20px 22px 18px;
-        background: var(--surface); color: inherit;
-        border: 1px solid var(--border); border-radius: 12px;
-        text-decoration: none; box-shadow: var(--shadow);
-        transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
-        overflow: hidden;
-      }}
-      .card:hover {{
-        border-color: var(--border-strong);
-        box-shadow: var(--shadow-hover);
-        transform: translateY(-2px);
-      }}
-      .card.primary {{ border-color: transparent; }}
-      .card.primary::before {{
-        content: ''; position: absolute; left: 0; top: 0; bottom: 0; width: 4px;
-        background: var(--accent);
-      }}
-      .card.primary:hover {{ border-color: transparent; }}
-      .card-title {{
-        font-size: 1.05rem; font-weight: 600; color: var(--title);
-        margin-bottom: 4px; line-height: 1.3;
-      }}
-      .card-desc {{
-        color: var(--desc); font-size: 0.9rem; line-height: 1.5;
+      .header {{ text-align: center; margin-bottom: 44px; }}
+      h1 {{
+        font-size: 2.6rem; font-weight: 700;
+        color: var(--title);
         margin-bottom: 12px;
       }}
+      .subtitle {{
+        font-size: 1.05rem; color: var(--muted);
+        max-width: 560px; margin: 0 auto; line-height: 1.6;
+      }}
+
+      .docs-grid {{
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        gap: 20px;
+      }}
+
+      .docs-card {{
+        background: var(--card);
+        border: 1px solid var(--border);
+        border-radius: 16px;
+        padding: 28px 22px 24px;
+        text-decoration: none; color: inherit;
+        display: block; text-align: center;
+        box-shadow: var(--shadow);
+        transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+      }}
+      .docs-card:hover {{
+        transform: translateY(-4px);
+        box-shadow: var(--shadow-hover);
+        border-color: var(--accent);
+      }}
+      .card-icon {{
+        display: block;
+        font-size: 2.6rem;
+        margin-bottom: 14px;
+        line-height: 1;
+      }}
+      .card-title {{
+        font-size: 1.2rem;
+        font-weight: 600;
+        color: var(--title);
+        margin-bottom: 8px;
+        line-height: 1.3;
+      }}
+      .card-desc {{
+        color: var(--desc);
+        font-size: 0.92rem;
+        line-height: 1.55;
+        margin-bottom: 14px;
+      }}
       .card-badge {{
-        display: inline-block; font-size: 11px; font-weight: 600;
-        padding: 3px 9px; border-radius: 999px;
-        text-transform: uppercase; letter-spacing: 0.04em;
+        display: inline-block;
+        font-size: 11px; font-weight: 600;
+        padding: 4px 11px; border-radius: 999px;
+        text-transform: uppercase; letter-spacing: 0.06em;
       }}
-      .card.primary .card-badge {{
-        background: var(--accent); color: var(--accent-fg);
+      .docs-card.primary .card-badge {{
+        background: var(--accent);
+        color: var(--accent-fg);
       }}
-      .card.secondary .card-badge {{
-        background: transparent; color: var(--muted);
-        border: 1px solid var(--border-strong);
+      .docs-card.secondary .card-badge {{
+        background: var(--muted-bg);
+        color: var(--muted-text);
+      }}
+
+      .handoff-section {{
+        margin-top: 56px; padding-top: 36px;
+        border-top: 1px solid var(--section-rule);
+      }}
+      .handoff-section h2 {{
+        font-size: 1.4rem; font-weight: 600;
+        color: var(--title); text-align: center;
+        margin-bottom: 8px;
+      }}
+      .handoff-section .handoff-subtitle {{
+        text-align: center; color: var(--muted);
+        max-width: 600px; margin: 0 auto 24px; font-size: 0.95rem;
+      }}
+      .handoff-grid {{
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        gap: 16px;
       }}
 
       .toolbar {{
         position: fixed; top: 14px; right: 14px;
-        display: flex; gap: 6px; align-items: center;
-        background: var(--surface); border: 1px solid var(--border);
-        border-radius: 8px; padding: 4px 6px; box-shadow: var(--shadow);
+        display: flex; gap: 4px; align-items: center;
+        background: var(--card); border: 1px solid var(--border);
+        border-radius: 8px; padding: 4px 6px;
+        box-shadow: var(--shadow);
         font-size: 12px; z-index: 10;
       }}
       .toolbar a, .toolbar button {{
@@ -913,38 +957,44 @@ def _render_refined(
       .toolbar a.active {{ color: var(--accent-fg); background: var(--accent); }}
       .toolbar .sep {{ width: 1px; height: 14px; background: var(--border); margin: 0 2px; }}
 
-      .card:focus-visible,
+      .docs-card:focus-visible,
       .toolbar a:focus-visible,
       .toolbar button:focus-visible {{
-        outline: 2px solid var(--focus-ring);
-        outline-offset: 2px;
+        outline: 2px solid var(--focus-ring); outline-offset: 2px;
       }}
 
       @media (max-width: 720px) {{
         body {{ padding: 32px 16px 64px; }}
-        .grid {{ grid-template-columns: 1fr; }}
+        h1 {{ font-size: 2.1rem; }}
+        .docs-grid, .handoff-grid {{ grid-template-columns: 1fr; }}
         .toolbar {{ top: 8px; right: 8px; }}
-        /* Preview-only links are hidden on small screens to keep the toggle
-           reachable. Final cleanup will remove them entirely. */
         .toolbar > a, .toolbar > .sep {{ display: none; }}
       }}
     </style>
   </head>
   <body>
     {_refined_toolbar()}
-    <div class="frame">
-      <div class="head">
+    <div class="container">
+      <div class="header">
         <h1>API Documentation</h1>
-        <div class="meta">fastapi-agent-blueprint · Pick a viewer or hand off the spec.</div>
+        <p class="subtitle">
+          fastapi-agent-blueprint &middot; Pick a viewer or hand off the spec.
+        </p>
       </div>
-      <div class="section-label">Viewers</div>
-      <div class="grid">
-{docs_rows}
+      <div class="docs-grid">
+{docs_grid}
       </div>
-      <div class="section-label">Share with frontend</div>
-      <div class="grid">
-{handoff_rows}
-      </div>
+      <section class="handoff-section">
+        <h2>Share with Frontend</h2>
+        <p class="handoff-subtitle">
+          For workflows that need persisted tokens or environments, hand the
+          spec off to a real client (Postman, Bruno, Insomnia, Hoppscotch, or
+          Scalar Client) and import it there.
+        </p>
+        <div class="handoff-grid">
+{handoff_grid}
+        </div>
+      </section>
     </div>
     <script>
       (function() {{
@@ -975,7 +1025,7 @@ def _render_refined(
 
 def _refined_card(card: dict[str, str]) -> str:
     kind = card.get("kind", "primary")
-    klass = "card primary" if kind == "primary" else "card secondary"
+    klass = "docs-card primary" if kind == "primary" else "docs-card secondary"
     is_external = card.get("external", "false") == "true"
     target = ' target="_blank" rel="noopener"' if is_external else ""
     download = (
@@ -983,9 +1033,11 @@ def _refined_card(card: dict[str, str]) -> str:
         if card.get("external") == "false" and card["key"] == "download"
         else ""
     )
+    icon = card.get("icon", "")
     return f"""        <a class="{klass}" href="{card["href"]}"{target}{download}>
+          <span class="card-icon" aria-hidden="true">{icon}</span>
           <div class="card-title">{card["title"]}</div>
-          <div class="card-desc">{card["tagline"]}</div>
+          <p class="card-desc">{card["tagline"]}</p>
           <span class="card-badge">{card["label"]}</span>
         </a>"""
 

--- a/src/_core/application/routers/api/docs_router.py
+++ b/src/_core/application/routers/api/docs_router.py
@@ -55,6 +55,10 @@ DOCS_CARDS: list[dict[str, str]] = [
 
 
 def _handoff_cards(download_url: str) -> list[dict[str, str]]:
+    # `kind="secondary"` keeps the Recommended visual weight reserved for the
+    # two viewer cards. Themes that read `kind` (Brutalist / Minimal / Mac /
+    # Refined) treat handoff rows as quieter; themes that ignore it are
+    # unaffected.
     return [
         {
             "key": "download",
@@ -63,6 +67,7 @@ def _handoff_cards(download_url: str) -> list[dict[str, str]]:
             "tagline": "Save the live spec as openapi.json for Postman, Bruno, or any client.",
             "label": "Spec",
             "external": "false",
+            "kind": "secondary",
         },
         {
             "key": "handoff",
@@ -71,11 +76,12 @@ def _handoff_cards(download_url: str) -> list[dict[str, str]]:
             "tagline": "Contract scope, test client comparison, and TypeScript SDK recipes.",
             "label": "Guide",
             "external": "true",
+            "kind": "secondary",
         },
     ]
 
 
-VALID_THEMES = {"brutalist", "editorial", "minimal", "mac"}
+VALID_THEMES = {"brutalist", "editorial", "minimal", "mac", "refined"}
 
 
 @router.get(
@@ -98,6 +104,8 @@ def docs_selector(request: Request, theme: str | None = None):
         body = _render_minimal(docs_cards, handoff_cards)
     elif selected == "mac":
         body = _render_mac(docs_cards, handoff_cards)
+    elif selected == "refined":
+        body = _render_refined(docs_cards, handoff_cards)
     else:
         body = _render_default(docs_cards, handoff_cards)
 
@@ -251,6 +259,7 @@ def _preview_bar(active: str) -> str:
         ("editorial", "Editorial"),
         ("minimal", "Minimal"),
         ("mac", "Mac"),
+        ("refined", "Refined"),
     ]
     rendered = []
     for key, label in items:
@@ -733,6 +742,283 @@ def _mac_row(card: dict[str, str]) -> str:
             <span class="{label_class}">{card["label"]}</span>
             <span class="chevron">&rsaquo;</span>
           </a>"""
+
+
+# ---------------------------------------------------------------------------
+# Refined Modern — keeps the legibility tools of a card grid (rounded card +
+# soft shadow + hierarchy + solid colour accent) but strips the AI-pattern
+# clichés (purple gradient, gradient text, emoji icons, frosted glass blur).
+# Light + dark variants, with a manual toggle that respects prefers-color-scheme
+# and persists to localStorage.
+# ---------------------------------------------------------------------------
+
+
+def _render_refined(
+    docs_cards: list[dict[str, str]],
+    handoff_cards: list[dict[str, str]],
+) -> str:
+    docs_rows = "\n".join(_refined_card(c) for c in docs_cards)
+    handoff_rows = "\n".join(_refined_card(c) for c in handoff_cards)
+    return f"""
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>API Documentation — fastapi-agent-blueprint</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <!-- theme: refined-modern -->
+    <script>
+      // Run before paint to avoid flash of unstyled theme. Reads localStorage
+      // first; falls back to OS prefers-color-scheme. Mirrors the toggle JS
+      // below but kept inline-early because deferred listeners would flicker.
+      (function() {{
+        try {{
+          var stored = localStorage.getItem('docs-selector-theme');
+          if (stored === 'dark' || stored === 'light') {{
+            document.documentElement.setAttribute('data-theme', stored);
+          }}
+        }} catch (e) {{ /* localStorage blocked — fall back to media query */ }}
+      }})();
+    </script>
+    <style>
+      :root {{
+        --bg: #f1f5f9;
+        --surface: #ffffff;
+        --title: #0f172a;
+        --desc: #475569;
+        --muted: #64748b;
+        --border: #e2e8f0;
+        --border-strong: #cbd5e1;
+        --shadow: 0 1px 2px rgba(15,23,42,0.06), 0 4px 12px rgba(15,23,42,0.04);
+        --shadow-hover: 0 2px 4px rgba(15,23,42,0.08), 0 12px 24px rgba(15,23,42,0.08);
+        --accent: #0f172a;
+        --accent-fg: #ffffff;
+        --accent-soft: #f1f5f9;
+        --focus-ring: #0f172a;
+      }}
+      :root[data-theme="dark"] {{
+        --bg: #0b1220;
+        --surface: #111a2e;
+        --title: #f8fafc;
+        --desc: #cbd5e1;
+        --muted: #94a3b8;
+        --border: #1e2a44;
+        --border-strong: #334155;
+        --shadow: 0 1px 2px rgba(0,0,0,0.4), 0 4px 12px rgba(0,0,0,0.25);
+        --shadow-hover: 0 2px 4px rgba(0,0,0,0.5), 0 12px 24px rgba(0,0,0,0.35);
+        --accent: #f8fafc;
+        --accent-fg: #0b1220;
+        --accent-soft: #1e2a44;
+        --focus-ring: #f8fafc;
+      }}
+      @media (prefers-color-scheme: dark) {{
+        :root:not([data-theme]) {{
+          --bg: #0b1220;
+          --surface: #111a2e;
+          --title: #f8fafc;
+          --desc: #cbd5e1;
+          --muted: #94a3b8;
+          --border: #1e2a44;
+          --border-strong: #334155;
+          --shadow: 0 1px 2px rgba(0,0,0,0.4), 0 4px 12px rgba(0,0,0,0.25);
+          --shadow-hover: 0 2px 4px rgba(0,0,0,0.5), 0 12px 24px rgba(0,0,0,0.35);
+          --accent: #f8fafc;
+          --accent-fg: #0b1220;
+          --accent-soft: #1e2a44;
+          --focus-ring: #f8fafc;
+        }}
+      }}
+
+      * {{ margin: 0; padding: 0; box-sizing: border-box; }}
+      html, body {{ background: var(--bg); }}
+      body {{
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Inter', Roboto, sans-serif;
+        color: var(--title);
+        min-height: 100vh; padding: 64px 24px 96px; line-height: 1.5;
+        font-size: 15px;
+      }}
+      .frame {{ max-width: 960px; margin: 0 auto; }}
+      .head {{ margin-bottom: 32px; }}
+      .head h1 {{
+        font-size: 1.9rem; font-weight: 600; letter-spacing: -0.01em;
+        color: var(--title); margin-bottom: 6px;
+      }}
+      .head .meta {{ color: var(--muted); font-size: 0.95rem; }}
+
+      .section-label {{
+        font-size: 11px; font-weight: 600; color: var(--muted);
+        text-transform: uppercase; letter-spacing: 0.08em;
+        margin: 32px 0 12px;
+      }}
+      .grid {{
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        gap: 16px;
+      }}
+
+      .card {{
+        position: relative;
+        display: block; padding: 20px 22px 18px;
+        background: var(--surface); color: inherit;
+        border: 1px solid var(--border); border-radius: 12px;
+        text-decoration: none; box-shadow: var(--shadow);
+        transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+        overflow: hidden;
+      }}
+      .card:hover {{
+        border-color: var(--border-strong);
+        box-shadow: var(--shadow-hover);
+        transform: translateY(-2px);
+      }}
+      .card.primary {{ border-color: transparent; }}
+      .card.primary::before {{
+        content: ''; position: absolute; left: 0; top: 0; bottom: 0; width: 4px;
+        background: var(--accent);
+      }}
+      .card.primary:hover {{ border-color: transparent; }}
+      .card-title {{
+        font-size: 1.05rem; font-weight: 600; color: var(--title);
+        margin-bottom: 4px; line-height: 1.3;
+      }}
+      .card-desc {{
+        color: var(--desc); font-size: 0.9rem; line-height: 1.5;
+        margin-bottom: 12px;
+      }}
+      .card-badge {{
+        display: inline-block; font-size: 11px; font-weight: 600;
+        padding: 3px 9px; border-radius: 999px;
+        text-transform: uppercase; letter-spacing: 0.04em;
+      }}
+      .card.primary .card-badge {{
+        background: var(--accent); color: var(--accent-fg);
+      }}
+      .card.secondary .card-badge {{
+        background: transparent; color: var(--muted);
+        border: 1px solid var(--border-strong);
+      }}
+
+      .toolbar {{
+        position: fixed; top: 14px; right: 14px;
+        display: flex; gap: 6px; align-items: center;
+        background: var(--surface); border: 1px solid var(--border);
+        border-radius: 8px; padding: 4px 6px; box-shadow: var(--shadow);
+        font-size: 12px; z-index: 10;
+      }}
+      .toolbar a, .toolbar button {{
+        background: transparent; border: 0; cursor: pointer;
+        color: var(--muted); text-decoration: none;
+        padding: 4px 8px; border-radius: 5px; font: inherit;
+      }}
+      .toolbar a:hover, .toolbar button:hover {{ color: var(--title); background: var(--accent-soft); }}
+      .toolbar a.active {{ color: var(--accent-fg); background: var(--accent); }}
+      .toolbar .sep {{ width: 1px; height: 14px; background: var(--border); margin: 0 2px; }}
+
+      .card:focus-visible,
+      .toolbar a:focus-visible,
+      .toolbar button:focus-visible {{
+        outline: 2px solid var(--focus-ring);
+        outline-offset: 2px;
+      }}
+
+      @media (max-width: 720px) {{
+        body {{ padding: 32px 16px 64px; }}
+        .grid {{ grid-template-columns: 1fr; }}
+        .toolbar {{ top: 8px; right: 8px; }}
+        /* Preview-only links are hidden on small screens to keep the toggle
+           reachable. Final cleanup will remove them entirely. */
+        .toolbar > a, .toolbar > .sep {{ display: none; }}
+      }}
+    </style>
+  </head>
+  <body>
+    {_refined_toolbar()}
+    <div class="frame">
+      <div class="head">
+        <h1>API Documentation</h1>
+        <div class="meta">fastapi-agent-blueprint · Pick a viewer or hand off the spec.</div>
+      </div>
+      <div class="section-label">Viewers</div>
+      <div class="grid">
+{docs_rows}
+      </div>
+      <div class="section-label">Share with frontend</div>
+      <div class="grid">
+{handoff_rows}
+      </div>
+    </div>
+    <script>
+      (function() {{
+        var KEY = 'docs-selector-theme';
+        var root = document.documentElement;
+        var btn = document.getElementById('theme-toggle');
+        function currentTheme() {{
+          return root.getAttribute('data-theme')
+            || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+        }}
+        function paint() {{
+          var dark = currentTheme() === 'dark';
+          btn.textContent = dark ? 'Light' : 'Dark';
+          btn.setAttribute('aria-pressed', dark ? 'true' : 'false');
+        }}
+        paint();
+        btn.addEventListener('click', function() {{
+          var next = currentTheme() === 'dark' ? 'light' : 'dark';
+          root.setAttribute('data-theme', next);
+          try {{ localStorage.setItem(KEY, next); }} catch (e) {{ /* ignore */ }}
+          paint();
+        }});
+      }})();
+    </script>
+  </body>
+</html>"""
+
+
+def _refined_card(card: dict[str, str]) -> str:
+    kind = card.get("kind", "primary")
+    klass = "card primary" if kind == "primary" else "card secondary"
+    is_external = card.get("external", "false") == "true"
+    target = ' target="_blank" rel="noopener"' if is_external else ""
+    download = (
+        " download"
+        if card.get("external") == "false" and card["key"] == "download"
+        else ""
+    )
+    return f"""        <a class="{klass}" href="{card["href"]}"{target}{download}>
+          <div class="card-title">{card["title"]}</div>
+          <div class="card-desc">{card["tagline"]}</div>
+          <span class="card-badge">{card["label"]}</span>
+        </a>"""
+
+
+def _refined_toolbar() -> str:
+    """Tiny top-right bar that hosts the preview links plus the theme toggle.
+
+    Once a redesign is picked, the preview-link cluster is dropped but the
+    theme toggle stays — it is part of the final UX, not the cleanup target.
+    """
+    items = [
+        ("default", "Current"),
+        ("brutalist", "Brutalist"),
+        ("editorial", "Editorial"),
+        ("minimal", "Minimal"),
+        ("mac", "Mac"),
+        ("refined", "Refined"),
+    ]
+    links = []
+    for key, label in items:
+        href = "/docs" if key == "default" else f"/docs?theme={key}"
+        is_active = key == "refined"
+        klass = "active" if is_active else ""
+        aria = ' aria-current="page"' if is_active else ""
+        links.append(f'<a href="{href}" class="{klass}"{aria}>{label}</a>')
+    return (
+        '<nav class="toolbar" aria-label="Theme preview">'
+        + "".join(links)
+        + '<span class="sep" aria-hidden="true"></span>'
+        + '<button id="theme-toggle" type="button"'
+        ' aria-label="Toggle light or dark theme" aria-pressed="false">Dark</button>'
+        + "</nav>"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/_core/application/routers/api/docs_router.py
+++ b/src/_core/application/routers/api/docs_router.py
@@ -8,18 +8,114 @@ HANDOFF_GUIDE_URL = (
     "/blob/main/docs/frontend-handoff.md"
 )
 
+# Card data shared by every theme renderer. Keep order stable: the first two
+# entries are the recommended viewers, the rest are alternates.
+DOCS_CARDS: list[dict[str, str]] = [
+    {
+        "key": "elements",
+        "href": "/api/docs-elements",
+        "title": "Stoplight Elements",
+        "tagline": "Interactive, three-pane reader. Best for browsing.",
+        "label": "Recommended — Visual",
+        "kind": "primary",
+    },
+    {
+        "key": "scalar",
+        "href": "/api/docs-scalar",
+        "title": "Scalar API Reference",
+        "tagline": "Modern reference with try-it that bridges into a client.",
+        "label": "Recommended — Try-it",
+        "kind": "primary",
+    },
+    {
+        "key": "swagger",
+        "href": "/api/docs-swagger",
+        "title": "Swagger UI",
+        "tagline": "FastAPI's bundled default. Familiar to most teams.",
+        "label": "Compatibility",
+        "kind": "secondary",
+    },
+    {
+        "key": "redoc",
+        "href": "/api/docs-redoc",
+        "title": "ReDoc",
+        "tagline": "Documentation-first three-panel layout.",
+        "label": "Clean",
+        "kind": "secondary",
+    },
+    {
+        "key": "rapidoc",
+        "href": "/api/docs-rapidoc",
+        "title": "RapiDoc",
+        "tagline": "Lightweight viewer. Fast initial load.",
+        "label": "Fast",
+        "kind": "secondary",
+    },
+]
+
+
+def _handoff_cards(download_url: str) -> list[dict[str, str]]:
+    return [
+        {
+            "key": "download",
+            "href": download_url,
+            "title": "Download OpenAPI (JSON)",
+            "tagline": "Save the live spec as openapi.json for Postman, Bruno, or any client.",
+            "label": "Spec",
+            "external": "false",
+        },
+        {
+            "key": "handoff",
+            "href": HANDOFF_GUIDE_URL,
+            "title": "Frontend Handoff Guide",
+            "tagline": "Contract scope, test client comparison, and TypeScript SDK recipes.",
+            "label": "Guide",
+            "external": "true",
+        },
+    ]
+
+
+VALID_THEMES = {"brutalist", "editorial", "minimal", "mac"}
+
 
 @router.get(
     "/docs",
     include_in_schema=False,
     description="API Docs Selector - Main page for choosing among various documentation UIs",
 )
-def docs_selector(request: Request):
+def docs_selector(request: Request, theme: str | None = None):
     root_path = request.scope.get("root_path", "")
     download_url = f"{root_path}/openapi-download.json"
+    handoff_cards = _handoff_cards(download_url)
+    docs_cards = DOCS_CARDS
 
-    return HTMLResponse(
-        f"""
+    selected = theme if theme in VALID_THEMES else None
+    if selected == "brutalist":
+        body = _render_brutalist(docs_cards, handoff_cards)
+    elif selected == "editorial":
+        body = _render_editorial(docs_cards, handoff_cards)
+    elif selected == "minimal":
+        body = _render_minimal(docs_cards, handoff_cards)
+    elif selected == "mac":
+        body = _render_mac(docs_cards, handoff_cards)
+    else:
+        body = _render_default(docs_cards, handoff_cards)
+
+    return HTMLResponse(body)
+
+
+# ---------------------------------------------------------------------------
+# Default theme — kept as the production surface from PR #156. Purple gradient,
+# rounded cards, the original "AI-pattern" look. Future cleanup will replace
+# this with whichever preview theme the user picks.
+# ---------------------------------------------------------------------------
+
+
+def _render_default(
+    docs_cards: list[dict[str, str]],
+    handoff_cards: list[dict[str, str]],
+) -> str:
+    return f"""
 <!doctype html>
 <html>
   <head>
@@ -28,221 +124,65 @@ def docs_selector(request: Request):
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <style>
-      * {{
-        margin: 0;
-        padding: 0;
-        box-sizing: border-box;
-      }}
-
+      * {{ margin: 0; padding: 0; box-sizing: border-box; }}
       body {{
         font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
         background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-        min-height: 100vh;
-        padding: 20px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
+        min-height: 100vh; padding: 20px;
+        display: flex; align-items: center; justify-content: center;
       }}
-
       .container {{
-        max-width: 1000px;
-        width: 100%;
-        background: rgba(255, 255, 255, 0.95);
-        backdrop-filter: blur(10px);
-        border-radius: 24px;
-        padding: 60px 40px;
+        max-width: 1000px; width: 100%;
+        background: rgba(255, 255, 255, 0.95); backdrop-filter: blur(10px);
+        border-radius: 24px; padding: 60px 40px;
         box-shadow: 0 25px 50px rgba(0, 0, 0, 0.15);
       }}
-
-      .header {{
-        text-align: center;
-        margin-bottom: 50px;
-      }}
-
+      .header {{ text-align: center; margin-bottom: 50px; }}
       h1 {{
-        font-size: 3.5rem;
-        font-weight: 700;
+        font-size: 3.5rem; font-weight: 700;
         background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
-        margin-bottom: 16px;
-        letter-spacing: -0.02em;
+        -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+        background-clip: text; margin-bottom: 16px; letter-spacing: -0.02em;
       }}
-
-      .subtitle {{
-        font-size: 1.2rem;
-        color: #64748b;
-        font-weight: 400;
-        max-width: 600px;
-        margin: 0 auto;
-        line-height: 1.6;
-      }}
-
-      .docs-grid {{
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-        gap: 24px;
-        margin-top: 40px;
-      }}
-
+      .subtitle {{ font-size: 1.2rem; color: #64748b; max-width: 600px; margin: 0 auto; line-height: 1.6; }}
+      .docs-grid {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 24px; margin-top: 40px; }}
       .docs-card {{
-        background: white;
-        border-radius: 16px;
-        padding: 32px 24px;
-        text-decoration: none;
-        color: inherit;
-        display: block;
+        background: white; border-radius: 16px; padding: 32px 24px;
+        text-decoration: none; color: inherit; display: block;
         transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-        border: 1px solid #e2e8f0;
-        position: relative;
-        overflow: hidden;
+        border: 1px solid #e2e8f0; position: relative; overflow: hidden;
       }}
-
       .docs-card::before {{
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        height: 4px;
+        content: ''; position: absolute; top: 0; left: 0; right: 0; height: 4px;
         background: linear-gradient(90deg, #667eea, #764ba2);
-        transform: scaleX(0);
-        transition: transform 0.3s ease;
+        transform: scaleX(0); transition: transform 0.3s ease;
       }}
-
-      .docs-card:hover {{
-        transform: translateY(-8px);
-        box-shadow: 0 20px 40px rgba(0, 0, 0, 0.1);
-        border-color: #667eea;
-      }}
-
-      .docs-card:hover::before {{
-        transform: scaleX(1);
-      }}
-
-      .card-icon {{
-        font-size: 3rem;
-        margin-bottom: 16px;
-        display: block;
-        text-align: center;
-      }}
-
-      .docs-title {{
-        font-size: 1.4rem;
-        font-weight: 600;
-        margin-bottom: 12px;
-        color: #1e293b;
-        text-align: center;
-        line-height: 1.3;
-      }}
-
-      .docs-desc {{
-        color: #64748b;
-        margin: 0;
-        font-size: 0.95rem;
-        line-height: 1.6;
-        text-align: center;
-      }}
-
+      .docs-card:hover {{ transform: translateY(-8px); box-shadow: 0 20px 40px rgba(0,0,0,0.1); border-color: #667eea; }}
+      .docs-card:hover::before {{ transform: scaleX(1); }}
+      .docs-title {{ font-size: 1.4rem; font-weight: 600; margin-bottom: 12px; color: #1e293b; line-height: 1.3; }}
+      .docs-desc {{ color: #64748b; margin: 0; font-size: 0.95rem; line-height: 1.6; }}
       .badge {{
-        display: inline-block;
-        background: linear-gradient(135deg, #667eea, #764ba2);
-        color: white;
-        padding: 4px 12px;
-        border-radius: 20px;
-        font-size: 0.75rem;
-        font-weight: 500;
-        margin-top: 16px;
-        text-transform: uppercase;
-        letter-spacing: 0.5px;
+        display: inline-block; background: linear-gradient(135deg, #667eea, #764ba2); color: white;
+        padding: 4px 12px; border-radius: 20px; font-size: 0.75rem; font-weight: 500;
+        margin-top: 16px; text-transform: uppercase; letter-spacing: 0.5px;
       }}
-
-      .badge.muted {{
-        background: #e2e8f0;
-        color: #475569;
+      .badge.muted {{ background: #e2e8f0; color: #475569; }}
+      .handoff-section {{ margin-top: 56px; padding-top: 40px; border-top: 1px solid #e2e8f0; }}
+      .handoff-section h2 {{ font-size: 1.6rem; font-weight: 600; color: #1e293b; text-align: center; margin-bottom: 8px; }}
+      .handoff-section p.handoff-subtitle {{ text-align: center; color: #64748b; max-width: 640px; margin: 0 auto 28px; line-height: 1.6; }}
+      .handoff-grid {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 16px; }}
+      .preview-bar {{
+        position: fixed; top: 16px; right: 16px; background: rgba(255,255,255,0.95);
+        padding: 8px 12px; border-radius: 8px; font-size: 0.78rem;
+        box-shadow: 0 4px 12px rgba(0,0,0,0.1); display: flex; gap: 8px; align-items: center;
       }}
-
-      .handoff-section {{
-        margin-top: 56px;
-        padding-top: 40px;
-        border-top: 1px solid #e2e8f0;
-      }}
-
-      .handoff-section h2 {{
-        font-size: 1.6rem;
-        font-weight: 600;
-        color: #1e293b;
-        text-align: center;
-        margin-bottom: 8px;
-      }}
-
-      .handoff-section p.handoff-subtitle {{
-        text-align: center;
-        color: #64748b;
-        font-size: 1rem;
-        max-width: 640px;
-        margin: 0 auto 28px;
-        line-height: 1.6;
-      }}
-
-      .handoff-grid {{
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-        gap: 16px;
-      }}
-
-      @media (max-width: 768px) {{
-        .container {{
-          padding: 40px 24px;
-          margin: 10px;
-        }}
-
-        h1 {{
-          font-size: 2.5rem;
-        }}
-
-        .subtitle {{
-          font-size: 1.1rem;
-        }}
-
-        .docs-grid {{
-          grid-template-columns: 1fr;
-          gap: 16px;
-        }}
-
-        .docs-card {{
-          padding: 24px 20px;
-        }}
-
-        .handoff-grid {{
-          grid-template-columns: 1fr;
-        }}
-      }}
-
-      @keyframes fadeInUp {{
-        from {{
-          opacity: 0;
-          transform: translateY(30px);
-        }}
-        to {{
-          opacity: 1;
-          transform: translateY(0);
-        }}
-      }}
-
-      .docs-card {{
-        animation: fadeInUp 0.6s ease forwards;
-      }}
-
-      .docs-card:nth-child(1) {{ animation-delay: 0.1s; }}
-      .docs-card:nth-child(2) {{ animation-delay: 0.2s; }}
-      .docs-card:nth-child(3) {{ animation-delay: 0.3s; }}
-      .docs-card:nth-child(4) {{ animation-delay: 0.4s; }}
-      .docs-card:nth-child(5) {{ animation-delay: 0.5s; }}
+      .preview-bar a {{ color: #4a5568; text-decoration: none; padding: 2px 6px; border-radius: 4px; }}
+      .preview-bar a:hover {{ background: #edf2f7; }}
+      .preview-bar a.active {{ background: #667eea; color: white; }}
     </style>
   </head>
   <body>
+    {_preview_bar("default")}
     <div class="container">
       <div class="header">
         <h1>🚀 API Documentation</h1>
@@ -251,59 +191,13 @@ def docs_selector(request: Request):
           Each one offers a unique set of features and user experience.
         </p>
       </div>
-
       <div class="docs-grid">
-        <a href="/api/docs-elements" class="docs-card">
-          <span class="card-icon">🎨</span>
-          <div class="docs-title">Stoplight Elements</div>
-          <p class="docs-desc">
-            An interactive, visually appealing API documentation that
-            delivers a rich user experience.
-          </p>
-          <span class="badge">Recommended — Visual</span>
-        </a>
-
-        <a href="/api/docs-scalar" class="docs-card">
-          <span class="card-icon">✨</span>
-          <div class="docs-title">Scalar API Reference</div>
-          <p class="docs-desc">
-            A modern, sophisticated API documentation with built-in
-            try-it experience that bridges into a full client.
-          </p>
-          <span class="badge">Recommended — Try-it</span>
-        </a>
-
-        <a href="/api/docs-swagger" class="docs-card">
-          <span class="card-icon">📚</span>
-          <div class="docs-title">FastAPI Swagger UI</div>
-          <p class="docs-desc">
-            The most widely used API documentation format, offering an
-            intuitive interface with full-featured functionality.
-          </p>
-          <span class="badge muted">Compatibility</span>
-        </a>
-
-        <a href="/api/docs-redoc" class="docs-card">
-          <span class="card-icon">📖</span>
-          <div class="docs-title">ReDoc</div>
-          <p class="docs-desc">
-            A clean, readable, documentation-focused design that lets
-            you explore API specifications in a well-organized manner.
-          </p>
-          <span class="badge muted">Clean</span>
-        </a>
-
-        <a href="/api/docs-rapidoc" class="docs-card">
-          <span class="card-icon">⚡</span>
-          <div class="docs-title">RapiDoc</div>
-          <p class="docs-desc">
-            A fast, lightweight API documentation that provides
-            a simple yet efficient interface.
-          </p>
-          <span class="badge muted">Fast</span>
-        </a>
+        {_default_card(docs_cards[0], "🎨")}
+        {_default_card(docs_cards[1], "✨")}
+        {_default_card(docs_cards[2], "📚")}
+        {_default_card(docs_cards[3], "📖")}
+        {_default_card(docs_cards[4], "⚡")}
       </div>
-
       <section class="handoff-section">
         <h2>📦 Share with Frontend</h2>
         <p class="handoff-subtitle">
@@ -312,31 +206,538 @@ def docs_selector(request: Request):
           OpenAPI spec and let the frontend import it into their tool of choice.
         </p>
         <div class="handoff-grid">
-          <a href="{download_url}" class="docs-card" download>
-            <span class="card-icon">⬇️</span>
-            <div class="docs-title">Download OpenAPI (JSON)</div>
-            <p class="docs-desc">
-              Save the live spec as <code>openapi.json</code> and import it into
-              Postman, Bruno, or any OpenAPI-aware client.
-            </p>
-            <span class="badge">Spec</span>
-          </a>
-
-          <a href="{HANDOFF_GUIDE_URL}" class="docs-card" target="_blank" rel="noopener">
-            <span class="card-icon">🧭</span>
-            <div class="docs-title">Frontend Handoff Guide</div>
-            <p class="docs-desc">
-              Contract scope (auth, errors, pagination, CORS), test client
-              comparison, and TypeScript SDK generation recipes.
-            </p>
-            <span class="badge">Guide</span>
-          </a>
+          {_default_handoff_card(handoff_cards[0], "⬇️")}
+          {_default_handoff_card(handoff_cards[1], "🧭")}
         </div>
       </section>
     </div>
   </body>
 </html>"""
+
+
+def _default_card(card: dict[str, str], icon: str) -> str:
+    badge_class = "badge" if card["kind"] == "primary" else "badge muted"
+    return f"""
+    <a href="{card["href"]}" class="docs-card">
+      <span style="font-size:3rem; display:block; text-align:center; margin-bottom:16px;">{icon}</span>
+      <div class="docs-title" style="text-align:center;">{card["title"]}</div>
+      <p class="docs-desc" style="text-align:center;">{card["tagline"]}</p>
+      <div style="text-align:center;"><span class="{badge_class}">{card["label"]}</span></div>
+    </a>"""
+
+
+def _default_handoff_card(card: dict[str, str], icon: str) -> str:
+    target = ' target="_blank" rel="noopener"' if card["external"] == "true" else ""
+    download = " download" if card["external"] == "false" else ""
+    return f"""
+    <a href="{card["href"]}" class="docs-card"{target}{download}>
+      <span style="font-size:3rem; display:block; text-align:center; margin-bottom:16px;">{icon}</span>
+      <div class="docs-title" style="text-align:center;">{card["title"]}</div>
+      <p class="docs-desc" style="text-align:center;">{card["tagline"]}</p>
+      <div style="text-align:center;"><span class="badge">{card["label"]}</span></div>
+    </a>"""
+
+
+def _preview_bar(active: str) -> str:
+    """Render a tiny floating bar that lets the reviewer hop between previews.
+
+    The bar is preview-only. Once the redesign is picked, this helper plus
+    `?theme=` dispatch will be removed and the chosen renderer becomes the
+    sole `_render` for `/docs`.
+    """
+    items = [
+        ("default", "Current"),
+        ("brutalist", "Brutalist"),
+        ("editorial", "Editorial"),
+        ("minimal", "Minimal"),
+        ("mac", "Mac"),
+    ]
+    rendered = []
+    for key, label in items:
+        href = "/docs" if key == "default" else f"/docs?theme={key}"
+        klass = "active" if key == active else ""
+        rendered.append(f'<a href="{href}" class="{klass}">{label}</a>')
+    return f'<div class="preview-bar">Preview · {" ".join(rendered)}</div>'
+
+
+# ---------------------------------------------------------------------------
+# Brutalist Terminal — black background, monospace, single-line frame, no
+# gradients / shadows / emojis. Reads like a TUI panel.
+# ---------------------------------------------------------------------------
+
+
+def _render_brutalist(
+    docs_cards: list[dict[str, str]],
+    handoff_cards: list[dict[str, str]],
+) -> str:
+    rows = "\n".join(_brutalist_row(c) for c in docs_cards)
+    handoff_rows = "\n".join(_brutalist_row(c) for c in handoff_cards)
+    return f"""
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>fastapi-agent-blueprint :: docs</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+      * {{ margin: 0; padding: 0; box-sizing: border-box; }}
+      :root {{
+        --bg: #0a0a0a;
+        --fg: #e6e6e6;
+        --muted: #7a7a7a;
+        --border: #2a2a2a;
+        --border-hover: #4a4a4a;
+        --accent: #e6c300;
+      }}
+      body {{
+        font-family: 'JetBrains Mono', 'SF Mono', 'Menlo', 'Consolas', monospace;
+        background: var(--bg); color: var(--fg);
+        min-height: 100vh; padding: 48px 24px; line-height: 1.55;
+        font-size: 14px;
+      }}
+      .frame {{ max-width: 760px; margin: 0 auto; }}
+      .head {{ border: 1px solid var(--border); padding: 20px 24px; margin-bottom: 0; }}
+      .head .title {{ color: var(--fg); font-weight: 600; }}
+      .head .meta {{ color: var(--muted); font-size: 12px; margin-top: 4px; }}
+      .section-head {{
+        border: 1px solid var(--border); border-top: none;
+        padding: 12px 24px; color: var(--muted); font-size: 12px;
+        text-transform: uppercase; letter-spacing: 0.1em;
+      }}
+      .row {{
+        display: block; padding: 18px 24px;
+        border: 1px solid var(--border); border-top: none;
+        text-decoration: none; color: var(--fg); transition: border-color 0.12s linear;
+      }}
+      .row:hover {{ border-color: var(--border-hover); }}
+      .row .marker {{ color: var(--muted); margin-right: 8px; }}
+      .row .name {{ font-weight: 600; }}
+      .row .desc {{ color: var(--muted); margin-top: 4px; font-size: 13px; }}
+      .row .label {{ color: var(--accent); font-size: 11px; margin-top: 8px; display: inline-block; }}
+      .row .label.muted {{ color: var(--muted); }}
+      .row.last {{ border-bottom: 1px solid var(--border); }}
+      .preview-bar {{
+        position: fixed; top: 12px; right: 12px;
+        background: var(--bg); border: 1px solid var(--border);
+        padding: 6px 10px; font-size: 12px; display: flex; gap: 6px; align-items: center;
+      }}
+      .preview-bar .lbl {{ color: var(--muted); margin-right: 4px; }}
+      .preview-bar a {{ color: var(--muted); text-decoration: none; padding: 2px 6px; }}
+      .preview-bar a:hover {{ color: var(--fg); }}
+      .preview-bar a.active {{ color: var(--accent); }}
+    </style>
+  </head>
+  <body>
+    {_preview_bar("brutalist")}
+    <div class="frame">
+      <div class="head">
+        <div class="title">fastapi-agent-blueprint :: api docs</div>
+        <div class="meta">5 viewers · 2 handoff actions · selector @ /docs</div>
+      </div>
+      <div class="section-head">viewer</div>
+{rows}
+      <div class="section-head">handoff</div>
+{handoff_rows}
+    </div>
+  </body>
+</html>"""
+
+
+def _brutalist_row(card: dict[str, str]) -> str:
+    label_class = "label" if card.get("kind", "primary") == "primary" else "label muted"
+    is_external = card.get("external", "false") == "true"
+    target = ' target="_blank" rel="noopener"' if is_external else ""
+    download = (
+        " download"
+        if card.get("external") == "false" and card["key"] == "download"
+        else ""
     )
+    return f"""      <a class="row" href="{card["href"]}"{target}{download}>
+        <div><span class="marker">&gt;</span><span class="name">{card["title"]}</span></div>
+        <div class="desc">{card["tagline"]}</div>
+        <div class="{label_class}">[{card["label"].lower()}]</div>
+      </a>"""
+
+
+# ---------------------------------------------------------------------------
+# Editorial / Print — cream background, serif headings, horizontal rules
+# instead of cards. Reads like a magazine table of contents.
+# ---------------------------------------------------------------------------
+
+
+def _render_editorial(
+    docs_cards: list[dict[str, str]],
+    handoff_cards: list[dict[str, str]],
+) -> str:
+    rows = "\n".join(_editorial_row(c) for c in docs_cards)
+    handoff_rows = "\n".join(_editorial_row(c) for c in handoff_cards)
+    return f"""
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>FastAPI Agent Blueprint — API Documentation</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://fonts.googleapis.com/css2?family=Newsreader:opsz,wght@6..72,400;6..72,600&family=Inter:wght@400;500&display=swap" rel="stylesheet">
+    <style>
+      * {{ margin: 0; padding: 0; box-sizing: border-box; }}
+      :root {{
+        --bg: #f7f3ec;
+        --fg: #1a1a1a;
+        --muted: #6b6353;
+        --rule: #d4cdb8;
+        --link: #1a1a1a;
+        --link-hover: #5a3d1e;
+      }}
+      body {{
+        background: var(--bg); color: var(--fg);
+        font-family: 'Inter', -apple-system, system-ui, sans-serif;
+        min-height: 100vh; padding: 80px 24px 120px; line-height: 1.6;
+      }}
+      .frame {{ max-width: 720px; margin: 0 auto; }}
+      .masthead {{ border-bottom: 1px solid var(--rule); padding-bottom: 24px; margin-bottom: 32px; }}
+      .masthead .eyebrow {{
+        font-size: 11px; text-transform: uppercase; letter-spacing: 0.18em;
+        color: var(--muted); margin-bottom: 12px;
+      }}
+      .masthead h1 {{
+        font-family: 'Newsreader', Georgia, serif;
+        font-size: 2.6rem; font-weight: 600; line-height: 1.1; letter-spacing: -0.01em;
+      }}
+      .masthead .lede {{
+        margin-top: 12px; color: var(--muted); font-size: 1.05rem; max-width: 560px;
+      }}
+      .section-title {{
+        font-family: 'Newsreader', Georgia, serif;
+        font-size: 1.2rem; font-weight: 600; margin: 48px 0 16px;
+        color: var(--fg); padding-bottom: 8px; border-bottom: 1px solid var(--rule);
+      }}
+      .row {{
+        display: block; padding: 22px 0; border-bottom: 1px solid var(--rule);
+        text-decoration: none; color: var(--link); transition: color 0.15s ease;
+      }}
+      .row:hover {{ color: var(--link-hover); }}
+      .row .row-head {{ display: flex; align-items: baseline; justify-content: space-between; gap: 16px; }}
+      .row .row-title {{
+        font-family: 'Newsreader', Georgia, serif; font-size: 1.45rem; font-weight: 600; line-height: 1.2;
+      }}
+      .row .arrow {{ color: var(--muted); font-size: 1.1rem; }}
+      .row:hover .arrow {{ color: var(--link-hover); }}
+      .row .row-desc {{ color: var(--muted); margin-top: 6px; font-size: 0.98rem; }}
+      .row .row-label {{
+        margin-top: 10px; font-size: 10px; text-transform: uppercase; letter-spacing: 0.18em;
+        color: var(--muted);
+      }}
+      .preview-bar {{
+        position: fixed; top: 16px; right: 16px;
+        background: var(--bg); border: 1px solid var(--rule);
+        padding: 6px 10px; font-size: 12px; display: flex; gap: 6px; align-items: center;
+        font-family: 'Inter', sans-serif;
+      }}
+      .preview-bar .lbl {{ color: var(--muted); margin-right: 4px; }}
+      .preview-bar a {{ color: var(--muted); text-decoration: none; padding: 2px 6px; }}
+      .preview-bar a:hover {{ color: var(--fg); }}
+      .preview-bar a.active {{ color: var(--fg); font-weight: 500; }}
+    </style>
+  </head>
+  <body>
+    {_preview_bar("editorial")}
+    <div class="frame">
+      <div class="masthead">
+        <div class="eyebrow">FastAPI Agent Blueprint · API Documentation</div>
+        <h1>Five readers, two handoffs.</h1>
+        <p class="lede">
+          The browser viewers are for reading. For the parts that need persisted
+          state — tokens, environments, request bodies — hand off the spec.
+        </p>
+      </div>
+      <div class="section-title">Viewers</div>
+{rows}
+      <div class="section-title">Handoff</div>
+{handoff_rows}
+    </div>
+  </body>
+</html>"""
+
+
+def _editorial_row(card: dict[str, str]) -> str:
+    is_external = card.get("external", "false") == "true"
+    target = ' target="_blank" rel="noopener"' if is_external else ""
+    download = (
+        " download"
+        if card.get("external") == "false" and card["key"] == "download"
+        else ""
+    )
+    return f"""      <a class="row" href="{card["href"]}"{target}{download}>
+        <div class="row-head">
+          <div class="row-title">{card["title"]}</div>
+          <div class="arrow">&rarr;</div>
+        </div>
+        <div class="row-desc">{card["tagline"]}</div>
+        <div class="row-label">{card["label"]}</div>
+      </a>"""
+
+
+# ---------------------------------------------------------------------------
+# Minimal Native — white background, system fonts, GitHub-flavoured 1px boxes.
+# Quiet and forgettable in the best way.
+# ---------------------------------------------------------------------------
+
+
+def _render_minimal(
+    docs_cards: list[dict[str, str]],
+    handoff_cards: list[dict[str, str]],
+) -> str:
+    rows = "\n".join(_minimal_row(c) for c in docs_cards)
+    handoff_rows = "\n".join(_minimal_row(c) for c in handoff_cards)
+    return f"""
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>API Documentation — fastapi-agent-blueprint</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+      * {{ margin: 0; padding: 0; box-sizing: border-box; }}
+      :root {{
+        --bg: #ffffff;
+        --fg: #0e0e10;
+        --muted: #57606a;
+        --border: #d0d7de;
+        --border-hover: #0969da;
+        --accent: #0969da;
+      }}
+      body {{
+        background: var(--bg); color: var(--fg);
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', sans-serif;
+        min-height: 100vh; padding: 64px 24px; line-height: 1.5;
+        font-size: 15px;
+      }}
+      .frame {{ max-width: 720px; margin: 0 auto; }}
+      .head h1 {{ font-size: 1.6rem; font-weight: 600; margin-bottom: 4px; }}
+      .head .meta {{ color: var(--muted); font-size: 13px; }}
+      .section-head {{
+        margin: 36px 0 12px; font-size: 12px; font-weight: 600; color: var(--muted);
+        text-transform: uppercase; letter-spacing: 0.04em;
+      }}
+      .list {{ display: flex; flex-direction: column; gap: 8px; }}
+      .row {{
+        display: flex; align-items: center; justify-content: space-between; gap: 16px;
+        padding: 14px 16px; border: 1px solid var(--border); border-radius: 6px;
+        text-decoration: none; color: var(--fg); transition: border-color 0.12s ease;
+      }}
+      .row:hover {{ border-color: var(--border-hover); }}
+      .row .row-text .name {{ font-weight: 600; font-size: 0.98rem; }}
+      .row .row-text .desc {{ color: var(--muted); font-size: 13px; margin-top: 2px; }}
+      .row .row-meta {{ display: flex; align-items: center; gap: 10px; flex-shrink: 0; }}
+      .row .label {{
+        font-size: 11px; color: var(--muted); border: 1px solid var(--border);
+        padding: 2px 8px; border-radius: 999px; white-space: nowrap;
+      }}
+      .row .label.primary {{ color: var(--accent); border-color: var(--accent); }}
+      .row .arrow {{ color: var(--muted); font-size: 14px; }}
+      .row:hover .arrow {{ color: var(--accent); }}
+      .preview-bar {{
+        position: fixed; top: 12px; right: 12px;
+        background: var(--bg); border: 1px solid var(--border); border-radius: 6px;
+        padding: 6px 10px; font-size: 12px; display: flex; gap: 6px; align-items: center;
+      }}
+      .preview-bar .lbl {{ color: var(--muted); margin-right: 4px; }}
+      .preview-bar a {{ color: var(--muted); text-decoration: none; padding: 2px 6px; border-radius: 3px; }}
+      .preview-bar a:hover {{ color: var(--fg); }}
+      .preview-bar a.active {{ color: var(--accent); font-weight: 500; }}
+    </style>
+  </head>
+  <body>
+    {_preview_bar("minimal")}
+    <div class="frame">
+      <div class="head">
+        <h1>API Documentation</h1>
+        <div class="meta">fastapi-agent-blueprint · dev environment · /docs</div>
+      </div>
+      <div class="section-head">Viewers</div>
+      <div class="list">
+{rows}
+      </div>
+      <div class="section-head">Handoff</div>
+      <div class="list">
+{handoff_rows}
+      </div>
+    </div>
+  </body>
+</html>"""
+
+
+def _minimal_row(card: dict[str, str]) -> str:
+    label_class = (
+        "label primary" if card.get("kind", "primary") == "primary" else "label"
+    )
+    is_external = card.get("external", "false") == "true"
+    target = ' target="_blank" rel="noopener"' if is_external else ""
+    download = (
+        " download"
+        if card.get("external") == "false" and card["key"] == "download"
+        else ""
+    )
+    return f"""        <a class="row" href="{card["href"]}"{target}{download}>
+          <div class="row-text">
+            <div class="name">{card["title"]}</div>
+            <div class="desc">{card["tagline"]}</div>
+          </div>
+          <div class="row-meta">
+            <span class="{label_class}">{card["label"]}</span>
+            <span class="arrow">&rsaquo;</span>
+          </div>
+        </a>"""
+
+
+# ---------------------------------------------------------------------------
+# Mac System Native — System Settings dialog inspired. Translucent panel,
+# SF font stack, traffic-light header, compact list rows with chevrons.
+# ---------------------------------------------------------------------------
+
+
+def _render_mac(
+    docs_cards: list[dict[str, str]],
+    handoff_cards: list[dict[str, str]],
+) -> str:
+    rows = "\n".join(_mac_row(c) for c in docs_cards)
+    handoff_rows = "\n".join(_mac_row(c) for c in handoff_cards)
+    return f"""
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>API Documentation</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+      * {{ margin: 0; padding: 0; box-sizing: border-box; }}
+      :root {{
+        --bg: #e6e6ec;
+        --panel: rgba(246, 246, 248, 0.92);
+        --panel-border: rgba(0,0,0,0.08);
+        --fg: #1d1d1f;
+        --muted: #6b6b70;
+        --row-border: rgba(0,0,0,0.06);
+        --accent: #007aff;
+        --row-bg: rgba(255,255,255,0.6);
+      }}
+      body {{
+        background: linear-gradient(180deg, #d8d8df 0%, #ececf2 100%); color: var(--fg);
+        font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Helvetica Neue', sans-serif;
+        min-height: 100vh; padding: 48px 24px;
+        display: flex; align-items: flex-start; justify-content: center;
+        font-size: 14px;
+      }}
+      .window {{
+        max-width: 640px; width: 100%;
+        background: var(--panel); backdrop-filter: blur(20px);
+        border: 1px solid var(--panel-border); border-radius: 12px;
+        box-shadow: 0 20px 50px rgba(0,0,0,0.18), 0 1px 0 rgba(255,255,255,0.6) inset;
+        overflow: hidden;
+      }}
+      .titlebar {{
+        display: flex; align-items: center; padding: 12px 16px;
+        border-bottom: 1px solid var(--row-border); background: rgba(255,255,255,0.4);
+      }}
+      .traffic {{ display: flex; gap: 8px; }}
+      .traffic span {{ width: 12px; height: 12px; border-radius: 50%; display: block; }}
+      .traffic .red {{ background: #ff5f57; }}
+      .traffic .yellow {{ background: #febc2e; }}
+      .traffic .green {{ background: #28c840; }}
+      .titlebar .title {{ flex: 1; text-align: center; font-weight: 600; font-size: 13px; color: var(--fg); }}
+      .titlebar .spacer {{ width: 52px; }}
+      .body {{ padding: 24px 24px 28px; }}
+      .body h2 {{ font-size: 1.5rem; font-weight: 600; margin-bottom: 4px; letter-spacing: -0.01em; }}
+      .body .subtitle {{ color: var(--muted); margin-bottom: 24px; font-size: 13px; }}
+      .group {{
+        background: var(--row-bg); border: 1px solid var(--row-border); border-radius: 10px;
+        overflow: hidden; margin-bottom: 16px;
+      }}
+      .group-label {{
+        font-size: 11px; font-weight: 500; color: var(--muted);
+        text-transform: uppercase; letter-spacing: 0.06em;
+        padding: 0 4px 6px; margin-top: 8px;
+      }}
+      .row {{
+        display: flex; align-items: center; gap: 12px;
+        padding: 11px 14px; border-bottom: 1px solid var(--row-border);
+        text-decoration: none; color: var(--fg); transition: background 0.1s ease;
+      }}
+      .row:last-child {{ border-bottom: none; }}
+      .row:hover {{ background: rgba(0,122,255,0.08); }}
+      .row .row-text {{ flex: 1; }}
+      .row .row-text .name {{ font-weight: 500; font-size: 14px; }}
+      .row .row-text .desc {{ color: var(--muted); font-size: 12px; margin-top: 1px; }}
+      .row .label {{
+        font-size: 11px; color: var(--muted); padding: 2px 8px;
+        border-radius: 5px; background: rgba(0,0,0,0.05); white-space: nowrap;
+      }}
+      .row .label.primary {{ color: white; background: var(--accent); }}
+      .row .chevron {{ color: var(--muted); font-size: 14px; flex-shrink: 0; }}
+      .preview-bar {{
+        position: fixed; top: 14px; right: 14px;
+        background: rgba(255,255,255,0.85); backdrop-filter: blur(12px);
+        border: 1px solid var(--panel-border); border-radius: 8px;
+        padding: 6px 10px; font-size: 12px; display: flex; gap: 6px; align-items: center;
+      }}
+      .preview-bar .lbl {{ color: var(--muted); margin-right: 4px; }}
+      .preview-bar a {{ color: var(--muted); text-decoration: none; padding: 2px 6px; border-radius: 4px; }}
+      .preview-bar a:hover {{ color: var(--fg); }}
+      .preview-bar a.active {{ color: white; background: var(--accent); }}
+    </style>
+  </head>
+  <body>
+    {_preview_bar("mac")}
+    <div class="window">
+      <div class="titlebar">
+        <div class="traffic">
+          <span class="red"></span><span class="yellow"></span><span class="green"></span>
+        </div>
+        <div class="title">API Documentation</div>
+        <div class="spacer"></div>
+      </div>
+      <div class="body">
+        <h2>Pick a viewer</h2>
+        <p class="subtitle">Or hand the spec off to a real client below.</p>
+        <div class="group-label">Viewers</div>
+        <div class="group">
+{rows}
+        </div>
+        <div class="group-label">Handoff</div>
+        <div class="group">
+{handoff_rows}
+        </div>
+      </div>
+    </div>
+  </body>
+</html>"""
+
+
+def _mac_row(card: dict[str, str]) -> str:
+    label_class = (
+        "label primary" if card.get("kind", "primary") == "primary" else "label"
+    )
+    is_external = card.get("external", "false") == "true"
+    target = ' target="_blank" rel="noopener"' if is_external else ""
+    download = (
+        " download"
+        if card.get("external") == "false" and card["key"] == "download"
+        else ""
+    )
+    return f"""          <a class="row" href="{card["href"]}"{target}{download}>
+            <div class="row-text">
+              <div class="name">{card["title"]}</div>
+              <div class="desc">{card["tagline"]}</div>
+            </div>
+            <span class="{label_class}">{card["label"]}</span>
+            <span class="chevron">&rsaquo;</span>
+          </a>"""
+
+
+# ---------------------------------------------------------------------------
+# Spec download + individual UI mounts (unchanged from PR #156).
+# ---------------------------------------------------------------------------
 
 
 @router.get(
@@ -360,7 +761,6 @@ def openapi_download(request: Request):
 def scalar_docs(request: Request):
     root_path = request.scope.get("root_path", "")
     spec_url = f"{root_path}{request.app.openapi_url}"
-
     return HTMLResponse(
         f"""
 <!doctype html>
@@ -376,7 +776,6 @@ def scalar_docs(request: Request):
     <script>
       Scalar.createApiReference('#api', {{
         url: '{spec_url}',
-        // proxyUrl: 'https://proxy.scalar.com' // Optional CORS bypass
       }});
     </script>
   </body>
@@ -392,7 +791,6 @@ def scalar_docs(request: Request):
 def elements_docs(request: Request):
     root_path = request.scope.get("root_path", "")
     spec_url = f"{root_path}{request.app.openapi_url}"
-
     return HTMLResponse(
         f"""
 <!doctype html>
@@ -418,7 +816,6 @@ def elements_docs(request: Request):
 def rapidoc_docs(request: Request):
     root_path = request.scope.get("root_path", "")
     spec_url = f"{root_path}{request.app.openapi_url}"
-
     return HTMLResponse(
         f"""
 <!doctype html>

--- a/src/_core/application/routers/api/docs_router.py
+++ b/src/_core/application/routers/api/docs_router.py
@@ -321,10 +321,16 @@ def _render_brutalist(
         display: block; padding: 18px 24px;
         border: 1px solid var(--border); border-top: none;
         text-decoration: none; color: var(--fg); transition: border-color 0.12s linear;
+        position: relative;
       }}
       .row:hover {{ border-color: var(--border-hover); }}
+      .row.primary {{
+        border-left: 3px solid var(--accent); padding-left: 22px;
+      }}
       .row .marker {{ color: var(--muted); margin-right: 8px; }}
+      .row.primary .marker {{ color: var(--accent); }}
       .row .name {{ font-weight: 600; }}
+      .row.primary .name {{ color: var(--accent); }}
       .row .desc {{ color: var(--muted); margin-top: 4px; font-size: 13px; }}
       .row .label {{ color: var(--accent); font-size: 11px; margin-top: 8px; display: inline-block; }}
       .row .label.muted {{ color: var(--muted); }}
@@ -357,7 +363,9 @@ def _render_brutalist(
 
 
 def _brutalist_row(card: dict[str, str]) -> str:
-    label_class = "label" if card.get("kind", "primary") == "primary" else "label muted"
+    kind = card.get("kind", "primary")
+    row_class = "row primary" if kind == "primary" else "row"
+    label_class = "label" if kind == "primary" else "label muted"
     is_external = card.get("external", "false") == "true"
     target = ' target="_blank" rel="noopener"' if is_external else ""
     download = (
@@ -365,8 +373,9 @@ def _brutalist_row(card: dict[str, str]) -> str:
         if card.get("external") == "false" and card["key"] == "download"
         else ""
     )
-    return f"""      <a class="row" href="{card["href"]}"{target}{download}>
-        <div><span class="marker">&gt;</span><span class="name">{card["title"]}</span></div>
+    marker = "*" if kind == "primary" else "&gt;"
+    return f"""      <a class="{row_class}" href="{card["href"]}"{target}{download}>
+        <div><span class="marker" aria-hidden="true">{marker}</span><span class="name">{card["title"]}</span></div>
         <div class="desc">{card["tagline"]}</div>
         <div class="{label_class}">[{card["label"].lower()}]</div>
       </a>"""
@@ -431,9 +440,17 @@ def _render_editorial(
       }}
       .row:hover {{ color: var(--link-hover); }}
       .row .row-head {{ display: flex; align-items: baseline; justify-content: space-between; gap: 16px; }}
+      .row .row-leading {{ display: flex; align-items: baseline; gap: 14px; min-width: 0; flex: 1; }}
+      .row .row-icon {{
+        font-family: 'Newsreader', Georgia, serif;
+        font-size: 1.5rem; color: var(--muted); flex-shrink: 0;
+        font-style: italic; min-width: 24px; text-align: center;
+      }}
+      .row.primary .row-icon {{ color: var(--link); font-weight: 600; font-style: normal; }}
       .row .row-title {{
         font-family: 'Newsreader', Georgia, serif; font-size: 1.45rem; font-weight: 600; line-height: 1.2;
       }}
+      .row.primary .row-title {{ font-size: 1.55rem; }}
       .row .arrow {{ color: var(--muted); font-size: 1.1rem; }}
       .row:hover .arrow {{ color: var(--link-hover); }}
       .row .row-desc {{ color: var(--muted); margin-top: 6px; font-size: 0.98rem; }}
@@ -441,6 +458,7 @@ def _render_editorial(
         margin-top: 10px; font-size: 10px; text-transform: uppercase; letter-spacing: 0.18em;
         color: var(--muted);
       }}
+      .row.primary .row-label {{ color: var(--link); font-weight: 600; }}
       .preview-bar {{
         position: fixed; top: 16px; right: 16px;
         background: var(--bg); border: 1px solid var(--rule);
@@ -474,6 +492,8 @@ def _render_editorial(
 
 
 def _editorial_row(card: dict[str, str]) -> str:
+    kind = card.get("kind", "primary")
+    row_class = "row primary" if kind == "primary" else "row"
     is_external = card.get("external", "false") == "true"
     target = ' target="_blank" rel="noopener"' if is_external else ""
     download = (
@@ -481,9 +501,13 @@ def _editorial_row(card: dict[str, str]) -> str:
         if card.get("external") == "false" and card["key"] == "download"
         else ""
     )
-    return f"""      <a class="row" href="{card["href"]}"{target}{download}>
+    icon = card.get("icon", "")
+    return f"""      <a class="{row_class}" href="{card["href"]}"{target}{download}>
         <div class="row-head">
-          <div class="row-title">{card["title"]}</div>
+          <div class="row-leading">
+            <span class="row-icon" aria-hidden="true">{icon}</span>
+            <div class="row-title">{card["title"]}</div>
+          </div>
           <div class="arrow">&rarr;</div>
         </div>
         <div class="row-desc">{card["tagline"]}</div>
@@ -540,6 +564,15 @@ def _render_minimal(
         text-decoration: none; color: var(--fg); transition: border-color 0.12s ease;
       }}
       .row:hover {{ border-color: var(--border-hover); }}
+      .row.primary {{
+        border-left: 3px solid var(--accent); padding-left: 14px;
+      }}
+      .row .row-leading {{ display: flex; align-items: center; gap: 12px; min-width: 0; flex: 1; }}
+      .row .row-icon {{
+        font-size: 1.5rem; line-height: 1; flex-shrink: 0;
+        width: 32px; text-align: center;
+      }}
+      .row .row-text {{ min-width: 0; }}
       .row .row-text .name {{ font-weight: 600; font-size: 0.98rem; }}
       .row .row-text .desc {{ color: var(--muted); font-size: 13px; margin-top: 2px; }}
       .row .row-meta {{ display: flex; align-items: center; gap: 10px; flex-shrink: 0; }}
@@ -547,7 +580,9 @@ def _render_minimal(
         font-size: 11px; color: var(--muted); border: 1px solid var(--border);
         padding: 2px 8px; border-radius: 999px; white-space: nowrap;
       }}
-      .row .label.primary {{ color: var(--accent); border-color: var(--accent); }}
+      .row .label.primary {{
+        color: white; background: var(--accent); border-color: var(--accent);
+      }}
       .row .arrow {{ color: var(--muted); font-size: 14px; }}
       .row:hover .arrow {{ color: var(--accent); }}
       .preview-bar {{
@@ -582,9 +617,9 @@ def _render_minimal(
 
 
 def _minimal_row(card: dict[str, str]) -> str:
-    label_class = (
-        "label primary" if card.get("kind", "primary") == "primary" else "label"
-    )
+    kind = card.get("kind", "primary")
+    row_class = "row primary" if kind == "primary" else "row"
+    label_class = "label primary" if kind == "primary" else "label"
     is_external = card.get("external", "false") == "true"
     target = ' target="_blank" rel="noopener"' if is_external else ""
     download = (
@@ -592,10 +627,14 @@ def _minimal_row(card: dict[str, str]) -> str:
         if card.get("external") == "false" and card["key"] == "download"
         else ""
     )
-    return f"""        <a class="row" href="{card["href"]}"{target}{download}>
-          <div class="row-text">
-            <div class="name">{card["title"]}</div>
-            <div class="desc">{card["tagline"]}</div>
+    icon = card.get("icon", "")
+    return f"""        <a class="{row_class}" href="{card["href"]}"{target}{download}>
+          <div class="row-leading">
+            <span class="row-icon" aria-hidden="true">{icon}</span>
+            <div class="row-text">
+              <div class="name">{card["title"]}</div>
+              <div class="desc">{card["tagline"]}</div>
+            </div>
           </div>
           <div class="row-meta">
             <span class="{label_class}">{card["label"]}</span>
@@ -679,8 +718,13 @@ def _render_mac(
       }}
       .row:last-child {{ border-bottom: none; }}
       .row:hover {{ background: rgba(0,122,255,0.08); }}
-      .row .row-text {{ flex: 1; }}
+      .row .row-icon {{
+        font-size: 1.6rem; line-height: 1; flex-shrink: 0;
+        width: 32px; text-align: center;
+      }}
+      .row .row-text {{ flex: 1; min-width: 0; }}
       .row .row-text .name {{ font-weight: 500; font-size: 14px; }}
+      .row.primary .row-text .name {{ font-weight: 700; color: var(--accent); }}
       .row .row-text .desc {{ color: var(--muted); font-size: 12px; margin-top: 1px; }}
       .row .label {{
         font-size: 11px; color: var(--muted); padding: 2px 8px;
@@ -728,9 +772,9 @@ def _render_mac(
 
 
 def _mac_row(card: dict[str, str]) -> str:
-    label_class = (
-        "label primary" if card.get("kind", "primary") == "primary" else "label"
-    )
+    kind = card.get("kind", "primary")
+    row_class = "row primary" if kind == "primary" else "row"
+    label_class = "label primary" if kind == "primary" else "label"
     is_external = card.get("external", "false") == "true"
     target = ' target="_blank" rel="noopener"' if is_external else ""
     download = (
@@ -738,7 +782,9 @@ def _mac_row(card: dict[str, str]) -> str:
         if card.get("external") == "false" and card["key"] == "download"
         else ""
     )
-    return f"""          <a class="row" href="{card["href"]}"{target}{download}>
+    icon = card.get("icon", "")
+    return f"""          <a class="{row_class}" href="{card["href"]}"{target}{download}>
+            <span class="row-icon" aria-hidden="true">{icon}</span>
             <div class="row-text">
               <div class="name">{card["title"]}</div>
               <div class="desc">{card["tagline"]}</div>

--- a/tests/e2e/test_docs_routes.py
+++ b/tests/e2e/test_docs_routes.py
@@ -1,0 +1,67 @@
+"""E2E coverage for the `/docs` selector and OpenAPI handoff routes.
+
+The selector page and `/openapi-download.json` route are dev-only. They support
+the frontend handoff flow described in `docs/frontend-handoff.md`. Regressions
+here would silently break the spec download button or expose the selector
+outside dev — both surfaces other tooling depends on.
+"""
+
+import re
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from src._apps.server.app import app
+
+
+def _client() -> AsyncClient:
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://localhost")
+
+
+@pytest.mark.asyncio
+async def test_docs_selector_returns_html():
+    async with _client() as client:
+        response = await client.get("/docs")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    body = response.text
+    assert "API Documentation" in body
+    assert "Stoplight Elements" in body
+    assert "Scalar API Reference" in body
+    assert "Recommended" in body
+    assert "Share with Frontend" in body
+    # The download card must point at the dedicated attachment route, not the
+    # bare /openapi.json (which would render inline). Match the href tail to
+    # stay agnostic to root_path prefixing.
+    download_match = re.search(
+        r'<a\s+href="([^"]*)"\s+class="docs-card"\s+download', body
+    )
+    assert download_match is not None
+    assert download_match.group(1).endswith("/openapi-download.json")
+    # Handoff guide link goes out to GitHub main; protect the path against
+    # silent renames.
+    assert "/docs/frontend-handoff.md" in body
+
+
+@pytest.mark.asyncio
+async def test_openapi_download_serves_attachment():
+    async with _client() as client:
+        response = await client.get("/openapi-download.json")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/json")
+    assert response.headers["content-disposition"].startswith("attachment")
+    assert "openapi.json" in response.headers["content-disposition"]
+    spec = response.json()
+    assert "openapi" in spec
+    assert "paths" in spec
+    assert spec["paths"], "OpenAPI paths block must not be empty"
+
+
+@pytest.mark.asyncio
+async def test_openapi_download_matches_openapi_json():
+    async with _client() as client:
+        baseline = await client.get("/openapi.json")
+        download = await client.get("/openapi-download.json")
+    assert baseline.status_code == 200
+    assert download.status_code == 200
+    assert baseline.json() == download.json()

--- a/tests/e2e/test_docs_routes.py
+++ b/tests/e2e/test_docs_routes.py
@@ -25,18 +25,43 @@ async def test_docs_selector_returns_html():
     assert response.status_code == 200
     assert "text/html" in response.headers["content-type"]
     body = response.text
+    # Hero + recommended viewers + handoff link must be present on every load.
     assert "API Documentation" in body
     assert "Stoplight Elements" in body
     assert "Scalar API Reference" in body
     assert "Recommended" in body
-    assert "Share with Frontend" in body
-    # The download card must point at the dedicated attachment route, not the
+    # The two viewer rows must carry the primary class so the accent strip
+    # actually renders; secondary handoff/viewer rows must keep their class.
+    assert "row primary" in body
+    assert 'class="row"' in body
+    # Light/dark theme system + toggle must be wired in.
+    assert "data-theme" in body
+    assert ':root[data-theme="dark"]' in body
+    assert "prefers-color-scheme: dark" in body
+    assert 'id="theme-toggle"' in body
+    assert "aria-pressed" in body
+    assert "localStorage" in body
+    # AI-pattern clichés must stay out of the production surface.
+    for cliche in (
+        "linear-gradient",
+        "-webkit-background-clip",
+        "backdrop-filter",
+    ):
+        assert cliche not in body, f"AI-pattern cliche leaked: {cliche}"
+
+
+@pytest.mark.asyncio
+async def test_docs_selector_links_to_handoff_and_download():
+    async with _client() as client:
+        response = await client.get("/docs")
+    body = response.text
+    # The download row must point at the dedicated attachment route, not the
     # bare /openapi.json (which would render inline). Match the href tail to
     # stay agnostic to root_path prefixing.
     download_match = re.search(
-        r'<a\s+href="([^"]*)"\s+class="docs-card"\s+download', body
+        r'<a\s+class="row[^"]*"\s+href="([^"]*openapi-download\.json)"', body
     )
-    assert download_match is not None
+    assert download_match is not None, "download row href missing"
     assert download_match.group(1).endswith("/openapi-download.json")
     # Handoff guide link goes out to GitHub main; protect the path against
     # silent renames.
@@ -68,67 +93,39 @@ async def test_openapi_download_matches_openapi_json():
 
 
 @pytest.mark.asyncio
-async def test_docs_selector_refined_theme_structure():
-    """Refined Modern carries a distinct set of structural markers.
-
-    The single-line marker check used by the parametrized test is not strong
-    enough to catch silent regressions in the Refined renderer (the toggle
-    JS, the dark-mode CSS variables, the primary card strip, the toolbar
-    aria attributes). This case asserts on the structural surface.
+async def test_legacy_theme_query_falls_through_to_default():
+    """Old preview URLs (`/docs?theme=brutalist` etc.) are no longer routed
+    to alternate renderers, but the dispatch was removed silently — FastAPI
+    drops unknown query params, so the server must return the default
+    selector unchanged. This test locks the graceful fallthrough so a future
+    edit cannot accidentally re-introduce a stale renderer behind the same
+    URL.
     """
     async with _client() as client:
-        response = await client.get("/docs?theme=refined")
-    assert response.status_code == 200
-    body = response.text
-    # Theme identifier (kept for grep across renderers).
-    assert "theme: refined-modern" in body
-    # CSS variable scheme + dark override are wired up.
-    assert "data-theme" in body
-    assert ':root[data-theme="dark"]' in body
-    assert "prefers-color-scheme: dark" in body
-    # Toggle button is present, accessible, and JS-controlled.
-    assert 'id="theme-toggle"' in body
-    assert "aria-pressed" in body
-    assert "localStorage" in body
-    # Primary card strip is the visual hierarchy carrier.
-    assert "card primary" in body
-    assert "card secondary" in body
-    # AI-pattern clichés are out of the Refined output.
-    refined_section_start = body.index("theme: refined-modern")
-    refined_section = body[refined_section_start:]
-    for cliche in (
-        "linear-gradient",
-        "-webkit-background-clip",
-        "backdrop-filter",
-    ):
-        assert cliche not in refined_section, f"AI-pattern cliche leaked: {cliche}"
+        baseline = await client.get("/docs")
+        legacy = await client.get("/docs?theme=brutalist")
+    assert baseline.status_code == 200
+    assert legacy.status_code == 200
+    assert baseline.text == legacy.text
 
 
 @pytest.mark.parametrize(
-    "theme,marker",
+    "path",
     [
-        ("brutalist", "JetBrains Mono"),
-        ("editorial", "Newsreader"),
-        ("minimal", "fastapi-agent-blueprint · dev environment"),
-        ("mac", "traffic"),
-        ("refined", "theme: refined-modern"),
+        "/docs-swagger",
+        "/docs-redoc",
+        "/docs-scalar",
+        "/docs-elements",
+        "/docs-rapidoc",
     ],
 )
 @pytest.mark.asyncio
-async def test_docs_selector_preview_themes(theme: str, marker: str):
-    """Each preview theme renders a distinct page that contains a theme-specific marker.
-
-    Preview themes are temporary — once one is picked as the production
-    redesign, the rest plus the `?theme=` dispatch get removed and these
-    parametrized cases drop out of the suite.
+async def test_docs_ui_routes_serve_html(path: str):
+    """The selector links to five docs UI routes; verify each one is wired up
+    and serves HTML (CDN renderers are loaded client-side, so the response
+    body is a small bootstrap page rather than the full spec render).
     """
     async with _client() as client:
-        response = await client.get(f"/docs?theme={theme}")
-    assert response.status_code == 200
+        response = await client.get(path)
+    assert response.status_code == 200, f"{path} did not return 200"
     assert "text/html" in response.headers["content-type"]
-    body = response.text
-    assert marker in body
-    # Every theme must surface the two recommended viewers and the handoff link.
-    assert "Stoplight Elements" in body
-    assert "Scalar" in body
-    assert "/docs/frontend-handoff.md" in body

--- a/tests/e2e/test_docs_routes.py
+++ b/tests/e2e/test_docs_routes.py
@@ -65,3 +65,32 @@ async def test_openapi_download_matches_openapi_json():
     assert baseline.status_code == 200
     assert download.status_code == 200
     assert baseline.json() == download.json()
+
+
+@pytest.mark.parametrize(
+    "theme,marker",
+    [
+        ("brutalist", "JetBrains Mono"),
+        ("editorial", "Newsreader"),
+        ("minimal", "fastapi-agent-blueprint · dev environment"),
+        ("mac", "traffic"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_docs_selector_preview_themes(theme: str, marker: str):
+    """Each preview theme renders a distinct page that contains a theme-specific marker.
+
+    Preview themes are temporary — once one is picked as the production
+    redesign, the rest plus the `?theme=` dispatch get removed and these
+    parametrized cases drop out of the suite.
+    """
+    async with _client() as client:
+        response = await client.get(f"/docs?theme={theme}")
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    body = response.text
+    assert marker in body
+    # Every theme must surface the two recommended viewers and the handoff link.
+    assert "Stoplight Elements" in body
+    assert "Scalar" in body
+    assert "/docs/frontend-handoff.md" in body

--- a/tests/e2e/test_docs_routes.py
+++ b/tests/e2e/test_docs_routes.py
@@ -67,6 +67,43 @@ async def test_openapi_download_matches_openapi_json():
     assert baseline.json() == download.json()
 
 
+@pytest.mark.asyncio
+async def test_docs_selector_refined_theme_structure():
+    """Refined Modern carries a distinct set of structural markers.
+
+    The single-line marker check used by the parametrized test is not strong
+    enough to catch silent regressions in the Refined renderer (the toggle
+    JS, the dark-mode CSS variables, the primary card strip, the toolbar
+    aria attributes). This case asserts on the structural surface.
+    """
+    async with _client() as client:
+        response = await client.get("/docs?theme=refined")
+    assert response.status_code == 200
+    body = response.text
+    # Theme identifier (kept for grep across renderers).
+    assert "theme: refined-modern" in body
+    # CSS variable scheme + dark override are wired up.
+    assert "data-theme" in body
+    assert ':root[data-theme="dark"]' in body
+    assert "prefers-color-scheme: dark" in body
+    # Toggle button is present, accessible, and JS-controlled.
+    assert 'id="theme-toggle"' in body
+    assert "aria-pressed" in body
+    assert "localStorage" in body
+    # Primary card strip is the visual hierarchy carrier.
+    assert "card primary" in body
+    assert "card secondary" in body
+    # AI-pattern clichés are out of the Refined output.
+    refined_section_start = body.index("theme: refined-modern")
+    refined_section = body[refined_section_start:]
+    for cliche in (
+        "linear-gradient",
+        "-webkit-background-clip",
+        "backdrop-filter",
+    ):
+        assert cliche not in refined_section, f"AI-pattern cliche leaked: {cliche}"
+
+
 @pytest.mark.parametrize(
     "theme,marker",
     [
@@ -74,6 +111,7 @@ async def test_openapi_download_matches_openapi_json():
         ("editorial", "Newsreader"),
         ("minimal", "fastapi-agent-blueprint · dev environment"),
         ("mac", "traffic"),
+        ("refined", "theme: refined-modern"),
     ],
 )
 @pytest.mark.asyncio

--- a/tests/unit/_core/test_config.py
+++ b/tests/unit/_core/test_config.py
@@ -754,3 +754,38 @@ class TestOtelConfig:
             s = _create_settings()
             assert s.otel_enabled is True
             assert s.otel_exporter_otlp_endpoint == "http://localhost:4317"
+
+
+class TestDocsUrlGating:
+    """`docs_url` / `redoc_url` / `openapi_url` are exposed only in dev envs.
+
+    Frontend handoff and /openapi-download.json depend on the same gate, so a
+    regression here would silently expose specs in prod. See `docs_router` and
+    `frontend-handoff.md`.
+    """
+
+    def test_docs_urls_exposed_in_dev(self):
+        env = {"ENV": "dev", **_REQUIRED_VARS}
+        with patch.dict(os.environ, env, clear=True):
+            s = _create_settings()
+            assert s.is_dev is True
+            assert s.docs_url == "/docs-swagger"
+            assert s.redoc_url == "/docs-redoc"
+            assert s.openapi_url == "/openapi.json"
+
+    def test_docs_urls_disabled_in_prod(self):
+        env = _make_safe_env("prod")
+        with patch.dict(os.environ, env, clear=True):
+            s = _create_settings()
+            assert s.is_dev is False
+            assert s.docs_url is None
+            assert s.redoc_url is None
+            assert s.openapi_url is None
+
+    def test_docs_urls_disabled_in_stg(self):
+        env = _make_safe_env("stg")
+        with patch.dict(os.environ, env, clear=True):
+            s = _create_settings()
+            assert s.is_dev is False
+            assert s.docs_url is None
+            assert s.openapi_url is None


### PR DESCRIPTION
## Related Issue

- Closes _none_ (no upstream issue; the work was scoped from an in-flight conversation)

## Change Summary

- Promote a new GitHub-flavoured `/docs` selector with two recommended viewers (Stoplight Elements + Scalar), three secondary viewers (Swagger / ReDoc / RapiDoc), and a `Share with Frontend` section that links the new spec download and handoff guide.
- Add `/openapi-download.json` route that returns the live spec with `Content-Disposition: attachment` so the spec can be saved as a real file rather than rendered inline.
- Add `docs/frontend-handoff.md` (English) describing the operating contract that the spec alone cannot communicate — `SuccessResponse` envelope, camelCase serialization (`accessToken` / `errorCode` / `currentPage` / …), JWT auth flow, RDB vs Cursor pagination shapes, CORS, breaking-change signals, plus a Postman / Bruno / Insomnia / Hoppscotch / Scalar Client comparison and Hey API + Orval SDK recipes.
- Sync `README.md`, `docs/README.ko.md`, `docs/quickstart.md`, `docs/reference.md`, `docs/tutorial/first-domain.md`, `examples/README.md`, `Makefile`, `scripts/demo.sh`, `scripts/demo-rag.sh` so every quickstart / demo / tutorial trail points at `/docs` (selector) instead of `/docs-swagger` directly.
- Light / dark theme toggle on the selector — pre-paint inline script hydrates the choice from `localStorage`, falls back to `prefers-color-scheme`, exposes `aria-pressed` on the button.
- Production guard tests added: settings-level gating (`docs_url is None` outside dev), e2e coverage for the selector body, the download attachment, the legacy `?theme=` query falling through to default, and all five CDN-mounted docs UIs returning HTML.
- Closing `/sync-guidelines` (commit 9616511) syncs `.claude/rules/*` (PR #156 + #154/PR #155 backfill rows, RBAC wording, admin login note), reshapes the agents `sync-guidelines` wrapper to the Claude `Procedure Overview` shape, and adds the governor-review-log entry for this PR.

## Type of Change

- [x] feat: New feature
- [x] docs: Documentation
- [x] test: Tests

## Checklist

- [x] Architecture rules followed (no Domain → Infrastructure imports; selector lives in `_core/application/routers/api/`)
- [x] Tests pass — 651 pass / 13 skipped (full suite minus the dynamodb / aws-extra tests that this dev shell does not have installed; the new tests are 9 of those passes)
- [x] Linting passes — `pre-commit run --all-files` is green (ruff format + check, mypy boundaries, Tier 1 language policy, governor closure)

## How to Test

- [ ] `make quickstart` and open http://127.0.0.1:8001/docs — Stoplight Elements + Scalar appear at the top with Recommended badges, three secondary viewers below, then a Share with Frontend section with download + handoff cards.
- [ ] Click the top-right `Dark` / `Light` button and refresh — the selected theme survives the reload via `localStorage`. Set OS dark mode and clear `localStorage` — the page comes up dark on first paint without flash.
- [ ] Click `Download OpenAPI (JSON)` — the browser saves a real `openapi.json` file (attachment), not an inline render. The file content equals `/api/openapi.json`.
- [ ] Click `Frontend Handoff Guide` — the GitHub URL renders the new `docs/frontend-handoff.md` (404 until this PR is merged; the link is intentionally pinned to `main`).
- [ ] Visit `/api/v1/docs-swagger`, `/docs-redoc`, `/docs-scalar`, `/docs-elements`, `/docs-rapidoc` — each renders its own viewer.
- [ ] `uv run pytest tests/e2e/test_docs_routes.py tests/unit/_core/test_config.py::TestDocsUrlGating -v` — 13/13 green.
- [ ] Build a non-dev `Settings` (`ENV=stg|prod`) — `docs_url`, `redoc_url`, `openapi_url` resolve to `None` (covered by `TestDocsUrlGating`).

## Follow-ups (out of scope)

- prod / staging spec exposure policy (currently dev-only) — needs an ADR.
- `make openapi-export` Makefile target + GitHub Action that commits `docs/openapi/openapi.json` per release.
- Stoplight / Scalar / RapiDoc CDN version pinning (currently `unpkg` / `jsdelivr` latest).
- Optional `make client` target that wraps `npx @hey-api/openapi-ts` for the typical frontend handoff flow.
- Make the five viewer card hrefs root_path-aware (currently `/api/...` hardcoded; works as long as `root_path="/api"` stays).

---

## Governor-Changing PR

This section is **required** because the closing `/sync-guidelines` commit (9616511) touches `.claude/rules/**` (Tier A/B per [`docs/ai/shared/governor-paths.md`](../docs/ai/shared/governor-paths.md)).

Source of truth: [`AGENTS.md` § Default Coding Flow](../AGENTS.md#default-coding-flow) + [`docs/ai/shared/governor-paths.md`](../docs/ai/shared/governor-paths.md) + [`docs/ai/shared/governor-review-log/README.md`](../docs/ai/shared/governor-review-log/README.md).

### Triggered files

- [x] At least one file in `changed_files` matches a Tier A / B / C path in `governor-paths.md`, and no full-set exclusion applies.
  - `.claude/rules/project-status.md`, `.claude/rules/architecture-conventions.md`, `.claude/rules/commands.md`, `.claude/rules/project-overview.md` (Tier A `.claude/rules/**`).
  - `docs/ai/shared/governor-review-log/pr-156-docs-selector-revamp-handoff.md` and `docs/ai/shared/governor-review-log/README.md` (Tier A `docs/ai/shared/**`).
  - `.agents/skills/sync-guidelines/SKILL.md` (Tier B `.agents/**`).

### Cross-tool review

- [x] Codex `gpt-5.5 --sandbox read-only` review completed at least once (plan stage and/or implementation stage).
  - 4 codex CLI rounds: design plan, first implementation pass (caught the `SuccessResponse` / camelCase contract drift), cleanup pass (caught the orphaned docs UI route guards + ReDoc list drift), `/sync-guidelines` closure pass (caught the stale #4 admin-auth sentence + agents wrapper drift).
- [x] All R-points addressed or explicitly deferred with rationale.
  - 17-row closure table in [`pr-156-docs-selector-revamp-handoff.md`](../docs/ai/shared/governor-review-log/pr-156-docs-selector-revamp-handoff.md): 16 Fixed + 1 Deferred-with-rationale (R2.3 toolbar mixed concerns — cleanup removed the toolbar entirely so the deferred concern is no longer reachable).
- [x] Final Verdict captured (`merge-ready` / `minor fixes recommended` / `block merge`).
  - Round 4 final verdict: merge-ready conditional on this artefact landing — closed by commit 9616511.

### Self-application proof

- [x] `/review-architecture` (or its manual equivalent) output captured for the changed surface — `Findings` / `Drift Candidates` / `Sync Required`.
  - See [`pr-156-docs-selector-revamp-handoff.md` § Self-Application Proof](../docs/ai/shared/governor-review-log/pr-156-docs-selector-revamp-handoff.md#self-application-proof).
- [x] `/sync-guidelines` (or its manual equivalent) output captured — `AUTO-FIX` / `REVIEW` / `Remaining`.
  - 5 AUTO-FIX items applied, 1 REVIEW item closed (`project-dna` §8 — docs UX out of scope), Remaining: none. Sync Required: false post-9616511.

### Review trail artifact

- [x] `docs/ai/shared/governor-review-log/pr-156-docs-selector-revamp-handoff.md` added with: Summary, Review Rounds, Inherited Constraints (IC-156-1 ~ IC-156-7), Self-Application Proof.
- [x] `governor-review-log/README.md` Index table updated.
- [ ] If this PR creates follow-up issues, each follow-up issue body links the new log entry under "Inherited Review Constraints" — N/A, no follow-up issues opened.

### Doc-only escape hygiene

- [x] If this PR is doc-only, confirm the changes do **not** touch policy / harness docs as listed in [`governor-paths.md`](../docs/ai/shared/governor-paths.md) Tier A. Touching those files disqualifies the doc-only auto-escape — see [`target-operating-model.md` §3](../docs/ai/shared/target-operating-model.md).
  - Not doc-only — the PR ships runtime code (`docs_router.py`) plus tests plus `.claude/rules/**` updates. Auto-escape does not apply; full `framing → plan → verify → self-review → completion gate` was followed.