### PR TITLE
feat(governor): F-1 — Claude bash hook sync advisory SOT via governor.sync_advisory_cli

### DIFF
--- a/.agents/shared/governor/sync_advisory.py
+++ b/.agents/shared/governor/sync_advisory.py
@@ -1,21 +1,21 @@
-"""Shared sync-advisory classification (PR-A.5).
+"""Shared sync-advisory classification (PR-A.5 + F-1).
 
 Single source of truth for ``FOUNDATION_PREFIXES`` / ``STRUCTURE_MARKERS``
-and the ``classify_advisory`` decision function. Extracted from the inline
-declarations in ``.codex/hooks/stop-sync-reminder.py`` so both the Codex
-Python hook and future Claude-side migrations consume identical rules
-(IC-2 single-source goal).
+and the ``classify_advisory`` decision function.  Both the Codex Python hook
+(``.codex/hooks/stop-sync-reminder.py``) and the Claude bash hook
+(``.claude/hooks/stop-sync-reminder.sh``) delegate here via thin shims,
+satisfying IC-2 (single SOT) and IC-14 (no inline policy redeclaration).
 
-The ``.claude/hooks/stop-sync-reminder.sh`` bash hook is NOT yet migrated
-(F-1 follow-up — see GitHub issue linked in PR-A.5 Footer).
+The bash hook uses ``governor.sync_advisory_cli`` (same package) as its
+bridge, with a fail-open inline-grep fallback for environments where Python
+is unavailable (HC-5.5).
 
-Semantic note — bash vs Python matching:
-  The bash hook uses anchored regex patterns (``pyproject.toml$``,
-  ``CLAUDE.md$``, ``.claude/settings.json$``) while this module uses
-  ``str.startswith`` prefix matching. Paths like ``pyproject.toml.bak``
-  would match here but not in the bash hook. Such paths are not produced
-  by normal git operations, so the divergence is accepted until F-1
-  unifies both sides.
+Semantic note — primary vs fallback matching:
+  This module uses ``str.startswith`` prefix matching. The bash fallback
+  (inactive under normal conditions) uses anchored ``grep -E`` patterns.
+  Paths like ``pyproject.toml.bak`` would match the Python path but not
+  the bash fallback.  Such paths are not produced by normal git operations,
+  so the divergence is accepted and confined to the fallback-only path.
 """
 
 from __future__ import annotations

--- a/.agents/shared/governor/sync_advisory.py
+++ b/.agents/shared/governor/sync_advisory.py
@@ -1,7 +1,7 @@
 """Shared sync-advisory classification (PR-A.5 + F-1).
 
 Single source of truth for ``FOUNDATION_PREFIXES`` / ``STRUCTURE_MARKERS``
-and the ``classify_advisory`` decision function.  Both the Codex Python hook
+and the ``classify_advisory`` decision function. Both the Codex Python hook
 (``.codex/hooks/stop-sync-reminder.py``) and the Claude bash hook
 (``.claude/hooks/stop-sync-reminder.sh``) delegate here via thin shims,
 satisfying IC-2 (single SOT) and IC-14 (no inline policy redeclaration).
@@ -14,7 +14,7 @@ Semantic note — primary vs fallback matching:
   This module uses ``str.startswith`` prefix matching. The bash fallback
   (inactive under normal conditions) uses anchored ``grep -E`` patterns.
   Paths like ``pyproject.toml.bak`` would match the Python path but not
-  the bash fallback.  Such paths are not produced by normal git operations,
+  the bash fallback. Such paths are not produced by normal git operations,
   so the divergence is accepted and confined to the fallback-only path.
 """
 

--- a/.agents/shared/governor/sync_advisory_cli.py
+++ b/.agents/shared/governor/sync_advisory_cli.py
@@ -23,7 +23,7 @@ def main() -> None:
         from governor.sync_advisory import classify_advisory
 
         lines = sys.stdin.read().splitlines()
-        changed = [line for line in lines if line.strip()]
+        changed = [line for line in lines if line]
         level, files = classify_advisory(changed)
         level_str = level if level is not None else "none"
         print(level_str)

--- a/.agents/shared/governor/sync_advisory_cli.py
+++ b/.agents/shared/governor/sync_advisory_cli.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""CLI bridge for governor.sync_advisory — bash integration (F-1).
+
+Reads newline-separated file paths from stdin.  Writes to stdout:
+  Line 1: "foundation" | "structure" | "none"
+  Lines 2+: matched file paths (omitted when level is "none")
+
+Always exits 0 — HC-5.5 fail-open: any exception produces "none" so the
+calling bash hook can use the result without error-path branching.
+
+Invocation (from .claude/hooks/stop-sync-reminder.sh):
+  printf '%s\\n' "$CHANGED" \\
+    | PYTHONPATH="$SHARED_DIR" python3 -m governor.sync_advisory_cli
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def main() -> None:
+    try:
+        from governor.sync_advisory import classify_advisory
+
+        lines = sys.stdin.read().splitlines()
+        changed = [line for line in lines if line.strip()]
+        level, files = classify_advisory(changed)
+        level_str = level if level is not None else "none"
+        print(level_str)
+        for f in files:
+            print(f)
+    except Exception:  # noqa: BLE001
+        # HC-5.5 fail-open: import error or runtime error → no advisory
+        print("none")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/stop-sync-reminder.sh
+++ b/.claude/hooks/stop-sync-reminder.sh
@@ -69,11 +69,27 @@ COMPLETION_OUT=$(python3 "${HOOK_DIR}/completion_gate.py" 2>/dev/null || true)
 
 [ -z "$CHANGED" ] && exit 0
 
-# Foundation: project-wide impact
-FOUNDATION=$(echo "$CHANGED" | grep -E '^(src/_core/|src/_apps/|pyproject\.toml$|\.pre-commit-config\.yaml$|AGENTS\.md$|CLAUDE\.md$|\.codex/|\.agents/|\.claude/rules/|\.claude/hooks/|\.claude/settings\.json$|docs/ai/shared/|docs/ai/shared/skills/)' || true)
+# Delegate classification to governor.sync_advisory via Python shim (F-1 SOT).
+# HC-5.5 fail-open: if the shim is unavailable, fall back to inline grep patterns.
+FOUNDATION=""
+STRUCTURE=""
+_ADVISORY_OK=0
+if _ADVISORY_RAW=$(printf '%s\n' "$CHANGED" \
+        | PYTHONPATH="${SHARED_DIR}" python3 -m governor.sync_advisory_cli 2>/dev/null); then
+    _ADVISORY_LEVEL=$(echo "$_ADVISORY_RAW" | head -1)
+    _ADVISORY_FILES=$(echo "$_ADVISORY_RAW" | tail -n +2 | grep -v '^$' || true)
+    case "$_ADVISORY_LEVEL" in
+        foundation) FOUNDATION="$_ADVISORY_FILES"; _ADVISORY_OK=1 ;;
+        structure)  STRUCTURE="$_ADVISORY_FILES";  _ADVISORY_OK=1 ;;
+        none)       _ADVISORY_OK=1 ;;
+    esac
+fi
 
-# Domain Structure: domain-level architectural impact (exclude _core/_apps)
-STRUCTURE=$(echo "$CHANGED" | grep -E '^src/[^_].*/((infrastructure/di/|interface/server/routers/|domain/protocols/|domain/dtos/))' || true)
+if [ "$_ADVISORY_OK" -eq 0 ]; then
+    # Fallback: governor.sync_advisory_cli unavailable (Python absent, import error, etc.)
+    FOUNDATION=$(echo "$CHANGED" | grep -E '^(src/_core/|src/_apps/|pyproject\.toml$|\.pre-commit-config\.yaml$|AGENTS\.md$|CLAUDE\.md$|\.codex/|\.agents/|\.claude/rules/|\.claude/hooks/|\.claude/settings\.json$|docs/ai/shared/|docs/ai/shared/skills/)' || true)
+    STRUCTURE=$(echo "$CHANGED" | grep -E '^src/[^_].*/((infrastructure/di/|interface/server/routers/|domain/protocols/|domain/dtos/))' || true)
+fi
 
 if [ -n "$FOUNDATION" ]; then
     echo ""

--- a/.claude/hooks/stop-sync-reminder.sh
+++ b/.claude/hooks/stop-sync-reminder.sh
@@ -82,6 +82,7 @@ if _ADVISORY_RAW=$(printf '%s\n' "$CHANGED" \
         foundation) FOUNDATION="$_ADVISORY_FILES"; _ADVISORY_OK=1 ;;
         structure)  STRUCTURE="$_ADVISORY_FILES";  _ADVISORY_OK=1 ;;
         none)       _ADVISORY_OK=1 ;;
+        *)          _ADVISORY_OK=1 ;;  # future extension — treat unknown level as none
     esac
 fi
 

--- a/tests/unit/agents_shared/test_stop_advisory_inline_guard.py
+++ b/tests/unit/agents_shared/test_stop_advisory_inline_guard.py
@@ -1,19 +1,26 @@
-"""Static guards and fail-open behavioral tests for PR-A.5.
+"""Static guards and fail-open behavioral tests for PR-A.5 + F-1.
 
 After PR-A.5, the Codex stop-sync-reminder hook must delegate classification
 logic to governor.sync_advisory rather than redeclaring FOUNDATION_PREFIXES /
 STRUCTURE_MARKERS inline.
 
-Guards:
+After F-1, the Claude bash hook must also delegate via governor.sync_advisory_cli
+with a HC-5.5 fail-open fallback to inline grep patterns.
+
+Codex Python hook guards:
   1. FOUNDATION_PREFIXES tuple not defined inline in the hook.
   2. STRUCTURE_MARKERS tuple not defined inline in the hook.
   3. Hook imports classify_advisory from governor.sync_advisory (not facade).
   4. No getattr(governor, ...) bypass in the hook.
 
-Behavioral tests:
+Codex behavioral tests:
   5. When _SYNC_OK=False (import failed), build_segments must not emit any
      sync advisory segment (HC-5.5 fail-open — IC-19 always-fallback does
      not apply when the import itself failed).
+
+Claude bash hook guards (F-1):
+  6. Bash hook invokes governor.sync_advisory_cli (primary classification path).
+  7. Bash hook retains a fail-open fallback (HC-5.5: inline grep when Python unavailable).
 """
 
 from __future__ import annotations
@@ -59,10 +66,15 @@ def _load_codex_stop_sync() -> types.ModuleType:
 
 
 _HOOK = REPO_ROOT / ".codex" / "hooks" / "stop-sync-reminder.py"
+_CLAUDE_HOOK = REPO_ROOT / ".claude" / "hooks" / "stop-sync-reminder.sh"
 
 
 def _text() -> str:
     return _HOOK.read_text(encoding="utf-8")
+
+
+def _bash_text() -> str:
+    return _CLAUDE_HOOK.read_text(encoding="utf-8")
 
 
 # ---------------------------------------------------------------------------
@@ -148,3 +160,31 @@ def test_sync_ok_false_no_advisory_segment() -> None:
             assert marker not in seg, (
                 f"Sync advisory appeared despite _SYNC_OK=False: {marker!r} found in segment"
             )
+
+
+# ---------------------------------------------------------------------------
+# 6. Claude bash hook delegates to governor.sync_advisory_cli (F-1)
+# ---------------------------------------------------------------------------
+
+
+def test_claude_bash_hook_delegates_to_sync_advisory_cli() -> None:
+    """stop-sync-reminder.sh must invoke governor.sync_advisory_cli (F-1 primary path)."""
+    text = _bash_text()
+    assert "sync_advisory_cli" in text, (
+        f"{_CLAUDE_HOOK.name}: does not invoke governor.sync_advisory_cli. "
+        "F-1 migration: primary classification must delegate to the shared governor module."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 7. Claude bash hook retains fail-open fallback (HC-5.5)
+# ---------------------------------------------------------------------------
+
+
+def test_claude_bash_hook_has_fail_open_fallback() -> None:
+    """stop-sync-reminder.sh must retain an inline grep fallback for HC-5.5 compliance."""
+    text = _bash_text()
+    assert "_ADVISORY_OK" in text, (
+        f"{_CLAUDE_HOOK.name}: _ADVISORY_OK flag absent — HC-5.5 fail-open fallback "
+        "must be present so classification degrades gracefully when Python is unavailable."
+    )

--- a/tests/unit/agents_shared/test_stop_advisory_inline_guard.py
+++ b/tests/unit/agents_shared/test_stop_advisory_inline_guard.py
@@ -182,9 +182,15 @@ def test_claude_bash_hook_delegates_to_sync_advisory_cli() -> None:
 
 
 def test_claude_bash_hook_has_fail_open_fallback() -> None:
-    """stop-sync-reminder.sh must retain an inline grep fallback for HC-5.5 compliance."""
+    """stop-sync-reminder.sh must retain the inline grep fallback for HC-5.5 compliance."""
     text = _bash_text()
     assert "_ADVISORY_OK" in text, (
         f"{_CLAUDE_HOOK.name}: _ADVISORY_OK flag absent — HC-5.5 fail-open fallback "
         "must be present so classification degrades gracefully when Python is unavailable."
+    )
+    # The inline grep fallback patterns must still be present in the file so the
+    # hook remains functional when Python is entirely unavailable.
+    assert "grep -E" in text, (
+        f"{_CLAUDE_HOOK.name}: inline grep -E fallback patterns absent. "
+        "HC-5.5 requires a working fallback when Python is unavailable."
     )

--- a/tests/unit/agents_shared/test_sync_advisory.py
+++ b/tests/unit/agents_shared/test_sync_advisory.py
@@ -1,13 +1,16 @@
-"""Unit tests for governor.sync_advisory.classify_advisory (PR-A.5).
+"""Unit tests for governor.sync_advisory.classify_advisory (PR-A.5 + F-1).
 
 Positive corpus: file paths that must trigger foundation or structure advisory.
 Negative corpus: file paths that must return (None, []).
+Section 7: CLI bridge (sync_advisory_cli) output format and fail-open.
 """
 
 from __future__ import annotations
 
+import io
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(REPO_ROOT / ".agents" / "shared"))
@@ -187,3 +190,58 @@ def test_foundation_prefixes_nonempty_tuple() -> None:
 def test_structure_markers_nonempty_tuple() -> None:
     assert isinstance(STRUCTURE_MARKERS, tuple)
     assert len(STRUCTURE_MARKERS) >= 4
+
+
+# ---------------------------------------------------------------------------
+# 7. CLI bridge (sync_advisory_cli) — output format and fail-open (F-1)
+# ---------------------------------------------------------------------------
+
+
+def _run_cli(stdin_text: str) -> list[str]:
+    """Run sync_advisory_cli.main() with the given stdin, return stdout lines."""
+    import governor.sync_advisory_cli as cli_mod
+
+    captured = io.StringIO()
+    with (
+        patch("sys.stdin", io.StringIO(stdin_text)),
+        patch("sys.stdout", captured),
+    ):
+        cli_mod.main()
+    return [line for line in captured.getvalue().splitlines() if line]
+
+
+def test_cli_foundation_output() -> None:
+    lines = _run_cli("AGENTS.md\nsrc/user/service.py\n")
+    assert lines[0] == "foundation"
+    assert "AGENTS.md" in lines[1:]
+
+
+def test_cli_structure_output() -> None:
+    lines = _run_cli("src/user/infrastructure/di/container.py\n")
+    assert lines[0] == "structure"
+    assert "src/user/infrastructure/di/container.py" in lines[1:]
+
+
+def test_cli_none_output() -> None:
+    lines = _run_cli("src/user/service.py\n")
+    assert lines == ["none"]
+
+
+def test_cli_empty_stdin_returns_none() -> None:
+    lines = _run_cli("")
+    assert lines == ["none"]
+
+
+def test_cli_fail_open_on_classify_error() -> None:
+    """Any exception inside main() must produce 'none' cleanly (HC-5.5 fail-open)."""
+    import governor.sync_advisory as adv_mod
+    import governor.sync_advisory_cli as cli_mod
+
+    captured = io.StringIO()
+    with (
+        patch("sys.stdin", io.StringIO("AGENTS.md\n")),
+        patch("sys.stdout", captured),
+        patch.object(adv_mod, "classify_advisory", side_effect=RuntimeError("boom")),
+    ):
+        cli_mod.main()
+    assert captured.getvalue().strip() == "none"


### PR DESCRIPTION
## Summary

- Migrates \`.claude/hooks/stop-sync-reminder.sh\` from inline bash \`grep -E\` classification to delegating FOUNDATION/STRUCTURE detection to the shared \`governor.sync_advisory\` module, satisfying **IC-2** (single SOT) and **IC-14** (no inline policy redeclaration in hooks)
- Adds \`.agents/shared/governor/sync_advisory_cli.py\`: thin Python CLI bridge that reads newline-delimited file paths from stdin and outputs \`foundation\`/\`structure\`/\`none\` + matched files; **HC-5.5 fail-open** — any exception prints \`"none"\` and exits 0
- **HC-5.5 fallback preserved**: inline grep patterns remain as the fallback path when Python is unavailable (\`_ADVISORY_OK=0\`); \`*)\` wildcard in \`case\` block prevents silent regression if \`classify_advisory\` gains new levels in future
- Closes issue #168 (F-1 follow-up from PR-A.5)

## Test plan

- [x] 5 new CLI unit tests in \`test_sync_advisory.py\` §7: foundation, structure, none, empty stdin, fail-open on classify error
- [x] 2 new bash hook static guards in \`test_stop_advisory_inline_guard.py\` (Guard 6: invokes \`sync_advisory_cli\`; Guard 7: \`_ADVISORY_OK\` flag + \`grep -E\` fallback present)
- [x] 462 unit tests pass
- [x] Codex cross-review round 1 → APPROVE-WITH-CHANGES (6 R-points raised)
- [x] Codex cross-review round 2 → APPROVE (all R-points closed)
- [x] Pre-commit hooks pass

## R-point Closure

ADR045-Phase5 (thin shim), ADR047-G15 (no \`__all__\` expansion), ADR047-G16 (IC-14: no inline policy redeclaration in hooks), IC-2 (single SOT for FOUNDATION/STRUCTURE classification), HC-5.5 (fail-open preserved).

| R-point | Severity | Closure | Notes |
|---------|----------|---------|-------|
| R1 | NIT | Fixed | \`__main__\` pattern confirmed correct — no change needed |
| R2 | NIT | Deferred-with-rationale | Optional \`__init__.py\` comment; no functional impact |
| R3 | MEDIUM | Fixed | \`*)\` wildcard arm added to case block |
| R4 | MEDIUM | Fixed | Guard 7 now asserts both \`_ADVISORY_OK\` and \`grep -E\` presence |
| R5 | NIT | Fixed | \`if line\` replaces \`if line.strip()\` |
| R6 | NIT | Fixed | Double-space after period in docstring fixed |

## Governor Footer

- trigger: yes
- reviewer: codex
- rounds: 2
- r-points-fixed: 5
- r-points-deferred: 1
- r-points-rejected: 0
- touched-adr-consequences: ADR047-G15, ADR047-G16
- pr-scope-notes: F-1 follow-up from PR-A.5; Claude bash hook delegates to governor.sync_advisory_cli with HC-5.5 inline-grep fallback; satisfies IC-2 and IC-14
- final-verdict: merge-ready
- links: n/a