### PR TITLE
feat(harness): PR-A.3 lifecycle invariant tests + pre-commit fail-soft

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,6 +93,17 @@ repos:
         pass_filenames: true
         files: '^(AGENTS\.md|CLAUDE\.md|CONTRIBUTING\.md|CODE_OF_CONDUCT\.md|SECURITY\.md|docs/ai/shared/.*\.md|docs/history/.*\.md|\.claude/rules/.*\.md|\.claude/hooks/.*|\.claude/skills/.*\.md|\.codex/rules/.*|\.codex/hooks/.*|\.agents/.*\.(py|md)|\.github/pull_request_template\.md|\.github/workflows/.*\.ya?ml)$'
 
+      # State lifecycle health check (PR-A.3):
+      # FAIL-HARD on git-tracked state files (.claude/state/, .codex/state/).
+      # WARN-ONLY (exit 0) when stale marker count exceeds threshold.
+      # pass_filenames: false — checks fixed state dirs, not changed-file list.
+      - id: state-lifecycle-check
+        name: "State lifecycle: no tracked state files (warn on stale markers)"
+        language: system
+        entry: python3 tools/check_state_lifecycle.py
+        pass_filenames: false
+        always_run: true
+
       # Guard G closure enforcement (post-ADR 047):
       # The canonical Guard G enforcement target moved from the per-PR
       # governor-review-log/ archive to the PR-description Governor Footer

--- a/tests/integration/test_stop_hook_e2e.py
+++ b/tests/integration/test_stop_hook_e2e.py
@@ -1,0 +1,112 @@
+"""E2E integration test: Codex stop-sync-reminder.py marker cleanup (PR-A.3).
+
+Runs .codex/hooks/stop-sync-reminder.py as a real subprocess against the live
+.codex/state/ directory.  Verifies that both fresh and stale exception-token
+markers written by this test are consumed by the hook's Phase 4 cleanup.
+
+Stripped environment: only PATH + HOME are forwarded to the subprocess,
+simulating a minimal agent invocation without project-specific env vars.
+
+IMPORTANT: this test writes to the real .codex/state/ directory so it
+exercises the actual production lifecycle path.  A finally block removes any
+markers the hook failed to consume so CI stays clean.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_HOOK = REPO_ROOT / ".codex" / "hooks" / "stop-sync-reminder.py"
+_STATE_DIR = REPO_ROOT / ".codex" / "state"
+
+# Unique infix so the finally block can identify markers created by this test
+# even if a real session runs concurrently.
+_E2E_INFIX = "e2etest"
+
+
+def test_stop_hook_e2e_marker_cleanup() -> None:
+    """stop-sync-reminder.py must consume all exception-token markers on Stop."""
+    _STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+    now = time.time()
+    stale_epoch = now - (48 * 3600)
+    written: list[Path] = []
+
+    try:
+        # 3 fresh markers (within 24 h — removed by IC-11 Option A bulk sweep)
+        for i in range(3):
+            ts_iso = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+            ts_compact = time.strftime("%Y%m%dT%H%M%S", time.gmtime())
+            marker = (
+                _STATE_DIR / f"exception-token-{ts_compact}-{_E2E_INFIX}f{i:012d}.json"
+            )
+            marker.write_text(
+                json.dumps({"matched": True, "token": "trivial", "ts": ts_iso}),
+                encoding="utf-8",
+            )
+            written.append(marker)
+
+        # 5 stale markers (48 h ago — also removed by bulk sweep regardless of age)
+        for i in range(5):
+            ts_iso = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(stale_epoch))
+            ts_compact = time.strftime("%Y%m%dT%H%M%S", time.gmtime(stale_epoch))
+            marker = (
+                _STATE_DIR / f"exception-token-{ts_compact}-{_E2E_INFIX}s{i:012d}.json"
+            )
+            marker.write_text(
+                json.dumps({"matched": True, "token": "trivial", "ts": ts_iso}),
+                encoding="utf-8",
+            )
+            os.utime(marker, (stale_epoch, stale_epoch))
+            written.append(marker)
+
+        # Stripped env: only PATH + HOME (no CODEX_THREAD_ID, AGENT_LOCALE, etc.)
+        env = {
+            "PATH": os.environ.get("PATH", "/usr/bin:/usr/local/bin"),
+            "HOME": os.environ.get("HOME", str(Path.home())),
+        }
+
+        proc = subprocess.run(
+            [sys.executable, str(_HOOK)],
+            cwd=str(REPO_ROOT),
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+
+        assert proc.returncode == 0, (
+            f"stop-sync-reminder.py exited with code {proc.returncode}\n"
+            f"stdout: {proc.stdout[:800]}\n"
+            f"stderr: {proc.stderr[:800]}"
+        )
+
+        # All 8 markers must be gone — consume_phase2_markers sweeps the glob
+        remaining = [m for m in written if m.exists()]
+        assert not remaining, (
+            f"{len(remaining)}/8 e2e marker(s) survived the Stop hook sweep:\n"
+            + "\n".join(f"  {m.name}" for m in remaining)
+        )
+
+        # stdout must be valid JSON (IC-2: single Stop event JSON line or empty)
+        stdout = proc.stdout.strip()
+        if stdout:
+            try:
+                json.loads(stdout)
+            except json.JSONDecodeError as exc:
+                raise AssertionError(
+                    f"Hook stdout is not valid JSON: {exc}\nstdout: {stdout[:400]}"
+                ) from exc
+
+    finally:
+        # Defensive cleanup: remove any markers this test created that survived
+        for marker in written:
+            if marker.exists():
+                marker.unlink(missing_ok=True)

--- a/tests/unit/agents_shared/test_state_lifecycle_invariant.py
+++ b/tests/unit/agents_shared/test_state_lifecycle_invariant.py
@@ -1,0 +1,161 @@
+"""Lifecycle invariant unit guards (PR-A.3).
+
+Five regression guards that protect the Phase 2/4 state lifecycle:
+
+  1. Corrupt JSON markers are skipped by read_latest_token (no crash).
+  2. Garbage ts values are skipped by read_latest_token (no crash).
+  3. Bulk consume of 200 stale markers completes in < 5 seconds.
+  4. stop-sync-reminder.py static check: both consume_phase2_markers and
+     cleanup_stale_verify_logs are still called (neither may be dropped).
+  5. Cross-reference: the AST-based fixture leak guard (test_no_test_state_leak.py)
+     must be present and contain its key test function.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / ".agents" / "shared"))
+
+from governor.markers import consume_phase2_markers, read_latest_token
+
+# ---------------------------------------------------------------------------
+# Guard 1 — corrupt JSON skipped by read_latest_token
+# ---------------------------------------------------------------------------
+
+
+def test_corrupt_json_skipped(tmp_path: Path) -> None:
+    """Corrupt JSON markers must be silently skipped, not raise."""
+    state_dir = tmp_path / ".claude" / "state"
+    state_dir.mkdir(parents=True)
+    (state_dir / "exception-token-20260101T000000-corrupt000001.json").write_text(
+        "{not valid json",
+        encoding="utf-8",
+    )
+    result = read_latest_token(state_dir)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Guard 2 — garbage ts treated as within-24h (fail-soft contract)
+# ---------------------------------------------------------------------------
+
+
+def test_garbage_ts_treated_as_recent(tmp_path: Path) -> None:
+    """_within_24h returns True on parse failure (HC-5.1 fail-soft contract).
+
+    A marker with an unparseable ts must NOT be silently dropped — it is treated
+    as "recent" so callers never silently expire on garbage input.  This test
+    guards the invariant: garbage ts → token still returned, no exception raised.
+    """
+    state_dir = tmp_path / ".claude" / "state"
+    state_dir.mkdir(parents=True)
+    marker = state_dir / "exception-token-20260101T000000-garbts000001.json"
+    marker.write_text(
+        json.dumps({"matched": True, "token": "trivial", "ts": "not-a-timestamp"}),
+        encoding="utf-8",
+    )
+    # Garbage ts → _within_24h returns True → marker is kept, token is returned
+    result = read_latest_token(state_dir)
+    assert result == "trivial", (
+        "Garbage ts must be treated as recent (fail-soft), not silently dropped"
+    )
+
+
+def test_missing_ts_field_skipped(tmp_path: Path) -> None:
+    """Markers missing the ts field entirely are silently skipped."""
+    state_dir = tmp_path / ".codex" / "state"
+    state_dir.mkdir(parents=True)
+    marker = state_dir / "exception-token-20260101T000000-nots0000001.json"
+    marker.write_text(
+        json.dumps({"matched": True, "token": "trivial"}),
+        encoding="utf-8",
+    )
+    result = read_latest_token(state_dir)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Guard 3 — 200-marker bulk consume completes quickly
+# ---------------------------------------------------------------------------
+
+
+def test_bulk_200_markers_consume(tmp_path: Path) -> None:
+    """consume_phase2_markers must handle 200 stale markers in < 5 seconds."""
+    state_dir = tmp_path / ".codex" / "state"
+    state_dir.mkdir(parents=True)
+
+    stale_epoch = time.time() - (7 * 24 * 3600)  # 7 days ago
+    stale_ts_compact = time.strftime("%Y%m%dT%H%M%S", time.gmtime(stale_epoch))
+    stale_ts_iso = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(stale_epoch))
+
+    for i in range(200):
+        marker = state_dir / f"exception-token-{stale_ts_compact}-bulk{i:012d}.json"
+        marker.write_text(
+            json.dumps({"matched": True, "token": "trivial", "ts": stale_ts_iso}),
+            encoding="utf-8",
+        )
+        os.utime(marker, (stale_epoch, stale_epoch))
+
+    assert len(list(state_dir.glob("exception-token-*.json"))) == 200
+
+    t0 = time.monotonic()
+    consume_phase2_markers(state_dir)
+    elapsed = time.monotonic() - t0
+
+    remaining = list(state_dir.glob("exception-token-*.json"))
+    assert not remaining, f"{len(remaining)} markers survived bulk consume"
+    assert elapsed < 5.0, f"Bulk consume took {elapsed:.2f}s (limit: 5s)"
+
+
+# ---------------------------------------------------------------------------
+# Guard 4 — stop-sync-reminder.py calls both cleanup functions (static)
+# ---------------------------------------------------------------------------
+
+
+def test_stop_hook_calls_consume_phase2_markers() -> None:
+    """stop-sync-reminder.py must call consume_phase2_markers. Regression guard."""
+    hook_text = (REPO_ROOT / ".codex" / "hooks" / "stop-sync-reminder.py").read_text(
+        encoding="utf-8"
+    )
+    assert "consume_phase2_markers" in hook_text, (
+        "REGRESSION: stop-sync-reminder.py no longer calls consume_phase2_markers. "
+        "Phase 2 marker cleanup (IC-11 Option A) must be preserved."
+    )
+
+
+def test_stop_hook_calls_cleanup_stale_verify_logs() -> None:
+    """stop-sync-reminder.py must call cleanup_stale_verify_logs. Regression guard."""
+    hook_text = (REPO_ROOT / ".codex" / "hooks" / "stop-sync-reminder.py").read_text(
+        encoding="utf-8"
+    )
+    assert "cleanup_stale_verify_logs" in hook_text, (
+        "REGRESSION: stop-sync-reminder.py no longer calls cleanup_stale_verify_logs. "
+        "Stale verify-log cleanup must be preserved."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Guard 5 — fixture leak guard cross-reference
+# ---------------------------------------------------------------------------
+
+
+def test_fixture_leak_guard_exists() -> None:
+    """The AST-based fixture leak guard file must exist and be intact."""
+    guard_file = (
+        REPO_ROOT / "tests" / "unit" / "agents_shared" / "test_no_test_state_leak.py"
+    )
+    assert guard_file.exists(), (
+        f"test_no_test_state_leak.py not found at {guard_file}. "
+        "This file guards against fixtures writing to real state dirs."
+    )
+    text = guard_file.read_text(encoding="utf-8")
+    assert "test_no_fixture_writes_real_state_dir" in text, (
+        "Key guard 'test_no_fixture_writes_real_state_dir' is missing from "
+        "test_no_test_state_leak.py — the guard may have been accidentally removed."
+    )

--- a/tools/check_state_lifecycle.py
+++ b/tools/check_state_lifecycle.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""State lifecycle health check — pre-commit integration (PR-A.3).
+
+Two-tier policy:
+  FAIL-HARD (exit 1) — git-tracked files exist under .claude/state/ or
+    .codex/state/: the .gitignore guard has been bypassed and exception-token
+    or verify-log files may be committed to version control.
+
+  WARN-ONLY (exit 0 + stderr) — stale marker count exceeds the threshold K.
+    A non-zero stale count is informational: the Stop hook may not have fired
+    recently, but it is not a commit-blocking error.
+
+Usage (pre-commit entry):
+  python3 tools/check_state_lifecycle.py
+  (pass_filenames: false — the tool checks fixed directories, not changed files)
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+_STATE_DIRS = (
+    REPO_ROOT / ".claude" / "state",
+    REPO_ROOT / ".codex" / "state",
+)
+# Warn when the total stale-marker count across both state dirs reaches this.
+_STALE_WARN_THRESHOLD = 10
+
+
+def _git_tracked_state_files() -> list[str]:
+    """Return a list of git-tracked paths inside the two state directories."""
+    tracked: list[str] = []
+    for pattern in (".claude/state/", ".codex/state/"):
+        result = subprocess.run(  # noqa: S603
+            ["git", "ls-files", pattern],
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        tracked.extend(line for line in result.stdout.splitlines() if line)
+    return tracked
+
+
+def _stale_counts(state_dir: Path) -> dict[str, int]:
+    """Return {'total': N, 'stale': M} marker counts for *state_dir*."""
+    if not state_dir.exists():
+        return {"total": 0, "stale": 0}
+
+    now = time.time()
+    total = 0
+    stale = 0
+    for pattern in ("exception-token-*.json", "verify-log-*.json"):
+        for path in state_dir.glob(pattern):
+            total += 1
+            try:
+                if (now - path.stat().st_mtime) > 86400:  # 24 h
+                    stale += 1
+            except OSError:
+                pass
+    return {"total": total, "stale": stale}
+
+
+def main() -> int:
+    # ------------------------------------------------------------------ #
+    # FAIL-HARD: tracked state files in version control                   #
+    # ------------------------------------------------------------------ #
+    tracked = _git_tracked_state_files()
+    if tracked:
+        print(
+            "check_state_lifecycle: FAIL — git-tracked state files detected:",
+            file=sys.stderr,
+        )
+        for f in tracked:
+            print(f"  {f}", file=sys.stderr)
+        print(
+            "\nThese files must not be committed.  Add them to .gitignore or run:\n"
+            "  git rm --cached .claude/state/ .codex/state/",
+            file=sys.stderr,
+        )
+        return 1
+
+    # ------------------------------------------------------------------ #
+    # WARN-ONLY: stale marker accumulation                                #
+    # ------------------------------------------------------------------ #
+    total_stale = 0
+    for state_dir in _STATE_DIRS:
+        counts = _stale_counts(state_dir)
+        if counts["stale"] > 0:
+            rel = state_dir.relative_to(REPO_ROOT)
+            print(
+                f"check_state_lifecycle: WARNING — {counts['stale']} stale marker(s)"
+                f" in {rel}/ (total: {counts['total']})."
+                " Stop hook may not have fired recently.",
+                file=sys.stderr,
+            )
+        total_stale += counts["stale"]
+
+    if total_stale > _STALE_WARN_THRESHOLD:
+        print(
+            f"check_state_lifecycle: WARNING — {total_stale} stale markers"
+            f" exceed threshold ({_STALE_WARN_THRESHOLD})."
+            " Run: python3 tools/governor_state_doctor.py",
+            file=sys.stderr,
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- **7 unit tests** (`test_state_lifecycle_invariant.py`): 5 regression guards protecting Phase 2/4 state lifecycle — corrupt JSON skipped, garbage ts treated as recent (HC-5.1 fail-soft), missing ts skipped, 200-marker bulk consume < 5s, static guard confirming both `consume_phase2_markers` + `cleanup_stale_verify_logs` are still called in `stop-sync-reminder.py`, cross-ref guard that `test_no_test_state_leak.py` exists.
- **1 integration test** (`test_stop_hook_e2e.py`): subprocess invocation of `stop-sync-reminder.py` against real `.codex/state/` with stripped env (PATH + HOME only). Writes 3 fresh + 5 stale markers, asserts all 8 are consumed, validates JSON stdout. `finally` block cleans up survivors.
- **`tools/check_state_lifecycle.py`** + **`.pre-commit-config.yaml`**: pre-commit hook. FAIL-HARD on git-tracked state files; WARN-ONLY (exit 0) when stale marker count exceeds threshold (10). Registered as `state-lifecycle-check` (`pass_filenames: false`, `always_run: true`).

Test count: 448 → 455 (+7 unit, +1 integration).

## Test plan

- [x] `pytest tests/unit/agents_shared/test_state_lifecycle_invariant.py -v` — 7 passed
- [x] `pytest tests/integration/test_stop_hook_e2e.py -v` — 1 passed
- [x] `pytest tests/unit/agents_shared/ -q` — 455 passed
- [x] `pre-commit run --files <changed-files>` — all hooks passed (incl. new state-lifecycle-check)

## Governor Footer

- trigger: yes
- reviewer: self
- rounds: 1
- r-points-fixed: 0
- r-points-deferred: 0
- r-points-rejected: 0
- touched-adr-consequences: none
- pr-scope-notes: PR-A.3 per plan; depends on PR-A.1 (governor_state_doctor) + PR-A.2b (stop-hook early-exit fix); pre-commit fail-hard on tracked state, warn-only on stale count
- final-verdict: merge-ready
- links: n/a