### PR TITLE
feat(auth): server-route RBAC for /v1/user (#199)

### DIFF
--- a/.claude/rules/project-status.md
+++ b/.claude/rules/project-status.md
@@ -1,6 +1,6 @@
 # Project Status
 
-> Last synced: 2026-05-27 via #194 (admin setup wizard + page-level permissions)
+> Last synced: 2026-05-27 via #199 (server-route RBAC for /v1/user)
 
 ## Current Version Context
 - Latest release: v0.6.0 (2026-05-07)
@@ -21,6 +21,7 @@
 | Independent Review Generalization | ADR 048 (PR #187) | Replaces "cross-tool only" mandatory sub-step with three-mode **independent review**: `cross-tool` (another AI tool), `self-structured` (single-tool structured checklist), `human` (non-author reviewer). `[skip-governor-footer]` restricted to non-governor-changing PRs in CI mode — governor-changing PRs cannot escape the requirement (ADR048-G1). Self-Structured Review Checklist added to all four review/sync skill docs. |
 | Context Budget Reduction | #186 (PR #187) | Archives 18 v0.4.0→v0.5.0 project-status rows to `docs/history/archive/project-status/`. Updates Current Version Context from v0.4.0 → v0.6.0. Defers AGENTS.md structural split to a follow-up issue (target: always-loaded context below ~600 lines; current after this PR: see issue #186). |
 | Admin Setup Wizard + Page-Level Permissions | #194 | Adds `User.permissions` (JSON), `User.password_temporary`, `User.is_bootstrap_admin` fields + migration 0006. Bootstrap one-time setup wizard (`/admin/setup`) creates first real admin; bootstrap credential permanently disabled afterward. `AdminAccountUseCase` + `AdminPermissionRegistry` for account lifecycle. `require_auth(page_key=...)` mandatory per-route gate enforced by AST test. `/admin/accounts` UI for account create/delete/permission-edit with last-accounts guard. Forced password change flow + refresh token revocation. |
+| Server-Route RBAC for /v1/user | #199 | Adds the `require_admin` interface dependency (`role == admin` and not `is_bootstrap_admin` → `403 FORBIDDEN`) plus a dedicated API `ForbiddenException`. All `/v1/user` routes (reads + CUD) become admin-only via a single router-level gate (default-deny for new routes); non-admin self-service stays on `/v1/auth/me`. Role is read live from the DB per request, and unauthenticated calls still resolve to 401 before the role check. Non-user `/v1/*` route-level gating remains a follow-up. |
 
 ## Architecture Violation Status
 - Domain → Infrastructure import: CLEAN
@@ -28,7 +29,7 @@
 - Entity pattern: CLEAN
 
 ## Not Yet Implemented
-- Server-route RBAC (per-endpoint role gating for FastAPI routes; admin page-level RBAC landed in #194, but `/v1/*` route-level role enforcement is still pending — tracked as follow-up to #194)
+- Server-route RBAC for non-user `/v1/*` routes (per-endpoint role gating; `/v1/user` reads + CUD landed in #199 and admin page-level RBAC in #194, but role enforcement for other domains' `/v1/*` routes is still pending)
 - File Upload (UploadFile)
 - Rate Limiting (slowapi)
 - WebSocket

--- a/docs/ai/shared/project-dna.md
+++ b/docs/ai/shared/project-dna.md
@@ -599,7 +599,7 @@ class {Name}Container(containers.DeclarativeContainer):
 | Structured Logging (structlog) | Active | structlog + asgi-correlation-id, RequestLogMiddleware (server), StructlogContextMiddleware (worker), LOG_LEVEL / LOG_JSON_FORMAT env vars, sqlalchemy.engine double-emit fix (#9) |
 | JWT/Authentication | Active | `src/auth/` provides HS256 access/refresh tokens, refresh-token rotation/revocation persistence, `/v1/auth/*`, and Bearer protection for `user` API routes (#4) |
 | File Upload (UploadFile) | Not implemented | |
-| RBAC/Permissions | Active | Page-level admin permissions via `User.permissions` (JSON column) added in #194. `User.role` determines admin status; `permissions` list controls which admin pages each admin can access. `/admin/accounts` UI manages accounts and per-page permission grants. Bootstrap one-time setup wizard creates the first real admin with all permissions. |
+| RBAC/Permissions | Active | Page-level admin permissions via `User.permissions` (JSON column) added in #194. `User.role` determines admin status; `permissions` list controls which admin pages each admin can access. `/admin/accounts` UI manages accounts and per-page permission grants. Bootstrap one-time setup wizard creates the first real admin with all permissions. Server-route RBAC for `/v1/user` (reads + CUD) added in #199 via the `require_admin` interface dependency (`role == admin` and not `is_bootstrap_admin`); non-user `/v1/*` route-level role gating is not yet implemented. |
 | Rate Limiting (slowapi) | Not implemented | |
 | WebSocket | Not implemented | |
 

--- a/src/auth/domain/exceptions/auth_exceptions.py
+++ b/src/auth/domain/exceptions/auth_exceptions.py
@@ -46,6 +46,17 @@ class RefreshTokenRevokedException(BaseCustomException):
         )
 
 
+class ForbiddenException(BaseCustomException):
+    """Authenticated caller lacks the required role for an API route."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            status_code=403,
+            message="Forbidden",
+            error_code="FORBIDDEN",
+        )
+
+
 class AdminSetupRequiredException(BaseCustomException):
     """Bootstrap credential used when no real admin exists — route to setup wizard."""
 

--- a/src/auth/interface/server/dependencies/auth_dependencies.py
+++ b/src/auth/interface/server/dependencies/auth_dependencies.py
@@ -3,9 +3,12 @@ from fastapi import Depends
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from src.auth.application.use_cases.auth_use_case import AuthUseCase
-from src.auth.domain.exceptions.auth_exceptions import UnauthorizedException
+from src.auth.domain.exceptions.auth_exceptions import (
+    ForbiddenException,
+    UnauthorizedException,
+)
 from src.auth.infrastructure.di.auth_container import AuthContainer
-from src.user.domain.dtos.user_dto import UserDTO
+from src.user.domain.dtos.user_dto import USER_ROLE_ADMIN, UserDTO
 
 bearer_scheme = HTTPBearer(auto_error=False)
 
@@ -18,3 +21,12 @@ async def get_current_user(
     if credentials is None or credentials.scheme.lower() != "bearer":
         raise UnauthorizedException()
     return await auth_use_case.get_current_user(credentials.credentials)
+
+
+async def require_admin(
+    current_user: UserDTO = Depends(get_current_user),
+) -> UserDTO:
+    """Admin-only API gate. Bootstrap admins are setup-only and rejected here."""
+    if current_user.role != USER_ROLE_ADMIN or current_user.is_bootstrap_admin:
+        raise ForbiddenException()
+    return current_user

--- a/src/user/interface/server/routers/user_router.py
+++ b/src/user/interface/server/routers/user_router.py
@@ -2,7 +2,10 @@ from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends, Query
 
 from src._core.application.dtos.base_response import SuccessResponse
-from src.auth.interface.server.dependencies.auth_dependencies import get_current_user
+from src.auth.interface.server.dependencies.auth_dependencies import (
+    get_current_user,
+    require_admin,
+)
 from src.user.domain.services.user_service import UserService
 from src.user.infrastructure.di.user_container import UserContainer
 from src.user.interface.server.schemas.user_schema import (
@@ -22,6 +25,7 @@ router = APIRouter(dependencies=[Depends(get_current_user)])
     summary="Create user",
     response_model=SuccessResponse[UserResponse],
     response_model_exclude={"pagination"},
+    dependencies=[Depends(require_admin)],
 )
 @inject
 async def create_user(
@@ -40,6 +44,7 @@ async def create_user(
     summary="Create users (batch)",
     response_model=SuccessResponse[list[UserResponse]],
     response_model_exclude={"pagination"},
+    dependencies=[Depends(require_admin)],
 )
 @inject
 async def create_users(
@@ -122,6 +127,7 @@ async def get_user_by_user_id(
     summary="Update user",
     response_model=SuccessResponse[UserResponse],
     response_model_exclude={"pagination"},
+    dependencies=[Depends(require_admin)],
 )
 @inject
 async def update_user_by_user_id(
@@ -141,6 +147,7 @@ async def update_user_by_user_id(
     summary="Delete user",
     response_model=SuccessResponse,
     response_model_exclude={"data", "pagination"},
+    dependencies=[Depends(require_admin)],
 )
 @inject
 async def delete_user_by_user_id(

--- a/src/user/interface/server/routers/user_router.py
+++ b/src/user/interface/server/routers/user_router.py
@@ -2,10 +2,7 @@ from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends, Query
 
 from src._core.application.dtos.base_response import SuccessResponse
-from src.auth.interface.server.dependencies.auth_dependencies import (
-    get_current_user,
-    require_admin,
-)
+from src.auth.interface.server.dependencies.auth_dependencies import require_admin
 from src.user.domain.services.user_service import UserService
 from src.user.infrastructure.di.user_container import UserContainer
 from src.user.interface.server.schemas.user_schema import (
@@ -14,7 +11,10 @@ from src.user.interface.server.schemas.user_schema import (
     UserResponse,
 )
 
-router = APIRouter(dependencies=[Depends(get_current_user)])
+# All /v1/user routes are admin-only (#199): user management (read + CUD)
+# exposes other users' PII. Self-service profile reads use /v1/auth/me.
+# New routes added to this router inherit the admin gate by default (default-deny).
+router = APIRouter(dependencies=[Depends(require_admin)])
 
 
 # ==========================================================================================
@@ -25,7 +25,6 @@ router = APIRouter(dependencies=[Depends(get_current_user)])
     summary="Create user",
     response_model=SuccessResponse[UserResponse],
     response_model_exclude={"pagination"},
-    dependencies=[Depends(require_admin)],
 )
 @inject
 async def create_user(
@@ -44,7 +43,6 @@ async def create_user(
     summary="Create users (batch)",
     response_model=SuccessResponse[list[UserResponse]],
     response_model_exclude={"pagination"},
-    dependencies=[Depends(require_admin)],
 )
 @inject
 async def create_users(
@@ -127,7 +125,6 @@ async def get_user_by_user_id(
     summary="Update user",
     response_model=SuccessResponse[UserResponse],
     response_model_exclude={"pagination"},
-    dependencies=[Depends(require_admin)],
 )
 @inject
 async def update_user_by_user_id(
@@ -147,7 +144,6 @@ async def update_user_by_user_id(
     summary="Delete user",
     response_model=SuccessResponse,
     response_model_exclude={"data", "pagination"},
-    dependencies=[Depends(require_admin)],
 )
 @inject
 async def delete_user_by_user_id(

--- a/tests/e2e/user/test_user_router.py
+++ b/tests/e2e/user/test_user_router.py
@@ -96,14 +96,28 @@ async def test_create_user_with_token(admin_override):
 
 
 @pytest.mark.asyncio
-async def test_get_users_with_token():
+async def test_admin_can_read_users(admin_override):
     async with _client() as client:
-        token_data = await _register(client, "listowner")
-        response = await client.get("/v1/users", headers=_auth_headers(token_data))
-    assert response.status_code == 200
-    data = response.json()
-    assert data["success"] is True
-    assert isinstance(data["data"], list)
+        created = await client.post(
+            "/v1/user",
+            json={
+                "username": "readtarget",
+                "fullName": "Read Target",
+                "email": "readtarget@example.com",
+                "password": "secret",
+            },
+        )
+        user_id = created.json()["data"]["id"]
+        listing = await client.get("/v1/users")
+        single = await client.get(f"/v1/user/{user_id}")
+        by_ids = await client.get(f"/v1/user/by-ids?ids={user_id}")
+
+    assert listing.status_code == 200
+    assert isinstance(listing.json()["data"], list)
+    assert single.status_code == 200
+    assert single.json()["data"]["id"] == user_id
+    assert by_ids.status_code == 200
+    assert [item["id"] for item in by_ids.json()["data"]] == [user_id]
 
 
 @pytest.mark.asyncio
@@ -256,6 +270,22 @@ async def test_user_cud_is_forbidden_for_non_admin():
 
 
 @pytest.mark.asyncio
+async def test_user_reads_are_forbidden_for_non_admin():
+    """User reads expose other users' PII, so they are admin-only too (#199)."""
+    async with _client() as client:
+        token_data = await _register(client, "rbacreader")
+        headers = _auth_headers(token_data)
+
+        listing = await client.get("/v1/users", headers=headers)
+        single = await client.get("/v1/user/1", headers=headers)
+        by_ids = await client.get("/v1/user/by-ids?ids=1", headers=headers)
+
+    for response in (listing, single, by_ids):
+        assert response.status_code == 403, response.text
+        assert response.json()["errorCode"] == "FORBIDDEN"
+
+
+@pytest.mark.asyncio
 async def test_admin_can_create_user_with_real_token(test_db):
     """A real token whose DB role is admin passes the gate (full auth chain)."""
     async with _client() as client:
@@ -285,7 +315,7 @@ async def test_bootstrap_admin_is_forbidden():
     )
     try:
         async with _client() as client:
-            response = await client.post(
+            create = await client.post(
                 "/v1/user",
                 json={
                     "username": "bootstrapblocked",
@@ -294,11 +324,13 @@ async def test_bootstrap_admin_is_forbidden():
                     "password": "secret",
                 },
             )
+            read = await client.get("/v1/users")
     finally:
         reset_current_user_override(app)
 
-    assert response.status_code == 403, response.text
-    assert response.json()["errorCode"] == "FORBIDDEN"
+    for response in (create, read):
+        assert response.status_code == 403, response.text
+        assert response.json()["errorCode"] == "FORBIDDEN"
 
 
 @pytest.mark.asyncio

--- a/tests/e2e/user/test_user_router.py
+++ b/tests/e2e/user/test_user_router.py
@@ -1,11 +1,49 @@
 import pytest
+import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy import update
 
 from src._apps.server.app import app
+from src._apps.server.testing import (
+    override_current_user,
+    reset_current_user_override,
+)
+from src.user.domain.dtos.user_dto import USER_ROLE_ADMIN, USER_ROLE_USER
+from src.user.infrastructure.database.models.user_model import UserModel
+from tests.factories.user_factory import make_user_dto
 
 
 def _client() -> AsyncClient:
     return AsyncClient(transport=ASGITransport(app=app), base_url="http://localhost")
+
+
+@pytest_asyncio.fixture
+async def admin_override():
+    """Force ``get_current_user`` to return a non-bootstrap admin for the test.
+
+    The existing CUD behaviour tests are now admin-gated; this override lets
+    them keep asserting business logic without minting a real admin token. It
+    is always reset on teardown so it cannot leak into other tests.
+    """
+    override_current_user(app, make_user_dto(role=USER_ROLE_ADMIN))
+    try:
+        yield
+    finally:
+        reset_current_user_override(app)
+
+
+async def _promote_to_admin(test_db, user_id: int) -> None:
+    async with test_db.session() as session:
+        await session.execute(
+            update(UserModel).where(UserModel.id == user_id).values(role="admin")
+        )
+        await session.commit()
+
+
+async def _role_of(test_db, user_id: int) -> str:
+    async with test_db.session() as session:
+        model = await session.get(UserModel, user_id)
+        return model.role
 
 
 async def _register(client: AsyncClient, suffix: str) -> dict:
@@ -36,7 +74,7 @@ async def test_user_routes_require_authentication():
 
 
 @pytest.mark.asyncio
-async def test_create_user_with_token():
+async def test_create_user_with_token(admin_override):
     async with _client() as client:
         token_data = await _register(client, "createowner")
         response = await client.post(
@@ -69,7 +107,7 @@ async def test_get_users_with_token():
 
 
 @pytest.mark.asyncio
-async def test_create_user_duplicate_returns_field_errors():
+async def test_create_user_duplicate_returns_field_errors(admin_override):
     payload = {
         "username": "e2edup",
         "fullName": "E2E Duplicate",
@@ -103,7 +141,7 @@ async def test_create_user_duplicate_returns_field_errors():
 
 
 @pytest.mark.asyncio
-async def test_create_users_duplicate_payload_is_all_or_nothing():
+async def test_create_users_duplicate_payload_is_all_or_nothing(admin_override):
     payload = [
         {
             "username": "e2ebatchdup",
@@ -140,7 +178,9 @@ async def test_create_users_duplicate_payload_is_all_or_nothing():
 
 
 @pytest.mark.asyncio
-async def test_update_user_allows_own_email_and_rejects_another_users_email():
+async def test_update_user_allows_own_email_and_rejects_another_users_email(
+    admin_override,
+):
     first_payload = {
         "username": "e2eupdateone",
         "fullName": "E2E Update One",
@@ -184,3 +224,106 @@ async def test_update_user_allows_own_email_and_rejects_another_users_email():
             "type": "unique",
         }
     ]
+
+
+# RBAC (#199) ===============================================================
+
+
+@pytest.mark.asyncio
+async def test_user_cud_is_forbidden_for_non_admin():
+    """A real (role=user) token reaches require_admin and is rejected with 403."""
+    user_payload = {
+        "username": "rbacnew",
+        "fullName": "RBAC New",
+        "email": "rbacnew@example.com",
+        "password": "secret",
+    }
+
+    async with _client() as client:
+        token_data = await _register(client, "rbacuser")
+        headers = _auth_headers(token_data)
+
+        create = await client.post("/v1/user", headers=headers, json=user_payload)
+        batch = await client.post("/v1/users", headers=headers, json=[user_payload])
+        update_one = await client.put(
+            "/v1/user/1", headers=headers, json={"fullName": "x"}
+        )
+        delete_one = await client.delete("/v1/user/1", headers=headers)
+
+    for response in (create, batch, update_one, delete_one):
+        assert response.status_code == 403, response.text
+        assert response.json()["errorCode"] == "FORBIDDEN"
+
+
+@pytest.mark.asyncio
+async def test_admin_can_create_user_with_real_token(test_db):
+    """A real token whose DB role is admin passes the gate (full auth chain)."""
+    async with _client() as client:
+        token_data = await _register(client, "rbacadmin")
+        await _promote_to_admin(test_db, token_data["user"]["id"])
+
+        response = await client.post(
+            "/v1/user",
+            headers=_auth_headers(token_data),
+            json={
+                "username": "rbacadmincreated",
+                "fullName": "RBAC Admin Created",
+                "email": "rbacadmincreated@example.com",
+                "password": "secret",
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["data"]["username"] == "rbacadmincreated"
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_admin_is_forbidden():
+    """Bootstrap admins are setup-only and must not pass the API admin gate."""
+    override_current_user(
+        app, make_user_dto(role=USER_ROLE_ADMIN, is_bootstrap_admin=True)
+    )
+    try:
+        async with _client() as client:
+            response = await client.post(
+                "/v1/user",
+                json={
+                    "username": "bootstrapblocked",
+                    "fullName": "Bootstrap Blocked",
+                    "email": "bootstrapblocked@example.com",
+                    "password": "secret",
+                },
+            )
+    finally:
+        reset_current_user_override(app)
+
+    assert response.status_code == 403, response.text
+    assert response.json()["errorCode"] == "FORBIDDEN"
+
+
+@pytest.mark.asyncio
+async def test_update_user_ignores_role_escalation(admin_override, test_db):
+    """role/permissions in the PUT body are silently ignored (no self-escalation)."""
+    async with _client() as client:
+        created = await client.post(
+            "/v1/user",
+            json={
+                "username": "noescalation",
+                "fullName": "No Escalation",
+                "email": "noescalation@example.com",
+                "password": "secret",
+            },
+        )
+        user_id = created.json()["data"]["id"]
+        updated = await client.put(
+            f"/v1/user/{user_id}",
+            json={
+                "fullName": "No Escalation Updated",
+                "role": "admin",
+                "permissions": ["accounts"],
+            },
+        )
+
+    assert created.status_code == 200, created.text
+    assert updated.status_code == 200, updated.text
+    assert await _role_of(test_db, user_id) == USER_ROLE_USER

--- a/tests/e2e/user/test_user_router.py
+++ b/tests/e2e/user/test_user_router.py
@@ -35,7 +35,9 @@ async def admin_override():
 async def _promote_to_admin(test_db, user_id: int) -> None:
     async with test_db.session() as session:
         await session.execute(
-            update(UserModel).where(UserModel.id == user_id).values(role="admin")
+            update(UserModel)
+            .where(UserModel.id == user_id)
+            .values(role=USER_ROLE_ADMIN)
         )
         await session.commit()
 


### PR DESCRIPTION
## Related Issue
- Closes #199

## Change Summary
- Add `require_admin` dependency (`role == admin AND not is_bootstrap_admin` → else `403 FORBIDDEN`) and a dedicated API-side `ForbiddenException`, separate from the admin-page `AdminPermissionDeniedException`.
- Gate all `/v1/user` routes (CUD **and** reads) to admins via a single router-level `require_admin`, making the router default-deny for future routes. Previously any authenticated user could mutate accounts and read every user's PII (email, full_name).
- Reads (`/v1/users`, `/v1/user/by-ids`, `/v1/user/{id}`) are admin-only; non-admin self-service stays on `/v1/auth/me`.
- Bootstrap admins are setup-only identities and are explicitly rejected by the API gate. Role is read live from the DB per request, so no token re-issue is needed and `401` (no/invalid/wrong-type token) still precedes the role check.
- Docs sync (`/sync-guidelines`): `project-dna.md` §8 RBAC row + `project-status.md` (Recent Major Changes row, narrowed Not Yet Implemented entry, Last synced) reflect that `/v1/user` server-route RBAC now exists while non-user `/v1/*` gating remains pending.

## Type of Change
- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] refactor: Code restructuring
- [x] docs: Documentation
- [ ] chore: Build/tooling
- [x] test: Tests
- [ ] ci: CI/CD
- [ ] perf: Performance
- [ ] style: Code style

## Checklist
- [x] Architecture rules followed (no Domain -> Infrastructure imports)
- [x] Tests pass
- [x] Linting passes (`ruff check src/`)

## How to Test
- `pytest tests/e2e/user/test_user_router.py` — 11 passed: admin 200 (CUD + reads), non-admin 403 on all CUD + reads, bootstrap-admin 403, real-token auth chain (DB-promoted admin → 200), role-escalation via PUT body ignored.
- `pytest tests/` — 956 passed, 15 skipped (10 DynamoDB integration errors are pre-existing/env-only: require docker dynamodb-local).
- `ruff check src/` + `ruff format --check` + Domain→Infra / Entity / Tier-1 language pre-commit hooks pass.
- Independent review: design, both implementation steps, and the `/review-pr` completion gate were cross-reviewed read-only with codex (gpt-5.5, reasoning xhigh) — final verdict merge-ready; one LOW finding (test helper literal → `USER_ROLE_ADMIN`) fixed; drift closed via `/sync-guidelines`.

---

## Governor Footer
- trigger: yes
- reviewer: codex-cli
- rounds: 3
- r-points-fixed: 7
- r-points-deferred: 2
- r-points-rejected: 0
- touched-adr-consequences: none
- pr-scope-notes: role-only RBAC for /v1/user (CUD + reads admin-only); non-user /v1/* route gating and permission-key registry deferred as follow-ups
- final-verdict: merge-ready
- links: https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/202
