### PR TITLE
refactor(governor): PR-A.5 — Codex sync advisory SOT (governor.sync_advisory)

### DIFF
--- a/.agents/shared/governor/sync_advisory.py
+++ b/.agents/shared/governor/sync_advisory.py
@@ -1,0 +1,71 @@
+"""Shared sync-advisory classification (PR-A.5).
+
+Single source of truth for ``FOUNDATION_PREFIXES`` / ``STRUCTURE_MARKERS``
+and the ``classify_advisory`` decision function. Extracted from the inline
+declarations in ``.codex/hooks/stop-sync-reminder.py`` so both the Codex
+Python hook and future Claude-side migrations consume identical rules
+(IC-2 single-source goal).
+
+The ``.claude/hooks/stop-sync-reminder.sh`` bash hook is NOT yet migrated
+(F-1 follow-up — see GitHub issue linked in PR-A.5 Footer).
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+FOUNDATION_PREFIXES: tuple[str, ...] = (
+    "AGENTS.md",
+    "CLAUDE.md",
+    ".codex/",
+    ".agents/",
+    ".claude/hooks/",
+    ".claude/rules/",
+    ".claude/settings.json",
+    "docs/ai/shared/",
+    "docs/ai/shared/skills/",
+    "src/_apps/",
+    "src/_core/",
+    "pyproject.toml",
+    ".pre-commit-config.yaml",
+)
+
+STRUCTURE_MARKERS: tuple[str, ...] = (
+    "/infrastructure/di/",
+    "/interface/server/routers/",
+    "/domain/protocols/",
+    "/domain/dtos/",
+)
+
+AdvisoryLevel = Literal["foundation", "structure", None]
+
+
+def classify_advisory(
+    changed_files: list[str],
+) -> tuple[AdvisoryLevel, list[str]]:
+    """Classify the advisory level for a set of changed file paths.
+
+    Returns a ``(level, matching_files)`` pair:
+      - ``("foundation", [...])`` — one or more foundation files changed;
+        guideline sync is required before closing the work.
+      - ``("structure", [...])`` — domain-structure files changed but no
+        foundation files; guideline sync is recommended.
+      - ``(None, [])`` — no advisory needed.
+
+    Foundation takes precedence over structure when both are present.
+    """
+    foundation = [p for p in changed_files if p.startswith(FOUNDATION_PREFIXES)]
+    if foundation:
+        return "foundation", foundation
+
+    structure = [
+        p
+        for p in changed_files
+        if p.startswith("src/")
+        and "/_" not in p
+        and any(marker in p for marker in STRUCTURE_MARKERS)
+    ]
+    if structure:
+        return "structure", structure
+
+    return None, []

--- a/.codex/hooks/stop-sync-reminder.py
+++ b/.codex/hooks/stop-sync-reminder.py
@@ -37,30 +37,6 @@ import sys
 
 from _shared import REPO_ROOT, changed_files
 
-FOUNDATION_PREFIXES = (
-    "AGENTS.md",
-    "CLAUDE.md",
-    ".codex/",
-    ".agents/",
-    ".claude/hooks/",
-    ".claude/rules/",
-    ".claude/settings.json",
-    "docs/ai/shared/",
-    "docs/ai/shared/skills/",
-    "src/_apps/",
-    "src/_core/",
-    "pyproject.toml",
-    ".pre-commit-config.yaml",
-)
-
-STRUCTURE_MARKERS = (
-    "/infrastructure/di/",
-    "/interface/server/routers/",
-    "/domain/protocols/",
-    "/domain/dtos/",
-)
-
-
 # AGENT_LOCALE resolver (issue #133) — separate try block so a locale.py
 # failure cannot break sync reminders. Keeps the canonical English values
 # inline below as the second arg to _loc(), preserving Issue AC.
@@ -76,6 +52,17 @@ except Exception:  # noqa: BLE001 — HC-5.5 fail-open
 
     def _resolve_locale_string(key: str) -> str:  # type: ignore[no-redef]
         return ""
+
+
+try:
+    from governor.sync_advisory import (  # noqa: E402
+        classify_advisory as _classify_advisory,
+    )
+
+    _SYNC_OK = True
+except Exception:  # noqa: BLE001 — HC-5.5 fail-open
+    _classify_advisory = None  # type: ignore[assignment]
+    _SYNC_OK = False
 
 
 def _loc(key: str, fallback: str) -> str:
@@ -99,19 +86,16 @@ def build_segments(changed: list[str] | None = None) -> list[str]:
     if changed is None:
         changed = changed_files()
 
-    foundation = [p for p in changed if p.startswith(FOUNDATION_PREFIXES)]
-    structure = [
-        p
-        for p in changed
-        if p.startswith("src/")
-        and "/_" not in p
-        and any(marker in p for marker in STRUCTURE_MARKERS)
-    ]
+    advisory_level, advisory_files = (
+        _classify_advisory(changed)
+        if _SYNC_OK and _classify_advisory is not None
+        else (None, [])
+    )
 
     segments: list[str] = []
 
     # (1) sync-reminder advisory (foundation > structure precedence)
-    if foundation:
+    if advisory_level == "foundation":
         segments.append(
             "\n".join(
                 [
@@ -120,7 +104,7 @@ def build_segments(changed: list[str] | None = None) -> list[str]:
                         "Guideline sync required before closing this work.",
                     ),
                     _loc("SYNC_FOUNDATION_FILES_HEADER", "Foundation files changed:"),
-                    *[f"- {path}" for path in foundation[:12]],
+                    *[f"- {path}" for path in advisory_files[:12]],
                     _loc("SYNC_CODEX_RUN_PRIMARY", "Codex: run $sync-guidelines"),
                     _loc(
                         "SYNC_CLAUDE_RUN_ALSO",
@@ -139,7 +123,7 @@ def build_segments(changed: list[str] | None = None) -> list[str]:
                 ]
             )
         )
-    elif structure:
+    elif advisory_level == "structure":
         segments.append(
             "\n".join(
                 [
@@ -147,7 +131,7 @@ def build_segments(changed: list[str] | None = None) -> list[str]:
                     _loc(
                         "SYNC_STRUCTURE_FILES_HEADER", "Domain structure files changed:"
                     ),
-                    *[f"- {path}" for path in structure[:12]],
+                    *[f"- {path}" for path in advisory_files[:12]],
                     _loc(
                         "SYNC_REPORT_BOTH_NOTE",
                         "When you run sync, report both AUTO-FIX and REVIEW targets "

--- a/tests/unit/agents_shared/test_stop_advisory_inline_guard.py
+++ b/tests/unit/agents_shared/test_stop_advisory_inline_guard.py
@@ -1,0 +1,77 @@
+"""Static guards for PR-A.5 sync-advisory thin-shim refactor.
+
+After PR-A.5, the Codex stop-sync-reminder hook must delegate classification
+logic to governor.sync_advisory rather than redeclaring FOUNDATION_PREFIXES /
+STRUCTURE_MARKERS inline.
+
+Guards:
+  1. FOUNDATION_PREFIXES tuple not defined inline in the hook.
+  2. STRUCTURE_MARKERS tuple not defined inline in the hook.
+  3. Hook imports classify_advisory from governor.sync_advisory (not facade).
+  4. No getattr(governor, ...) bypass in the hook.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+_HOOK = REPO_ROOT / ".codex" / "hooks" / "stop-sync-reminder.py"
+
+
+def _text() -> str:
+    return _HOOK.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# 1. FOUNDATION_PREFIXES not defined inline
+# ---------------------------------------------------------------------------
+
+
+def test_no_inline_foundation_prefixes() -> None:
+    text = _text()
+    # Must NOT define the tuple as a local name
+    assert "FOUNDATION_PREFIXES = (" not in text, (
+        f"{_HOOK.name}: FOUNDATION_PREFIXES defined inline. "
+        "Move to governor.sync_advisory — hook must be a thin shim."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. STRUCTURE_MARKERS not defined inline
+# ---------------------------------------------------------------------------
+
+
+def test_no_inline_structure_markers() -> None:
+    text = _text()
+    assert "STRUCTURE_MARKERS = (" not in text, (
+        f"{_HOOK.name}: STRUCTURE_MARKERS defined inline. "
+        "Move to governor.sync_advisory — hook must be a thin shim."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Hook imports from governor.sync_advisory submodule
+# ---------------------------------------------------------------------------
+
+
+def test_imports_from_sync_advisory_submodule() -> None:
+    text = _text()
+    assert "from governor.sync_advisory import" in text, (
+        f"{_HOOK.name}: does not import from governor.sync_advisory. "
+        "Classification must delegate to the shared submodule."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. No getattr(governor, ...) bypass
+# ---------------------------------------------------------------------------
+
+
+def test_no_getattr_governor_bypass() -> None:
+    text = _text()
+    assert "getattr(governor," not in text, (
+        f"{_HOOK.name}: getattr(governor, ...) pattern detected. "
+        "Use explicit submodule imports instead."
+    )

--- a/tests/unit/agents_shared/test_sync_advisory.py
+++ b/tests/unit/agents_shared/test_sync_advisory.py
@@ -1,0 +1,189 @@
+"""Unit tests for governor.sync_advisory.classify_advisory (PR-A.5).
+
+Positive corpus: file paths that must trigger foundation or structure advisory.
+Negative corpus: file paths that must return (None, []).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / ".agents" / "shared"))
+
+from governor.sync_advisory import (
+    FOUNDATION_PREFIXES,
+    STRUCTURE_MARKERS,
+    classify_advisory,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _level(paths: list[str]) -> str | None:
+    level, _ = classify_advisory(paths)
+    return level
+
+
+def _files(paths: list[str]) -> list[str]:
+    _, matched = classify_advisory(paths)
+    return matched
+
+
+# ---------------------------------------------------------------------------
+# 1. Foundation positive corpus
+# ---------------------------------------------------------------------------
+
+
+def test_agents_md_is_foundation() -> None:
+    assert _level(["AGENTS.md"]) == "foundation"
+
+
+def test_claude_md_is_foundation() -> None:
+    assert _level(["CLAUDE.md"]) == "foundation"
+
+
+def test_codex_hook_is_foundation() -> None:
+    assert _level([".codex/hooks/pre-tool-security.py"]) == "foundation"
+
+
+def test_agents_shared_is_foundation() -> None:
+    assert _level([".agents/shared/governor/shell_safety.py"]) == "foundation"
+
+
+def test_claude_hook_is_foundation() -> None:
+    assert _level([".claude/hooks/pre_tool_security.py"]) == "foundation"
+
+
+def test_claude_rules_is_foundation() -> None:
+    assert _level([".claude/rules/project-status.md"]) == "foundation"
+
+
+def test_claude_settings_is_foundation() -> None:
+    assert _level([".claude/settings.json"]) == "foundation"
+
+
+def test_docs_ai_shared_is_foundation() -> None:
+    assert _level(["docs/ai/shared/harness-asset-matrix.md"]) == "foundation"
+
+
+def test_src_apps_is_foundation() -> None:
+    assert _level(["src/_apps/server/app.py"]) == "foundation"
+
+
+def test_src_core_is_foundation() -> None:
+    assert _level(["src/_core/domain/base_service.py"]) == "foundation"
+
+
+def test_pyproject_toml_is_foundation() -> None:
+    assert _level(["pyproject.toml"]) == "foundation"
+
+
+def test_pre_commit_config_is_foundation() -> None:
+    assert _level([".pre-commit-config.yaml"]) == "foundation"
+
+
+def test_foundation_files_returned_in_matched() -> None:
+    paths = ["AGENTS.md", "src/user/service.py"]
+    level, matched = classify_advisory(paths)
+    assert level == "foundation"
+    assert "AGENTS.md" in matched
+    assert "src/user/service.py" not in matched
+
+
+# ---------------------------------------------------------------------------
+# 2. Foundation takes precedence over structure
+# ---------------------------------------------------------------------------
+
+
+def test_foundation_beats_structure() -> None:
+    paths = [
+        "AGENTS.md",
+        "src/user/infrastructure/di/container.py",
+    ]
+    assert _level(paths) == "foundation"
+
+
+# ---------------------------------------------------------------------------
+# 3. Structure positive corpus
+# ---------------------------------------------------------------------------
+
+
+def test_infra_di_is_structure() -> None:
+    assert _level(["src/user/infrastructure/di/container.py"]) == "structure"
+
+
+def test_server_routers_is_structure() -> None:
+    assert _level(["src/user/interface/server/routers/user_router.py"]) == "structure"
+
+
+def test_domain_protocols_is_structure() -> None:
+    assert _level(["src/user/domain/protocols/user_repo_protocol.py"]) == "structure"
+
+
+def test_domain_dtos_is_structure() -> None:
+    assert _level(["src/user/domain/dtos/user_dto.py"]) == "structure"
+
+
+def test_structure_files_returned_in_matched() -> None:
+    paths = ["src/user/infrastructure/di/container.py", "src/user/service.py"]
+    level, matched = classify_advisory(paths)
+    assert level == "structure"
+    assert "src/user/infrastructure/di/container.py" in matched
+    assert "src/user/service.py" not in matched
+
+
+# ---------------------------------------------------------------------------
+# 4. Structure negative: paths with /_ segment excluded from structure
+# ---------------------------------------------------------------------------
+
+
+def test_underscore_segment_path_is_not_structure() -> None:
+    # Paths with /_ in them are excluded from structure detection.
+    # e.g. src/user/_archive/infrastructure/di/ is not a domain structure path.
+    # (src/_core/ is a foundation prefix, so it returns "foundation" — not "structure")
+    assert _level(["src/user/_archive/infrastructure/di/container.py"]) is None
+
+
+# ---------------------------------------------------------------------------
+# 5. Negative corpus — must return (None, [])
+# ---------------------------------------------------------------------------
+
+
+def test_plain_src_file_passes() -> None:
+    assert _level(["src/user/service.py"]) is None
+
+
+def test_test_file_passes() -> None:
+    assert _level(["tests/unit/test_user.py"]) is None
+
+
+def test_readme_passes() -> None:
+    assert _level(["README.md"]) is None
+
+
+def test_docs_non_ai_shared_passes() -> None:
+    assert _level(["docs/operations/observability-otel.md"]) is None
+
+
+def test_empty_list_passes() -> None:
+    assert _level([]) is None
+    assert _files([]) == []
+
+
+# ---------------------------------------------------------------------------
+# 6. Constants integrity
+# ---------------------------------------------------------------------------
+
+
+def test_foundation_prefixes_nonempty_tuple() -> None:
+    assert isinstance(FOUNDATION_PREFIXES, tuple)
+    assert len(FOUNDATION_PREFIXES) >= 10
+
+
+def test_structure_markers_nonempty_tuple() -> None:
+    assert isinstance(STRUCTURE_MARKERS, tuple)
+    assert len(STRUCTURE_MARKERS) >= 4


### PR DESCRIPTION
## Summary

- Extracts `FOUNDATION_PREFIXES` / `STRUCTURE_MARKERS` from inline `.codex/hooks/stop-sync-reminder.py` into `.agents/shared/governor/sync_advisory.py` (single source of truth)
- Adds `classify_advisory(changed_files) -> (level, matching_files)` function that encapsulates the foundation > structure precedence logic
- Refactors `stop-sync-reminder.py` to a thin shim: imports `_classify_advisory` via try/except HC-5.5 fail-open; `build_segments` delegates classification entirely to the governor submodule
- Adds 27-case positive/negative corpus unit tests (`test_sync_advisory.py`) and 4-guard static test (`test_stop_advisory_inline_guard.py`)
- `.claude/hooks/stop-sync-reminder.sh` is intentionally **not touched** (F-1 follow-up — bash→python migration risk; see issue #168)

## Diff stat

```
.agents/shared/governor/sync_advisory.py         | +68
.codex/hooks/stop-sync-reminder.py               | +19 / -36
tests/unit/agents_shared/test_sync_advisory.py   | +190
tests/unit/agents_shared/test_stop_advisory_inline_guard.py | +80
```

## Parity verification

Before (inline):
```python
foundation = [p for p in changed if p.startswith(FOUNDATION_PREFIXES)]
structure  = [p for p in changed if p.startswith("src/") and "/_" not in p
              and any(marker in p for marker in STRUCTURE_MARKERS)]
if foundation: ...
elif structure: ...
```

After (thin shim):
```python
advisory_level, advisory_files = _classify_advisory(changed) if _SYNC_OK ...
if advisory_level == "foundation": ...
elif advisory_level == "structure": ...
```

The `classify_advisory` function in `sync_advisory.py` is a direct transcription of the same logic — same tuple values, same precedence, same `/_` exclusion.

## F-1 follow-up

Claude `.sh` sync advisory unification is tracked in issue **#168**. The bash hook continues to use its own inline arrays until that issue is resolved.

## Governor Footer
- trigger: yes
- reviewer: self
- rounds: 1
- r-points-fixed: 0
- r-points-deferred: 0
- r-points-rejected: 0
- touched-adr-consequences: ADR047-G15, ADR047-G16
- pr-scope-notes: Extracts FOUNDATION_PREFIXES/STRUCTURE_MARKERS/classify_advisory into governor.sync_advisory; Codex stop hook is now a thin shim; F-1 (Claude .sh sync advisory unification) deferred to issue #168; IC-2 partially achieved for Codex side
- final-verdict: merge-ready
- links: https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/168