### PR TITLE
fix(docs): correct Codex CLI skill count 15 → 14

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Full integration walkthrough (auth · RBAC · worker · admin · RAG · OTEL): [
 **AI-assisted acceleration**
 
 - `/new-domain order` scaffolds **44 files** (15 source + 25 `__init__.py` + 4 tests) in one command
-- **14 Claude Code + 15 Codex CLI skills** sharing one `AGENTS.md` rules file
+- **14 Claude Code + 14 Codex CLI skills** sharing one `AGENTS.md` rules file
 - Both tools supported equally — swap `/` for `$` to switch between them
 - Full setup: [`docs/ai-development.md`](docs/ai-development.md)
 - Manual path: [`docs/tutorial/first-domain.md`](docs/tutorial/first-domain.md) (Path B)
@@ -141,7 +141,7 @@ Full integration walkthrough (auth · RBAC · worker · admin · RAG · OTEL): [
 | Zero-boilerplate CRUD (8 methods) | **Yes** | No | No | No |
 | Auto domain discovery | **Yes** | No | No | No |
 | Architecture enforcement (pre-commit) | **Yes** | No | No | No |
-| AI workflow skills (Claude + Codex) | **14 + 15** | 0 | 0 | 0 |
+| AI workflow skills (Claude + Codex) | **14 + 14** | 0 | 0 | 0 |
 | Vector infrastructure (S3 Vectors) | **Yes** | No | No | No |
 | Multi-interface (API + Worker + Admin + MCP) | **3 + 1 planned** | 2 | 1 | 1 |
 | Architecture Decision Records | **18 active · 30 archived** | 0 | 0 | 0 |

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -95,7 +95,7 @@ make quickstart   # :8001 에 FastAPI 기동, SQLite 스키마 자동 생성
 | 보일러플레이트 제로 CRUD (8개 메서드) | **Yes** | No | No | No |
 | 도메인 자동 발견 | **Yes** | No | No | No |
 | 아키텍처 자동 강제 (pre-commit) | **Yes** | No | No | No |
-| AI 워크플로우 스킬 (Claude + Codex) | **14 + 15** | 0 | 0 | 0 |
+| AI 워크플로우 스킬 (Claude + Codex) | **14 + 14** | 0 | 0 | 0 |
 | 벡터 인프라 (S3 Vectors) | **Yes** | No | No | No |
 | 멀티 인터페이스 (API + Worker + Admin + MCP) | **3 + 1 예정** | 2 | 1 | 1 |
 | Architecture Decision Records | **18 active · 30 archived** | 0 | 0 | 0 |

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -84,7 +84,7 @@ make quickstart   # :8001 에 FastAPI 기동, SQLite 스키마 자동 생성
 - **도메인 자동 발견.** `src/{name}/` 에 폴더 하나만 두면 자동 등록. Container 수정도, bootstrap 수정도 필요 없음.
 - **환경변수 한 줄로 교체 가능한 인프라.** PostgreSQL / MySQL / SQLite · DynamoDB · S3 / MinIO · S3 Vectors · SQS / RabbitMQ / InMemory · LLM/Embedding 모두 OpenAI / Bedrock.
 - **커밋 시점에 아키텍처 강제.** Pre-commit 훅이 `Domain → Infrastructure` import 를 차단하여 DDD 계약이 썩지 않도록 보장.
-- **AI 네이티브 워크플로우.** Claude Code 14개 + Codex CLI 15개 스킬이 동일한 `AGENTS.md` 규칙을 공유 — 한 줄로 도메인 스캐폴딩, 라우트 추가, 아키텍처 감사가 가능.
+- **AI 네이티브 워크플로우.** Claude Code 14개 + Codex CLI 14개 스킬이 동일한 `AGENTS.md` 규칙을 공유 — 한 줄로 도메인 스캐폴딩, 라우트 추가, 아키텍처 감사가 가능.
 
 ---
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -12,7 +12,7 @@ and the "why not X?" questions that come up on HN and Reddit.
 | Zero-boilerplate CRUD (8 methods) | **Yes** | No | No | No |
 | Auto domain discovery | **Yes** | No | No | No |
 | Architecture enforcement (pre-commit) | **Yes** | No | No | No |
-| AI workflow skills (Claude + Codex) | **14 + 15** | 0 | 0 | 0 |
+| AI workflow skills (Claude + Codex) | **14 + 14** | 0 | 0 | 0 |
 | Vector infrastructure (S3 Vectors) | **Yes** | No | No | No |
 | Multi-interface (API + Worker + Admin + MCP) | **3 + 1 planned** | 2 | 1 | 1 |
 | Architecture Decision Records | **18 active · 30 archived** | 0 | 0 | 0 |


### PR DESCRIPTION
## Summary

- Actual skill count in `.agents/skills/` is 14 (matches `.claude/skills/`)
- Updates the incorrect "14 + 15" figure across README.md, docs/comparison.md, docs/README.ko.md
- Caught during Codex cross-review of launch draft posts

## Files changed

- `README.md` — hero AI section + comparison table
- `docs/comparison.md` — feature matrix
- `docs/README.ko.md` — KO prose line + comparison table

## Governor Footer

- trigger: no
- reviewer: n/a
- rounds: 0
- r-points-fixed: 0
- r-points-deferred: 0
- r-points-rejected: 0
- touched-adr-consequences: none
- pr-scope-notes: Docs-only fix. Corrects Codex CLI skill count (15 to 14) in three files.
- final-verdict: merge-ready
- links: n/a