### PR TITLE
docs(agents): PR-B.4c — AGENTS.override.md de-recommendation

### DIFF
--- a/.codex/hooks/session-start.py
+++ b/.codex/hooks/session-start.py
@@ -10,7 +10,7 @@ message = "\n".join(
         "- Command hooks: .codex/hooks.json",
         "- Reasoning-level guards (F/G/H/I) live in AGENTS.md § Reasoning-Level Consistency Guards; they apply to every conversation and review step, not only PR-level work.",
         "- Use `codex -p research` or `codex --search` only when live web search is actually needed.",
-        "- If context feels tight, keep root AGENTS.md short and prefer AGENTS.override.md plus named skills.",
+        "- If context feels tight, keep root AGENTS.md short and prefer named skills; AGENTS.override.md is acceptable only when explicitly subject to the same governance as AGENTS.md.",
         "- Codex memories are personal/session optimization, not the team's canonical rules.",
     ]
 )

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -449,7 +449,8 @@ uv run alembic current
 ## Drift Management
 
 - `AGENTS.md` is the canonical source for shared rules; tool-specific harness docs must point here instead of re-copying rules
-- Keep root `AGENTS.md` short and stable; when local context needs more detail, prefer named skills instead of expanding the root doc; `AGENTS.override.md` may be used only if it is explicitly subject to the same drift-management and language-policy governance as `AGENTS.md` itself
+- Keep root `AGENTS.md` short and stable; when local context needs more detail, prefer named skills instead of expanding the root doc
+- `AGENTS.override.md` may be used only if it is explicitly subject to the same drift-management and language-policy governance as `AGENTS.md` itself
 - Codex memories are personal/session optimization only; do not treat them as a shared rule source
 - Shared rule sources: `AGENTS.md`, `docs/ai/shared/`, `docs/ai/shared/skills/`, `.claude/`, `.codex/`, and `.agents/`
 - Update related documentation in the same change when shared rules or harness behavior changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -449,7 +449,7 @@ uv run alembic current
 ## Drift Management
 
 - `AGENTS.md` is the canonical source for shared rules; tool-specific harness docs must point here instead of re-copying rules
-- Keep root `AGENTS.md` short and stable; when local context needs more detail, prefer `AGENTS.override.md` or named skills instead of expanding the root doc
+- Keep root `AGENTS.md` short and stable; when local context needs more detail, prefer named skills instead of expanding the root doc; `AGENTS.override.md` may be used only if it is explicitly subject to the same drift-management and language-policy governance as `AGENTS.md` itself
 - Codex memories are personal/session optimization only; do not treat them as a shared rule source
 - Shared rule sources: `AGENTS.md`, `docs/ai/shared/`, `docs/ai/shared/skills/`, `.claude/`, `.codex/`, and `.agents/`
 - Update related documentation in the same change when shared rules or harness behavior changes

--- a/docs/ai/shared/repo-facts.md
+++ b/docs/ai/shared/repo-facts.md
@@ -39,7 +39,7 @@ This file contains stable repository facts for both Claude and Codex workflows.
 ## Context Management
 
 - Keep root `AGENTS.md` short and stable.
-- Use nested `AGENTS.override.md` for directory-local rules when a subtree needs extra guidance.
+- Prefer named skills (`.agents/skills/*/SKILL.md`) for local extension; `AGENTS.override.md` may be used only if it is explicitly subject to the same drift-management and language-policy governance as `AGENTS.md` itself.
 - Put repeatable procedures in `.agents/skills/*/SKILL.md`.
 - Use `codex -p research` or `codex --search` only when live web search is necessary.
 - Treat Codex memories as personal or session-local optimization only, never as team governance.


### PR DESCRIPTION
## Summary

Weakens the `AGENTS.override.md` default recommendation in `§ Drift Management` across three locations:

- **AGENTS.md**: Split former run-on bullet into two: (1) prefer named skills for local extension; (2) `AGENTS.override.md` acceptable only when explicitly subject to the same drift-management + language-policy governance as `AGENTS.md` itself
- **docs/ai/shared/repo-facts.md** L42: Updated unqualified "Use nested `AGENTS.override.md`" → named-skills-first with governance condition
- **.codex/hooks/session-start.py** L13: Updated "prefer `AGENTS.override.md` plus named skills" in session systemMessage → named-skills-first with governance condition

Named skills (`.agents/skills/*/SKILL.md`, `.claude/skills/*/SKILL.md`) are the established, governed extension mechanism. `AGENTS.override.md` creates a parallel governance track not automatically subject to drift-management or language-policy enforcement; this PR makes the governance condition explicit.

No `must/shall` policy language introduced — this is a weakening (from default-recommend to conditional-allowed), not a hard ban.

## Diff stat

```
 .codex/hooks/session-start.py | 2 +-
 AGENTS.md                     | 3 ++-
 docs/ai/shared/repo-facts.md  | 2 +-
 3 files changed, 4 insertions(+), 3 deletions(-)
```

## Test plan

- [x] `python3 tools/check_language_policy.py` — 0 violations (182 files scanned)
- [x] Remaining AGENTS.override.md grep: `grep -rn "AGENTS.override" ... | grep -v archive/` → 3 hits, all qualified language
- [x] `pre-commit run --all-files` passes

## R-point Closure (Round 1 → Round 2)

| R# | Severity | Description | Status |
|----|----------|-------------|--------|
| R1 | MAJOR | `repo-facts.md` L42 unqualified "Use nested `AGENTS.override.md`" | Fixed |
| R2 | MAJOR | `.codex/hooks/session-start.py` L13 unqualified "prefer `AGENTS.override.md`" in session systemMessage | Fixed |
| R3 | NIT | `AGENTS.md` run-on sentence — split into two bullets | Fixed |

## Governor Footer

- trigger: yes
- reviewer: codex-cli
- rounds: 2
- r-points-fixed: 3
- r-points-deferred: 0
- r-points-rejected: 0
- touched-adr-consequences: none
- pr-scope-notes: no must/shall language; no new IC slots; named-skills-first + governance-condition qualifier applied consistently across 3 locations
- final-verdict: merge-ready
- links: n/a