### PR TITLE
feat(admin): loading states for async admin interactions (#198)

### DIFF
--- a/.claude/rules/project-status.md
+++ b/.claude/rules/project-status.md
@@ -1,6 +1,6 @@
 # Project Status
 
-> Last synced: 2026-05-27 via #195 (centralized admin error handling)
+> Last synced: 2026-05-28 via #198 (admin loading states)
 
 ## Current Version Context
 - Latest release: v0.6.0 (2026-05-07)
@@ -23,6 +23,7 @@
 | Admin Setup Wizard + Page-Level Permissions | #194 | Adds `User.permissions` (JSON), `User.password_temporary`, `User.is_bootstrap_admin` fields + migration 0006. Bootstrap one-time setup wizard (`/admin/setup`) creates first real admin; bootstrap credential permanently disabled afterward. `AdminAccountUseCase` + `AdminPermissionRegistry` for account lifecycle. `require_auth(page_key=...)` mandatory per-route gate enforced by AST test. `/admin/accounts` UI for account create/delete/permission-edit with last-accounts guard. Forced password change flow + refresh token revocation. |
 | Server-Route RBAC for /v1/user | #199 | Adds the `require_admin` interface dependency (`role == admin` and not `is_bootstrap_admin` → `403 FORBIDDEN`) plus a dedicated API `ForbiddenException`. All `/v1/user` routes (reads + CUD) become admin-only via a single router-level gate (default-deny for new routes); non-admin self-service stays on `/v1/auth/me`. Role is read live from the DB per request, and unauthenticated calls still resolve to 401 before the role check. Non-user `/v1/*` route-level gating remains a follow-up. |
 | Centralized Admin Error Handling | #195 | Adds `AdminErrorHandler` + `@admin_error_boundary`, a global `app.on_exception` safety net, and an unauthenticated `/admin/error` page (`src/_core/infrastructure/admin/error_handler.py`). Admin errors route centrally across page boundary / event callbacks / global handler: only 4xx `BaseCustomException.message` is shown (warning), `>=500`/generic show a generic message (negative), and raw `str(exc)` never reaches the UI — full detail goes to the structured log with `context`/`admin_user`/`error_type`/`error_code`. `BaseAdminPage.render_*` delegate to the handler; `str(exc)` leaks removed from docs/ai_usage/accounts/setup/change_password. AST tests enforce the no-leak rule and `/admin/error` gate-exemption (IC-195-1). |
+| Admin Loading States | #198 | Adds `button_loading` async context manager (`layout.py`) applied to every admin write button (docs Ask, accounts create/save/remove, setup, change-password, login) — Quasar `loading`+`disable` cleared in `finally`; navigation/refresh kept outside the context. `BaseAdminPage.render_list/render_detail` render a structure-mirroring skeleton (`await ui.context.client.connected()` before fetch so it is visible during slow loads; deleted in `finally`); list rows = `min(page_size, 8)`, detail rows = `max(visible columns, 4)`. |
 
 ## Architecture Violation Status
 - Domain → Infrastructure import: CLEAN

--- a/docs/ai/shared/project-dna.md
+++ b/docs/ai/shared/project-dna.md
@@ -766,7 +766,7 @@ Quickstart prints the seeded `admin / admin` credentials only when `ENV=quicksta
 ### Loading states (#198)
 
 - **Async write buttons**: wrap the slow `await` in `async with button_loading(btn)` (`layout.py`) — it sets Quasar `loading`+`disable` and always clears in `finally`. Keep navigation / `dlg.close()` / list-refresh *outside* the `async with` so the button is not toggled after it may be torn down.
-- **Page data loading**: `BaseAdminPage.render_list/render_detail` render a structure-mirroring skeleton, `await ui.context.client.connected()` before the fetch (so the skeleton is actually flushed to the client during a slow load), and delete the skeleton in `finally`. One change covers all domain pages; custom non-`BaseAdminPage` content areas use `ui.spinner` for inline feedback.
+- **Page data loading**: `BaseAdminPage.render_list/render_detail` render a structure-mirroring skeleton, `await ui.context.client.connected()` before the fetch (so the skeleton is actually flushed to the client during a slow load), and delete the skeleton in `finally`. One change covers all domain pages; custom non-`BaseAdminPage` content areas (e.g. `docs_query_page`, `ai_usage_summary_page`) should provide appropriate inline feedback (e.g. `ui.spinner`) for their own slow fetches.
 
 ## §12. S3 Vector Store Pattern
 

--- a/docs/ai/shared/project-dna.md
+++ b/docs/ai/shared/project-dna.md
@@ -763,6 +763,11 @@ The NiceGUI admin layer integrates with the auth-domain credential check (PR #15
 
 Quickstart prints the seeded `admin / admin` credentials only when `ENV=quickstart`; production / staging deployments must override the bootstrap env vars or disable seeding.
 
+### Loading states (#198)
+
+- **Async write buttons**: wrap the slow `await` in `async with button_loading(btn)` (`layout.py`) — it sets Quasar `loading`+`disable` and always clears in `finally`. Keep navigation / `dlg.close()` / list-refresh *outside* the `async with` so the button is not toggled after it may be torn down.
+- **Page data loading**: `BaseAdminPage.render_list/render_detail` render a structure-mirroring skeleton, `await ui.context.client.connected()` before the fetch (so the skeleton is actually flushed to the client during a slow load), and delete the skeleton in `finally`. One change covers all domain pages; custom non-`BaseAdminPage` content areas use `ui.spinner` for inline feedback.
+
 ## §12. S3 Vector Store Pattern
 
 ### VectorModel (Data Model)

--- a/src/_apps/admin/pages/accounts.py
+++ b/src/_apps/admin/pages/accounts.py
@@ -9,7 +9,7 @@ from src._core.infrastructure.admin.error_handler import (
     AdminErrorHandler,
     admin_error_boundary,
 )
-from src._core.infrastructure.admin.layout import admin_layout
+from src._core.infrastructure.admin.layout import admin_layout, button_loading
 from src.auth.domain.exceptions.auth_exceptions import (
     AdminLastAccountsGuardException,
     AdminSelfActionForbiddenException,
@@ -70,18 +70,19 @@ async def accounts_page():
                 ui.notify("All fields are required", type="warning")
                 return
             selected = [k for k, cb in perm_checkboxes.items() if cb.value]
-            try:
-                new_admin, temp_pw = await use_case.create_account(
-                    CreateAdminAccountDTO(
-                        username=username,
-                        full_name=full_name,
-                        email=email,
-                        permissions=selected,
+            async with button_loading(create_btn):
+                try:
+                    new_admin, temp_pw = await use_case.create_account(
+                        CreateAdminAccountDTO(
+                            username=username,
+                            full_name=full_name,
+                            email=email,
+                            permissions=selected,
+                        )
                     )
-                )
-            except Exception as exc:  # noqa: BLE001 - delegated to AdminErrorHandler
-                await AdminErrorHandler.handle(exc, context="admin_account_create")
-                return
+                except Exception as exc:  # noqa: BLE001 - delegated to handler
+                    await AdminErrorHandler.handle(exc, context="admin_account_create")
+                    return
 
             new_username.set_value("")
             new_full_name.set_value("")
@@ -92,8 +93,10 @@ async def accounts_page():
             ui.notify("Admin '" + new_admin.username + "' created", type="positive")
             await refresh_list()
 
-        ui.button("Create", on_click=create_account).props("color=primary").classes(
-            "q-mt-sm"
+        create_btn = (
+            ui.button("Create", on_click=create_account)
+            .props("color=primary")
+            .classes("q-mt-sm")
         )
 
     await refresh_list()
@@ -141,29 +144,31 @@ def _render_admin_list(
 
                             async def save_perms(a=a):
                                 selected = [k for k, cb in perm_cbs.items() if cb.value]
-                                try:
-                                    await use_case.update_permissions(
-                                        admin_id=a.id,
-                                        permissions=selected,
-                                        requesting_admin_id=requesting_admin_id,
-                                    )
-                                except AdminLastAccountsGuardException:
-                                    ui.notify(
-                                        "Cannot remove the last accounts-permission holder",
-                                        type="negative",
-                                    )
-                                    return
-                                except Exception as exc:  # noqa: BLE001 - delegated
-                                    await AdminErrorHandler.handle(
-                                        exc, context="admin_account_update_permissions"
-                                    )
-                                    return
+                                async with button_loading(save_btn):
+                                    try:
+                                        await use_case.update_permissions(
+                                            admin_id=a.id,
+                                            permissions=selected,
+                                            requesting_admin_id=requesting_admin_id,
+                                        )
+                                    except AdminLastAccountsGuardException:
+                                        ui.notify(
+                                            "Cannot remove the last accounts-permission holder",
+                                            type="negative",
+                                        )
+                                        return
+                                    except Exception as exc:  # noqa: BLE001 - delegated
+                                        await AdminErrorHandler.handle(
+                                            exc,
+                                            context="admin_account_update_permissions",
+                                        )
+                                        return
                                 ui.notify("Permissions updated", type="positive")
                                 dlg.close()
                                 await refresh_cb()
 
                             with ui.row().classes("q-mt-md"):
-                                ui.button("Save", on_click=save_perms).props(
+                                save_btn = ui.button("Save", on_click=save_perms).props(
                                     "color=primary"
                                 )
                                 ui.button("Cancel", on_click=dlg.close).props("flat")
@@ -184,31 +189,32 @@ def _render_admin_list(
                             )
 
                             async def confirm_remove(a=a):
-                                try:
-                                    await use_case.delete_account(
-                                        admin_id=a.id,
-                                        requesting_admin_id=requesting_admin_id,
-                                    )
-                                except AdminSelfActionForbiddenException:
-                                    ui.notify(
-                                        "Cannot remove your own account",
-                                        type="negative",
-                                    )
-                                    dlg.close()
-                                    return
-                                except AdminLastAccountsGuardException:
-                                    ui.notify(
-                                        "Cannot remove the last accounts-permission holder",
-                                        type="negative",
-                                    )
-                                    dlg.close()
-                                    return
-                                except Exception as exc:  # noqa: BLE001 - delegated
-                                    dlg.close()
-                                    await AdminErrorHandler.handle(
-                                        exc, context="admin_account_delete"
-                                    )
-                                    return
+                                async with button_loading(remove_btn):
+                                    try:
+                                        await use_case.delete_account(
+                                            admin_id=a.id,
+                                            requesting_admin_id=requesting_admin_id,
+                                        )
+                                    except AdminSelfActionForbiddenException:
+                                        ui.notify(
+                                            "Cannot remove your own account",
+                                            type="negative",
+                                        )
+                                        dlg.close()
+                                        return
+                                    except AdminLastAccountsGuardException:
+                                        ui.notify(
+                                            "Cannot remove the last accounts-permission holder",
+                                            type="negative",
+                                        )
+                                        dlg.close()
+                                        return
+                                    except Exception as exc:  # noqa: BLE001 - delegated
+                                        dlg.close()
+                                        await AdminErrorHandler.handle(
+                                            exc, context="admin_account_delete"
+                                        )
+                                        return
                                 ui.notify(
                                     "Admin '" + a.username + "' removed",
                                     type="positive",
@@ -217,9 +223,9 @@ def _render_admin_list(
                                 await refresh_cb()
 
                             with ui.row():
-                                ui.button("Remove", on_click=confirm_remove).props(
-                                    "color=negative"
-                                )
+                                remove_btn = ui.button(
+                                    "Remove", on_click=confirm_remove
+                                ).props("color=negative")
                                 ui.button("Cancel", on_click=dlg.close).props("flat")
                         dlg.open()
 

--- a/src/_apps/admin/pages/accounts.py
+++ b/src/_apps/admin/pages/accounts.py
@@ -189,38 +189,40 @@ def _render_admin_list(
                             )
 
                             async def confirm_remove(a=a):
+                                success = False
                                 async with button_loading(remove_btn):
                                     try:
                                         await use_case.delete_account(
                                             admin_id=a.id,
                                             requesting_admin_id=requesting_admin_id,
                                         )
+                                        success = True
                                     except AdminSelfActionForbiddenException:
                                         ui.notify(
                                             "Cannot remove your own account",
                                             type="negative",
                                         )
-                                        dlg.close()
-                                        return
                                     except AdminLastAccountsGuardException:
                                         ui.notify(
                                             "Cannot remove the last accounts-permission holder",
                                             type="negative",
                                         )
-                                        dlg.close()
-                                        return
                                     except Exception as exc:  # noqa: BLE001 - delegated
-                                        dlg.close()
                                         await AdminErrorHandler.handle(
                                             exc, context="admin_account_delete"
                                         )
-                                        return
-                                ui.notify(
-                                    "Admin '" + a.username + "' removed",
-                                    type="positive",
-                                )
+                                # Keep dlg.close() / refresh outside the loading
+                                # context (§11 convention) — button is still
+                                # alive here, the dialog hide happens after the
+                                # loading state has cleared.
+                                if success:
+                                    ui.notify(
+                                        "Admin '" + a.username + "' removed",
+                                        type="positive",
+                                    )
                                 dlg.close()
-                                await refresh_cb()
+                                if success:
+                                    await refresh_cb()
 
                             with ui.row():
                                 remove_btn = ui.button(

--- a/src/_apps/admin/pages/change_password.py
+++ b/src/_apps/admin/pages/change_password.py
@@ -10,7 +10,7 @@ from src._core.infrastructure.admin.error_handler import (
     AdminErrorHandler,
     admin_error_boundary,
 )
-from src._core.infrastructure.admin.layout import admin_layout
+from src._core.infrastructure.admin.layout import admin_layout, button_loading
 from src.auth.domain.exceptions.auth_exceptions import InvalidCredentialsException
 
 # page_configs is injected by bootstrap_admin() after discovery
@@ -56,26 +56,29 @@ async def change_password_page():
                 ui.notify("Passwords do not match", type="warning")
                 return
 
-            try:
-                await get_admin_account_use_case().change_password(
-                    user_id=session.user_id,
-                    current_password=current_pw.value,
-                    new_password=new_pw.value,
-                )
-            except InvalidCredentialsException:
-                ui.notify("Current password is incorrect", type="negative")
-                return
-            except Exception as exc:  # noqa: BLE001 - delegated to AdminErrorHandler
-                await AdminErrorHandler.handle(exc, context="admin_change_password")
-                return
+            async with button_loading(change_btn):
+                try:
+                    await get_admin_account_use_case().change_password(
+                        user_id=session.user_id,
+                        current_password=current_pw.value,
+                        new_password=new_pw.value,
+                    )
+                except InvalidCredentialsException:
+                    ui.notify("Current password is incorrect", type="negative")
+                    return
+                except Exception as exc:  # noqa: BLE001 - delegated to handler
+                    await AdminErrorHandler.handle(exc, context="admin_change_password")
+                    return
 
             ui.notify("Password changed successfully", type="positive")
             AdminAuthProvider.logout()
             ui.navigate.to("/admin/login")
 
-        ui.button("Change Password", on_click=do_change).classes(
-            "q-mt-md full-width"
-        ).props("color=primary")
+        change_btn = (
+            ui.button("Change Password", on_click=do_change)
+            .classes("q-mt-md full-width")
+            .props("color=primary")
+        )
 
         if not is_forced:
             ui.button("Cancel", on_click=lambda: ui.navigate.to("/admin/")).classes(

--- a/src/_apps/admin/pages/login.py
+++ b/src/_apps/admin/pages/login.py
@@ -4,6 +4,7 @@ from src._core.infrastructure.admin.auth import (
     AdminAuthProvider,
     get_admin_auth_provider,
 )
+from src._core.infrastructure.admin.layout import button_loading
 from src.auth.domain.exceptions.auth_exceptions import (
     AdminCredentialDisabledException,
     AdminSetupRequiredException,
@@ -21,19 +22,20 @@ def login_page():
         ).classes("full-width")
 
         async def try_login():
-            try:
-                session = await get_admin_auth_provider().authenticate(
-                    username.value,
-                    password.value,
-                )
-            except AdminSetupRequiredException:
-                app.storage.user["setup_granted"] = True
-                ui.navigate.to("/admin/setup")
-            except (InvalidCredentialsException, AdminCredentialDisabledException):
-                ui.notify("Invalid credentials", type="negative")
-            else:
-                AdminAuthProvider.login(session)
-                ui.navigate.to("/admin/")
+            async with button_loading(login_btn):
+                try:
+                    session = await get_admin_auth_provider().authenticate(
+                        username.value,
+                        password.value,
+                    )
+                except AdminSetupRequiredException:
+                    app.storage.user["setup_granted"] = True
+                    ui.navigate.to("/admin/setup")
+                except (InvalidCredentialsException, AdminCredentialDisabledException):
+                    ui.notify("Invalid credentials", type="negative")
+                else:
+                    AdminAuthProvider.login(session)
+                    ui.navigate.to("/admin/")
 
         password.on("keydown.enter", try_login)
-        ui.button("Login", on_click=try_login).classes("q-mt-md full-width")
+        login_btn = ui.button("Login", on_click=try_login).classes("q-mt-md full-width")

--- a/src/_apps/admin/pages/login.py
+++ b/src/_apps/admin/pages/login.py
@@ -22,6 +22,7 @@ def login_page():
         ).classes("full-width")
 
         async def try_login():
+            target: str | None = None
             async with button_loading(login_btn):
                 try:
                     session = await get_admin_auth_provider().authenticate(
@@ -30,12 +31,15 @@ def login_page():
                     )
                 except AdminSetupRequiredException:
                     app.storage.user["setup_granted"] = True
-                    ui.navigate.to("/admin/setup")
+                    target = "/admin/setup"
                 except (InvalidCredentialsException, AdminCredentialDisabledException):
                     ui.notify("Invalid credentials", type="negative")
                 else:
                     AdminAuthProvider.login(session)
-                    ui.navigate.to("/admin/")
+                    target = "/admin/"
+            # Navigate only after loading state is cleared (button not yet torn down).
+            if target:
+                ui.navigate.to(target)
 
         password.on("keydown.enter", try_login)
         login_btn = ui.button("Login", on_click=try_login).classes("q-mt-md full-width")

--- a/src/_apps/admin/pages/setup.py
+++ b/src/_apps/admin/pages/setup.py
@@ -48,6 +48,7 @@ async def setup_page():
                 ui.notify("All fields are required", type="warning")
                 return
 
+            setup_already_complete = False
             async with button_loading(create_btn):
                 try:
                     (
@@ -60,16 +61,17 @@ async def setup_page():
                         bootstrap_username=settings.admin_bootstrap_username,
                     )
                 except AdminSetupForbiddenException:
-                    ui.notify(
-                        "Setup is already complete. Please log in.", type="warning"
-                    )
-                    ui.navigate.to("/admin/login")
-                    return
+                    setup_already_complete = True
                 except Exception as exc:  # noqa: BLE001 - delegated to handler
                     # Includes UserAlreadyExistsException (4xx) → AdminErrorHandler
                     # surfaces exc.message as a warning and logs with context.
                     await AdminErrorHandler.handle(exc, context="admin_setup_create")
                     return
+            # Navigate only after loading state is cleared (button not yet torn down).
+            if setup_already_complete:
+                ui.notify("Setup is already complete. Please log in.", type="warning")
+                ui.navigate.to("/admin/login")
+                return
 
             # Clear bootstrap session flag; user must log in as the new admin.
             AdminAuthProvider.logout()

--- a/src/_apps/admin/pages/setup.py
+++ b/src/_apps/admin/pages/setup.py
@@ -9,6 +9,7 @@ from src._core.infrastructure.admin.error_handler import (
     AdminErrorHandler,
     admin_error_boundary,
 )
+from src._core.infrastructure.admin.layout import button_loading
 from src.auth.domain.exceptions.auth_exceptions import AdminSetupForbiddenException
 
 
@@ -47,25 +48,28 @@ async def setup_page():
                 ui.notify("All fields are required", type="warning")
                 return
 
-            try:
-                (
-                    new_admin,
-                    temp_password,
-                ) = await get_admin_account_use_case().create_first_admin(
-                    username=username,
-                    full_name=full_name,
-                    email=email,
-                    bootstrap_username=settings.admin_bootstrap_username,
-                )
-            except AdminSetupForbiddenException:
-                ui.notify("Setup is already complete. Please log in.", type="warning")
-                ui.navigate.to("/admin/login")
-                return
-            except Exception as exc:  # noqa: BLE001 - delegated to AdminErrorHandler
-                # Includes UserAlreadyExistsException (4xx) → AdminErrorHandler
-                # surfaces exc.message as a warning and logs with context.
-                await AdminErrorHandler.handle(exc, context="admin_setup_create")
-                return
+            async with button_loading(create_btn):
+                try:
+                    (
+                        new_admin,
+                        temp_password,
+                    ) = await get_admin_account_use_case().create_first_admin(
+                        username=username,
+                        full_name=full_name,
+                        email=email,
+                        bootstrap_username=settings.admin_bootstrap_username,
+                    )
+                except AdminSetupForbiddenException:
+                    ui.notify(
+                        "Setup is already complete. Please log in.", type="warning"
+                    )
+                    ui.navigate.to("/admin/login")
+                    return
+                except Exception as exc:  # noqa: BLE001 - delegated to handler
+                    # Includes UserAlreadyExistsException (4xx) → AdminErrorHandler
+                    # surfaces exc.message as a warning and logs with context.
+                    await AdminErrorHandler.handle(exc, context="admin_setup_create")
+                    return
 
             # Clear bootstrap session flag; user must log in as the new admin.
             AdminAuthProvider.logout()
@@ -97,6 +101,8 @@ async def setup_page():
                 )
                 ui.timer(8.0, lambda: ui.navigate.to("/admin/login"), once=True)
 
-        ui.button("Create Admin Account", on_click=create_first_admin).classes(
-            "q-mt-md full-width"
-        ).props("color=primary")
+        create_btn = (
+            ui.button("Create Admin Account", on_click=create_first_admin)
+            .classes("q-mt-md full-width")
+            .props("color=primary")
+        )

--- a/src/_core/infrastructure/admin/base_admin_page.py
+++ b/src/_core/infrastructure/admin/base_admin_page.py
@@ -93,13 +93,16 @@ class BaseAdminPage:
         """
         skeleton = self._render_list_skeleton()
         try:
+            # Flush the skeleton to the client before the (slow) fetch so it is
+            # actually visible during loading — not just built then replaced.
+            await ui.context.client.connected()
             dtos, pagination = await self._fetch_list_data(page, search)
         except Exception as exc:  # noqa: BLE001 - delegated to AdminErrorHandler
-            skeleton.delete()
             await AdminErrorHandler.handle(exc, context=f"{self.domain_name}_list")
             return
+        finally:
+            skeleton.delete()  # finally: also covers cancellation / disconnect
 
-        skeleton.delete()
         self.render_list_header()
         self.render_search_bar(search)
         self.render_list_summary(pagination)
@@ -113,14 +116,17 @@ class BaseAdminPage:
         """
         skeleton = self._render_detail_skeleton()
         try:
+            # Flush the skeleton to the client before the (slow) fetch so it is
+            # actually visible during loading — not just built then replaced.
+            await ui.context.client.connected()
             dto = await self._fetch_detail_data(record_id)
         except Exception as exc:  # noqa: BLE001 - delegated to AdminErrorHandler
-            skeleton.delete()
             await AdminErrorHandler.handle(exc, context=f"{self.domain_name}_detail")
             self._render_back_button()
             return
+        finally:
+            skeleton.delete()  # finally: also covers cancellation / disconnect
 
-        skeleton.delete()
         self.render_detail_header(record_id)
         self.render_detail_card(dto)
 

--- a/src/_core/infrastructure/admin/base_admin_page.py
+++ b/src/_core/infrastructure/admin/base_admin_page.py
@@ -91,12 +91,15 @@ class BaseAdminPage:
 
         Override individual hook methods to customize rendering.
         """
+        skeleton = self._render_list_skeleton()
         try:
             dtos, pagination = await self._fetch_list_data(page, search)
         except Exception as exc:  # noqa: BLE001 - delegated to AdminErrorHandler
+            skeleton.delete()
             await AdminErrorHandler.handle(exc, context=f"{self.domain_name}_list")
             return
 
+        skeleton.delete()
         self.render_list_header()
         self.render_search_bar(search)
         self.render_list_summary(pagination)
@@ -108,15 +111,55 @@ class BaseAdminPage:
 
         Override individual hook methods to customize rendering.
         """
+        skeleton = self._render_detail_skeleton()
         try:
             dto = await self._fetch_detail_data(record_id)
         except Exception as exc:  # noqa: BLE001 - delegated to AdminErrorHandler
+            skeleton.delete()
             await AdminErrorHandler.handle(exc, context=f"{self.domain_name}_detail")
             self._render_back_button()
             return
 
+        skeleton.delete()
         self.render_detail_header(record_id)
         self.render_detail_card(dto)
+
+    # ── Loading skeletons ──
+
+    def _list_skeleton_rows(self) -> int:
+        """Placeholder row count for the list skeleton (default 8; less if the
+        page size is smaller)."""
+        return min(self.page_size, 8)
+
+    def _render_list_skeleton(self) -> ui.element:
+        """Render a list-shaped skeleton (heading + search + summary + rows)
+        shown while ``_fetch_list_data`` is pending. Caller deletes it."""
+        with ui.column().classes("w-full q-gutter-sm") as container:
+            ui.skeleton(type="text", width="45%", height="32px")
+            ui.skeleton(type="rect", width="280px", height="40px")
+            ui.skeleton(type="text", width="25%", height="16px")
+            for _ in range(self._list_skeleton_rows()):
+                ui.skeleton(type="rect", width="100%", height="44px")
+        return container
+
+    def _detail_skeleton_rows(self) -> int:
+        """Placeholder field-row count for the detail skeleton (mirrors visible
+        columns, minimum 4)."""
+        return max(len(self.get_visible_columns()), 4)
+
+    def _render_detail_skeleton(self) -> ui.element:
+        """Render a detail-shaped skeleton (back-button header + field rows)
+        shown while ``_fetch_detail_data`` is pending. Caller deletes it."""
+        with ui.column().classes("w-full q-gutter-sm") as container:
+            with ui.row().classes("items-center q-gutter-sm"):
+                ui.skeleton(type="QBtn", width="36px", height="36px")
+                ui.skeleton(type="text", width="200px", height="32px")
+            with ui.card().classes("w-full"):
+                for _ in range(self._detail_skeleton_rows()):
+                    with ui.row().classes("items-center q-py-xs"):
+                        ui.skeleton(type="text", width="160px", height="18px")
+                        ui.skeleton(type="text", width="300px", height="18px")
+        return container
 
     # ── Data fetching (overridable) ──
 

--- a/src/_core/infrastructure/admin/layout.py
+++ b/src/_core/infrastructure/admin/layout.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
 from nicegui import ui
@@ -9,6 +11,27 @@ from src.auth.domain.dtos.auth_dto import AdminSessionDTO
 
 if TYPE_CHECKING:
     from src._core.infrastructure.admin.base_admin_page import BaseAdminPage
+
+
+@asynccontextmanager
+async def button_loading(button: ui.button) -> AsyncIterator[None]:
+    """Show Quasar ``loading`` + ``disable`` on a button while an async op runs.
+
+    Gives immediate feedback on slow admin write actions and blocks duplicate
+    submits. Cleanup runs in ``finally`` so the button is always re-enabled —
+    even when the wrapped block raises or returns early.
+
+    Usage::
+
+        async def on_click() -> None:
+            async with button_loading(submit_btn):
+                await slow_operation()
+    """
+    button.props("loading disable")
+    try:
+        yield
+    finally:
+        button.props(remove="loading disable")
 
 
 def admin_layout(

--- a/src/docs/interface/admin/pages/docs_page.py
+++ b/src/docs/interface/admin/pages/docs_page.py
@@ -8,7 +8,7 @@ from src._core.infrastructure.admin.error_handler import (
     AdminErrorHandler,
     admin_error_boundary,
 )
-from src._core.infrastructure.admin.layout import admin_layout
+from src._core.infrastructure.admin.layout import admin_layout, button_loading
 from src.docs.interface.admin.configs.docs_admin_config import docs_admin_page
 
 # page_configs is injected by bootstrap_admin() after discovery
@@ -55,14 +55,15 @@ async def docs_query_page() -> None:
         if not question:
             ui.notify("Question is required", type="warning")
             return
-        try:
-            service = docs_admin_page._get_extra_service("query")
-            answer, retrieved_count = await service.answer_question(
-                question=question, top_k=int(top_k_input.value or 5)
-            )
-        except Exception as exc:  # noqa: BLE001 - delegated to AdminErrorHandler
-            await AdminErrorHandler.handle(exc, context="docs_query")
-            return
+        async with button_loading(ask_btn):
+            try:
+                service = docs_admin_page._get_extra_service("query")
+                answer, retrieved_count = await service.answer_question(
+                    question=question, top_k=int(top_k_input.value or 5)
+                )
+            except Exception as exc:  # noqa: BLE001 - delegated to AdminErrorHandler
+                await AdminErrorHandler.handle(exc, context="docs_query")
+                return
 
         answer_card.clear()
         answer_card.style("display: block")
@@ -90,7 +91,7 @@ async def docs_query_page() -> None:
                             "text-caption"
                         )
 
-    ui.button("Ask", on_click=_run_query).props("color=primary")
+    ask_btn = ui.button("Ask", on_click=_run_query).props("color=primary")
 
 
 @ui.page("/admin/docs/{record_id}")

--- a/tests/unit/_core/infrastructure/admin/test_loading_states.py
+++ b/tests/unit/_core/infrastructure/admin/test_loading_states.py
@@ -1,0 +1,79 @@
+"""Unit tests for admin loading states (#198): button_loading + skeleton counts."""
+
+from __future__ import annotations
+
+import pytest
+
+from src._core.infrastructure.admin.base_admin_page import BaseAdminPage, ColumnConfig
+from src._core.infrastructure.admin.layout import button_loading
+
+
+class _FakeButton:
+    """Records props() calls the way NiceGUI's ui.button exposes them."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str | None, str | None]] = []
+
+    def props(self, add: str | None = None, *, remove: str | None = None):
+        self.calls.append((add, remove))
+        return self
+
+
+@pytest.mark.asyncio
+async def test_button_loading_sets_then_clears_on_success():
+    btn = _FakeButton()
+    async with button_loading(btn):
+        assert btn.calls == [("loading disable", None)]
+    assert btn.calls[-1] == (None, "loading disable")
+
+
+@pytest.mark.asyncio
+async def test_button_loading_clears_on_exception():
+    btn = _FakeButton()
+    with pytest.raises(ValueError):
+        async with button_loading(btn):
+            raise ValueError("boom")
+    # loading was set, then removed in finally despite the exception
+    assert btn.calls[0] == ("loading disable", None)
+    assert btn.calls[-1] == (None, "loading disable")
+
+
+@pytest.mark.asyncio
+async def test_button_loading_clears_on_early_return():
+    btn = _FakeButton()
+
+    async def handler() -> None:
+        async with button_loading(btn):
+            return  # early return inside the context
+
+    await handler()
+    assert btn.calls[-1] == (None, "loading disable")
+
+
+def test_list_skeleton_rows_defaults_to_8():
+    page = BaseAdminPage(domain_name="t", display_name="T", icon="x")
+    assert page.page_size == 20
+    assert page._list_skeleton_rows() == 8
+
+
+def test_list_skeleton_rows_match_small_page_size():
+    page = BaseAdminPage(domain_name="t", display_name="T", icon="x", page_size=3)
+    assert page._list_skeleton_rows() == 3
+
+
+def test_detail_skeleton_rows_minimum_4():
+    page = BaseAdminPage(
+        domain_name="t",
+        display_name="T",
+        icon="x",
+        columns=[ColumnConfig(field_name="id", header_name="ID")],
+    )
+    assert page._detail_skeleton_rows() == 4
+
+
+def test_detail_skeleton_rows_mirror_visible_columns():
+    columns = [ColumnConfig(field_name=f"f{i}", header_name=f"F{i}") for i in range(6)]
+    columns.append(ColumnConfig(field_name="secret", header_name="S", hidden=True))
+    page = BaseAdminPage(domain_name="t", display_name="T", icon="x", columns=columns)
+    # 6 visible (hidden excluded) → max(6, 4) == 6
+    assert page._detail_skeleton_rows() == 6


### PR DESCRIPTION
## Related Issue
- Closes #198

## Change Summary
- `button_loading` async context manager (`layout.py`): sets Quasar `loading`+`disable` on a button for the duration of an async op and **always clears in `finally`** (success / exception / early-return). Applied to every admin write button — docs Ask, accounts create/save-perms/remove, setup create, change-password, login.
- For dialog / navigation flows, only the slow `await` is wrapped; `dlg.close()` / `refresh_cb()` / `ui.navigate.to()` run **after** the `async with` so the button is never toggled once it may be torn down.
- Skeleton UI in `BaseAdminPage.render_list/render_detail`: a structure-mirroring skeleton renders while `_fetch_*` is pending. `await ui.context.client.connected()` runs before the fetch so the skeleton is actually flushed to the client during a slow load (not just built then replaced), and the skeleton is deleted in `finally` (covers cancellation / disconnect). One change covers all domain pages. List rows = `min(page_size, 8)`; detail field rows = `max(visible columns, 4)`.
- Docs sync (`/sync-guidelines`): project-dna §11 Loading-states subsection + project-status row.

## Type of Change
- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] refactor: Code restructuring
- [x] docs: Documentation
- [ ] chore: Build/tooling
- [x] test: Tests
- [ ] ci: CI/CD
- [ ] perf: Performance
- [ ] style: Code style

## Checklist
- [x] Architecture rules followed (no Domain -> Infrastructure imports)
- [x] Tests pass
- [x] Linting passes (`ruff check src/`)

## How to Test
- `pytest tests/unit/_core/infrastructure/admin/ -v` — 54 passed incl. `button_loading` clears on success/exception/early-return and skeleton row-count logic.
- `pytest tests/` — 973 passed, 15 skipped (10 DynamoDB integration deselected: need docker).
- `ruff check` + `ruff format` + Tier-1 language pre-commit hooks pass.
- **Manual (recommended)**: `make quickstart` → `/admin` → confirm list/detail skeletons during load and button spinner/disable on Ask / Create; verify no stuck loading on error.
- Independent review: design + implementation cross-reviewed read-only with codex (gpt-5.5, reasoning xhigh), 2 implementation rounds. Round-1 findings (login/setup navigate-inside-loading, skeleton `finally`, skeleton-flush-before-fetch) all fixed in `656ccd4`; round-2 verdict **merge-ready**, no must-fix.

---

## Governor Footer
- trigger: yes
- reviewer: codex-cli
- rounds: 3
- r-points-fixed: 4
- r-points-deferred: 0
- r-points-rejected: 0
- touched-adr-consequences: none
- pr-scope-notes: admin loading states (button_loading + skeleton); UI-only, no auth/permission/exposure change; skeleton visibility guaranteed via ui.context.client.connected()
- final-verdict: merge-ready
- links: https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/204
