### PR TITLE
docs: sync checklists and add-admin-page skill for #194 gate pattern

### DIFF
--- a/docs/ai/shared/architecture-review-checklist.md
+++ b/docs/ai/shared/architecture-review-checklist.md
@@ -81,7 +81,7 @@ Check `interface/admin/` files and compare with `project-dna` section 11.
 - [ ] [MEDIUM] Page file imports config from the configs module instead of defining it inline
 - [ ] [HIGH] Page files do not import domain services directly
 - [ ] [MEDIUM] `page_configs: list[BaseAdminPage] = []` is declared at module level
-- [ ] Admin endpoint access restriction enforced — see security-checklist.md §2 for canonical rule and severity
+- [ ] [HIGH][IC-155-4] Admin endpoint access restriction enforced — every `@ui.page("/admin/")` route calls `require_auth(page_key=...)` or `require_auth_allowlisted()` as its first statement. See security-checklist.md §2 for grep pattern and AST test reference.
 - [ ] [HIGH] Sensitive fields use `masked=True` in `ColumnConfig`
 
 ## 8. Bootstrap Wiring

--- a/docs/ai/shared/security-checklist.md
+++ b/docs/ai/shared/security-checklist.md
@@ -55,7 +55,10 @@ Check router files and configuration files:
   - When not implemented: treat as `[OPEN][BLOCKING]` and require production-safe auth before release
 ### Admin Dashboard Security
 - [ ] [Always][BLOCKING] Admin endpoint access restriction verified
-  - Grep: Every `@ui.page("/admin/` function awaits `require_auth()` before any rendering
+  - Grep: Every `@ui.page("/admin/")` function (except `/admin/login` and `/admin/setup`) calls
+    `require_auth(page_key="<key>")` or `require_auth_allowlisted()` as its first statement
+    and returns immediately on `None`. An AST test at
+    `tests/unit/_core/infrastructure/admin/test_route_coverage.py` enforces this invariant (IC-155-4).
 - [ ] [Always][HIGH] Admin authentication delegates credential checks to the auth domain
   - Grep: Verify `AdminAuthProvider` calls `AuthUseCase.admin_login()` and password verification stays in `AuthService.verify_credentials()`
 - [ ] [Always][HIGH] Sensitive fields masked in admin grid

--- a/docs/ai/shared/skills/add-admin-page.md
+++ b/docs/ai/shared/skills/add-admin-page.md
@@ -88,17 +88,19 @@ page_configs: list[BaseAdminPage] = []
 
 @ui.page("/admin/{name}")
 async def {name}_list_page(page: int = 1, search: str = ""):
-    if not await require_auth():
+    session = await require_auth(page_key="{name}")
+    if session is None:
         return
-    admin_layout(page_configs, current_domain="{name}")
+    admin_layout(page_configs, current_domain="{name}", session=session)
     await {name}_admin_page.render_list(page=page, search=search)
 
 
 @ui.page("/admin/{name}/{record_id}")
 async def {name}_detail_page(record_id: int):
-    if not await require_auth():
+    session = await require_auth(page_key="{name}")
+    if session is None:
         return
-    admin_layout(page_configs, current_domain="{name}")
+    admin_layout(page_configs, current_domain="{name}", session=session)
     await {name}_admin_page.render_detail(record_id=record_id)
 ```
 

--- a/docs/history/047-governor-review-provenance-consolidation.md
+++ b/docs/history/047-governor-review-provenance-consolidation.md
@@ -219,7 +219,7 @@ The 44 historical IC tags from `docs/ai/shared/governor-review-log/pr-*.md` (as 
 | IC-155-1 | #155 | durable-domain | domain:auth (project-dna) | NiceGUI admin session storage may contain only `authenticated`, `user_id`, `username`, `role`. Never tokens. |
 | IC-155-2 | #155 | durable-domain | domain:auth (project-dna) | NiceGUI admin authorization is DB-role based. Non-admin and wrong-password both surface as "invalid credentials". |
 | IC-155-3 | #155 | durable-domain | domain:auth (project-dna) | `ADMIN_BOOTSTRAP_*` is seed-only; never a primary login authority. |
-| IC-155-4 | #155 | pr-scope | archive-only | "Minimal RBAC for this PR is limited to `user.role` admin authorization" — follow-up may extend. |
+| IC-155-4 | #155 (extended by #194) | durable-domain | domain:auth (project-dna) | "Minimal RBAC for this PR is limited to `user.role` admin authorization" — extended by #194 to mandatory `require_auth(page_key=...)` per-route gate + page-level `User.permissions` RBAC. Verified by AST test `test_route_coverage.py`. See project-dna.md §11. |
 | IC-156-1 | #156 (in flight) | durable-domain | domain:docs | Selector renderer is a single `_render_selector` helper; theme toggle / FOUC / aria belong to production surface. |
 | IC-156-2 | #156 (in flight) | durable-domain | domain:docs | `DOCS_CARDS` and `_handoff_cards()` carry an `icon` field with `.get("icon", "")` fallback. |
 | IC-156-3 | #156 (in flight) | durable-domain | domain:docs | `kind` discrimination (`primary` / `secondary`) is the canonical Recommended-vs-rest hierarchy carrier. |


### PR DESCRIPTION
## Summary

- \`add-admin-page\` skill template updated to require \`require_auth(page_key=...)\` mandatory gate pattern (#194)
- \`security-checklist\` §2: update \`require_auth\` grep to dual-gate pattern (\`require_auth(page_key=)\` + \`require_auth_allowlisted()\`) with AST test reference
- \`architecture-review-checklist\` §7: add \`[HIGH][IC-155-4]\` severity and explicit gate description
- ADR 047: promote IC-155-4 from pr-scope to durable-domain; add errata noting #194 extended it to full page-level permissions + mandatory gate

## Context

This commit was authored after PR #200 was opened, so it was not included in the merge. The \`add-admin-page\` skill template is the most critical change — without this, \`/add-admin-page\` generates pages without the \`require_auth(page_key=...)\` gate that #194 made mandatory.

## Self-Structured Review

- [x] Skill template change matches current \`user_page.py\` reference impl — \`require_auth(page_key=...)\` + session return pattern confirmed correct
- [x] Security checklist dual-gate grep pattern is accurate — reflects actual \`require_auth(page_key=)\` / \`require_auth_allowlisted()\` split introduced in #194
- [x] Architecture checklist §7 severity promoted to \`[HIGH][IC-155-4]\` — consistent with AST test enforcement level
- [x] IC-155-4 promotion from \`pr-scope\` to \`durable-domain\` is factually correct — #194 landed the mandatory gate, making the follow-up note obsolete
- [x] No new policy introduced — all changes are corrective sync against #194 implementation
- [x] No durable governance G-slots added or modified — IC Classification Table row edit only

## Test plan

- [ ] Verify \`docs/ai/shared/skills/add-admin-page.md\` includes \`require_auth(page_key="{name}")\` in the page template
- [ ] Verify \`security-checklist\` dual-gate grep pattern is accurate against current \`user_page.py\`

---

## Governor Footer
- trigger: yes
- reviewer: self-structured
- rounds: 1
- r-points-fixed: 0
- r-points-deferred: 0
- r-points-rejected: 0
- touched-adr-consequences: none
- pr-scope-notes: corrective sync only — IC-155-4 promoted from pr-scope to durable-domain; no new policy introduced
- final-verdict: merge-ready
- links: https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/201