### PR TITLE
feat(admin): NiceGUI admin UI/UX — theme, dark mode, shell redesign (#193)

### DIFF
--- a/_env/local.env.example
+++ b/_env/local.env.example
@@ -21,7 +21,7 @@ ADMIN_BOOTSTRAP_FULL_NAME=Administrator
 # Admin dashboard initial dark-mode policy (#193): unset = follow OS preference,
 # true = start dark, false = start light. The in-header toggle overrides per session.
 # ADMIN_DARK_MODE_DEFAULT=
-# Admin color palette (#193): "default" (classic blue) or "slate" (slate + indigo).
+# Admin style preset (#193): default | linear | shadcn | supabase.
 # ADMIN_THEME_PALETTE=default
 
 # Admin auth uses a SEPARATE JWT realm from customer auth (ADR 049).

--- a/_env/local.env.example
+++ b/_env/local.env.example
@@ -23,6 +23,8 @@ ADMIN_BOOTSTRAP_FULL_NAME=Administrator
 # ADMIN_DARK_MODE_DEFAULT=
 # Admin style preset (#193): default | linear | shadcn | supabase.
 # ADMIN_THEME_PALETTE=default
+# Brand name shown in the admin header + login card (#193).
+# ADMIN_BRAND_NAME=Admin Console
 
 # Admin auth uses a SEPARATE JWT realm from customer auth (ADR 049).
 # Local auto-generates both secrets on boot (fine for dev). In stg/prod

--- a/_env/local.env.example
+++ b/_env/local.env.example
@@ -21,6 +21,8 @@ ADMIN_BOOTSTRAP_FULL_NAME=Administrator
 # Admin dashboard initial dark-mode policy (#193): unset = follow OS preference,
 # true = start dark, false = start light. The in-header toggle overrides per session.
 # ADMIN_DARK_MODE_DEFAULT=
+# Admin color palette (#193): "default" (classic blue) or "slate" (slate + indigo).
+# ADMIN_THEME_PALETTE=default
 
 # Admin auth uses a SEPARATE JWT realm from customer auth (ADR 049).
 # Local auto-generates both secrets on boot (fine for dev). In stg/prod

--- a/_env/local.env.example
+++ b/_env/local.env.example
@@ -18,6 +18,9 @@ ADMIN_BOOTSTRAP_USERNAME=admin
 ADMIN_BOOTSTRAP_PASSWORD=REPLACE_ME
 ADMIN_BOOTSTRAP_EMAIL=admin@example.com
 ADMIN_BOOTSTRAP_FULL_NAME=Administrator
+# Admin dashboard initial dark-mode policy (#193): unset = follow OS preference,
+# true = start dark, false = start light. The in-header toggle overrides per session.
+# ADMIN_DARK_MODE_DEFAULT=
 
 # Admin auth uses a SEPARATE JWT realm from customer auth (ADR 049).
 # Local auto-generates both secrets on boot (fine for dev). In stg/prod

--- a/_env/quickstart.env.example
+++ b/_env/quickstart.env.example
@@ -35,7 +35,7 @@ ADMIN_BOOTSTRAP_FULL_NAME=Administrator
 # Admin dashboard initial dark-mode policy (#193): unset = follow OS preference,
 # true = start dark, false = start light. The in-header toggle overrides per session.
 # ADMIN_DARK_MODE_DEFAULT=
-# Admin color palette (#193): "default" (classic blue) or "slate" (slate + indigo).
+# Admin style preset (#193): default | linear | shadcn | supabase.
 # ADMIN_THEME_PALETTE=default
 
 # Admin auth uses a SEPARATE JWT realm from customer auth (ADR 049).

--- a/_env/quickstart.env.example
+++ b/_env/quickstart.env.example
@@ -35,6 +35,8 @@ ADMIN_BOOTSTRAP_FULL_NAME=Administrator
 # Admin dashboard initial dark-mode policy (#193): unset = follow OS preference,
 # true = start dark, false = start light. The in-header toggle overrides per session.
 # ADMIN_DARK_MODE_DEFAULT=
+# Admin color palette (#193): "default" (classic blue) or "slate" (slate + indigo).
+# ADMIN_THEME_PALETTE=default
 
 # Admin auth uses a SEPARATE JWT realm from customer auth (ADR 049).
 # Quickstart auto-generates both signing secrets on boot, so nothing is

--- a/_env/quickstart.env.example
+++ b/_env/quickstart.env.example
@@ -32,6 +32,10 @@ ADMIN_BOOTSTRAP_PASSWORD=admin
 ADMIN_BOOTSTRAP_EMAIL=admin@example.com
 ADMIN_BOOTSTRAP_FULL_NAME=Administrator
 
+# Admin dashboard initial dark-mode policy (#193): unset = follow OS preference,
+# true = start dark, false = start light. The in-header toggle overrides per session.
+# ADMIN_DARK_MODE_DEFAULT=
+
 # Admin auth uses a SEPARATE JWT realm from customer auth (ADR 049).
 # Quickstart auto-generates both signing secrets on boot, so nothing is
 # required here. In stg/prod ADMIN_JWT_SECRET_KEY is mandatory and must

--- a/_env/quickstart.env.example
+++ b/_env/quickstart.env.example
@@ -37,6 +37,8 @@ ADMIN_BOOTSTRAP_FULL_NAME=Administrator
 # ADMIN_DARK_MODE_DEFAULT=
 # Admin style preset (#193): default | linear | shadcn | supabase.
 # ADMIN_THEME_PALETTE=default
+# Brand name shown in the admin header + login card (#193).
+# ADMIN_BRAND_NAME=Admin Console
 
 # Admin auth uses a SEPARATE JWT realm from customer auth (ADR 049).
 # Quickstart auto-generates both signing secrets on boot, so nothing is

--- a/src/_apps/admin/bootstrap.py
+++ b/src/_apps/admin/bootstrap.py
@@ -32,6 +32,7 @@ from src._core.infrastructure.admin.base_admin_page import BaseAdminPage
 from src._core.infrastructure.admin.error_handler import (
     handle_uncaught_admin_exception,
 )
+from src._core.infrastructure.admin.theme import install_admin_theme_css
 from src._core.infrastructure.discovery import discover_domains
 from src.admin_identity.domain.dtos.admin_identity_dto import BootstrapAdminDTO
 
@@ -89,7 +90,17 @@ def bootstrap_admin(fastapi_app: FastAPI) -> None:
     for cfg in page_configs:
         permission_registry.register(cfg.domain_name)
 
-    ui.run_with(fastapi_app, storage_secret=settings.admin_storage_secret)
+    # Inject the shared admin theme CSS into every page head (#193). Self-guarded
+    # against duplicate injection on repeated bootstrap calls (test reloads).
+    install_admin_theme_css()
+
+    # ``dark`` sets the first-paint theme for every admin page; None follows the
+    # browser's prefers-color-scheme. The in-header toggle overrides per session.
+    ui.run_with(
+        fastapi_app,
+        storage_secret=settings.admin_storage_secret,
+        dark=settings.admin_dark_mode_default,
+    )
 
 
 def _install_bootstrap_admin_seed(fastapi_app: FastAPI, admin_container) -> None:

--- a/src/_apps/admin/pages/accounts.py
+++ b/src/_apps/admin/pages/accounts.py
@@ -16,6 +16,7 @@ from src._core.infrastructure.admin.error_handler import (
     admin_error_boundary,
 )
 from src._core.infrastructure.admin.layout import admin_layout, button_loading
+from src._core.infrastructure.admin.theme import AdminClasses
 from src.admin_identity.domain.dtos.admin_identity_dto import (
     AdminIdentityDTO,
     CreateAdminAccountDTO,
@@ -139,14 +140,14 @@ def _render_admin_list(
                 with ui.column():
                     ui.label(admin.username).classes("text-weight-bold")
                     ui.label(admin.full_name).classes("text-caption")
-                    ui.label(admin.email).classes("text-caption text-grey-7")
+                    ui.label(admin.email).classes(f"text-caption {AdminClasses.MUTED}")
                     flags = []
                     if admin.is_bootstrap_admin:
                         flags.append("bootstrap")
                     if admin.password_temporary:
                         flags.append("temp-pw")
                     if flags:
-                        ui.label(", ".join(flags)).classes("text-caption text-orange")
+                        ui.label(", ".join(flags)).classes("text-caption text-warning")
                     perms_text = ", ".join(admin.permissions) or "(none)"
                     ui.label("Permissions: " + perms_text).classes("text-caption")
 

--- a/src/_apps/admin/pages/audit_log.py
+++ b/src/_apps/admin/pages/audit_log.py
@@ -77,7 +77,9 @@ async def audit_log_page() -> None:
         apply_btn = ui.button("Apply", on_click=lambda: _apply()).props("color=primary")
 
     grid_container = ui.column().classes("w-full")
-    pagination_container = ui.row().classes("q-gutter-sm items-center q-mt-sm")
+    pagination_container = ui.row().classes(
+        f"q-gutter-sm items-center q-mt-sm {AdminClasses.PAGINATION}"
+    )
 
     def _build_filter() -> AuditLogFilter:
         actions = tuple(AdminAction(a) for a in (action_select.value or []))

--- a/src/_apps/admin/pages/audit_log.py
+++ b/src/_apps/admin/pages/audit_log.py
@@ -29,6 +29,7 @@ from src._core.infrastructure.admin.auth import require_auth
 from src._core.infrastructure.admin.base_admin_page import BaseAdminPage
 from src._core.infrastructure.admin.error_handler import admin_error_boundary
 from src._core.infrastructure.admin.layout import admin_layout, button_loading
+from src._core.infrastructure.admin.theme import AdminClasses
 
 # Injected by bootstrap_admin() after discovery (mirrors accounts.py).
 page_configs: list[BaseAdminPage] = []
@@ -151,27 +152,23 @@ def _render_grid(
     show_detail_cb,
 ) -> None:
     row_data = [r.model_dump(mode="json") for r in rows]
-    grid = (
-        ui.aggrid(
-            {
-                "columnDefs": [
-                    {"headerName": "Time (UTC)", "field": "created_at", "width": 200},
-                    {"headerName": "User", "field": "admin_username", "width": 140},
-                    {"headerName": "Action", "field": "action", "width": 160},
-                    {"headerName": "Domain", "field": "domain", "width": 100},
-                    {"headerName": "Record", "field": "record_id", "width": 100},
-                    {"headerName": "Result", "field": "result", "width": 100},
-                    {"headerName": "Reason", "field": "failure_reason", "width": 180},
-                    {"headerName": "IP", "field": "ip_address", "width": 130},
-                ],
-                "rowData": row_data,
-                "defaultColDef": {"resizable": True, "sortable": True},
-                "rowSelection": "single",
-            }
-        )
-        .classes("w-full")
-        .style("height: 480px")
-    )
+    grid = ui.aggrid(
+        {
+            "columnDefs": [
+                {"headerName": "Time (UTC)", "field": "created_at", "width": 200},
+                {"headerName": "User", "field": "admin_username", "width": 140},
+                {"headerName": "Action", "field": "action", "width": 160},
+                {"headerName": "Domain", "field": "domain", "width": 100},
+                {"headerName": "Record", "field": "record_id", "width": 100},
+                {"headerName": "Result", "field": "result", "width": 100},
+                {"headerName": "Reason", "field": "failure_reason", "width": 180},
+                {"headerName": "IP", "field": "ip_address", "width": 130},
+            ],
+            "rowData": row_data,
+            "defaultColDef": {"resizable": True, "sortable": True},
+            "rowSelection": "single",
+        }
+    ).classes(f"w-full {AdminClasses.GRID}")
 
     async def _on_row_clicked(event) -> None:
         audit_id = event.args.get("data", {}).get("id")
@@ -202,7 +199,7 @@ def _open_detail_dialog(dto: AuditLogDTO) -> None:
         )
         created_iso = dto.created_at.isoformat() if dto.created_at else "—"
         ui.label(f"{dto.admin_username} · {created_iso}").classes(
-            "text-caption text-grey-7 q-mb-sm"
+            f"text-caption {AdminClasses.MUTED} q-mb-sm"
         )
         if dto.correlation_id:
             with ui.row().classes("items-center q-gutter-sm q-mb-sm"):

--- a/src/_apps/admin/pages/dashboard.py
+++ b/src/_apps/admin/pages/dashboard.py
@@ -4,6 +4,7 @@ from src._core.infrastructure.admin.auth import require_auth_allowlisted
 from src._core.infrastructure.admin.base_admin_page import BaseAdminPage
 from src._core.infrastructure.admin.error_handler import admin_error_boundary
 from src._core.infrastructure.admin.layout import admin_layout
+from src._core.infrastructure.admin.theme import AdminClasses
 
 # page_configs is injected by bootstrap_admin() after discovery
 page_configs: list[BaseAdminPage] = []
@@ -33,7 +34,7 @@ async def dashboard_page():
                 )
             ):
                 with ui.row().classes("items-center q-pa-sm"):
-                    ui.icon(pc.icon).classes("text-h4 text-blue-800")
+                    ui.icon(pc.icon).classes(f"text-h4 {AdminClasses.ACCENT_ICON}")
                     ui.label(pc.display_name).classes("text-h6")
 
         if "accounts" in permissions:
@@ -43,7 +44,9 @@ async def dashboard_page():
                 .on("click", lambda: ui.navigate.to("/admin/accounts"))
             ):
                 with ui.row().classes("items-center q-pa-sm"):
-                    ui.icon("manage_accounts").classes("text-h4 text-blue-800")
+                    ui.icon("manage_accounts").classes(
+                        f"text-h4 {AdminClasses.ACCENT_ICON}"
+                    )
                     ui.label("Accounts").classes("text-h6")
 
         if "audit_log" in permissions:
@@ -53,5 +56,5 @@ async def dashboard_page():
                 .on("click", lambda: ui.navigate.to("/admin/audit-log"))
             ):
                 with ui.row().classes("items-center q-pa-sm"):
-                    ui.icon("fact_check").classes("text-h4 text-blue-800")
+                    ui.icon("fact_check").classes(f"text-h4 {AdminClasses.ACCENT_ICON}")
                     ui.label("Audit Log").classes("text-h6")

--- a/src/_apps/admin/pages/dashboard.py
+++ b/src/_apps/admin/pages/dashboard.py
@@ -4,7 +4,6 @@ from src._core.infrastructure.admin.auth import require_auth_allowlisted
 from src._core.infrastructure.admin.base_admin_page import BaseAdminPage
 from src._core.infrastructure.admin.error_handler import admin_error_boundary
 from src._core.infrastructure.admin.layout import admin_layout
-from src._core.infrastructure.admin.theme import AdminClasses
 
 # page_configs is injected by bootstrap_admin() after discovery
 page_configs: list[BaseAdminPage] = []
@@ -34,7 +33,7 @@ async def dashboard_page():
                 )
             ):
                 with ui.row().classes("items-center q-pa-sm"):
-                    ui.icon(pc.icon).classes(f"text-h4 {AdminClasses.ACCENT_ICON}")
+                    ui.icon(pc.icon).classes("text-h4 text-primary")
                     ui.label(pc.display_name).classes("text-h6")
 
         if "accounts" in permissions:
@@ -44,9 +43,7 @@ async def dashboard_page():
                 .on("click", lambda: ui.navigate.to("/admin/accounts"))
             ):
                 with ui.row().classes("items-center q-pa-sm"):
-                    ui.icon("manage_accounts").classes(
-                        f"text-h4 {AdminClasses.ACCENT_ICON}"
-                    )
+                    ui.icon("manage_accounts").classes("text-h4 text-primary")
                     ui.label("Accounts").classes("text-h6")
 
         if "audit_log" in permissions:
@@ -56,5 +53,5 @@ async def dashboard_page():
                 .on("click", lambda: ui.navigate.to("/admin/audit-log"))
             ):
                 with ui.row().classes("items-center q-pa-sm"):
-                    ui.icon("fact_check").classes(f"text-h4 {AdminClasses.ACCENT_ICON}")
+                    ui.icon("fact_check").classes("text-h4 text-primary")
                     ui.label("Audit Log").classes("text-h6")

--- a/src/_apps/admin/pages/error.py
+++ b/src/_apps/admin/pages/error.py
@@ -14,6 +14,8 @@ import re
 
 from nicegui import ui
 
+from src._core.infrastructure.admin.theme import AdminClasses
+
 # Correlation ids are short hex/uuid-ish tokens; reject anything else before
 # echoing the query value back into the page (no reflected-content surprises).
 _RID_PATTERN = re.compile(r"^[A-Za-z0-9-]{1,64}$")
@@ -22,13 +24,15 @@ _RID_PATTERN = re.compile(r"^[A-Za-z0-9-]{1,64}$")
 @ui.page("/admin/error")
 def error_page(rid: str = "") -> None:
     with ui.card().classes("absolute-center w-96 items-center"):
-        ui.icon("error_outline").classes("text-h2 text-red-700")
+        ui.icon("error_outline").classes("text-h2 text-negative")
         ui.label("Something went wrong").classes("text-h5 q-mb-sm")
         ui.label(
             "An unexpected error occurred. Please contact your administrator."
         ).classes("text-body2 text-center q-mb-md")
         if rid and _RID_PATTERN.match(rid):
-            ui.label(f"Reference ID: {rid}").classes("text-caption text-grey-7 q-mb-md")
+            ui.label(f"Reference ID: {rid}").classes(
+                f"text-caption {AdminClasses.MUTED} q-mb-md"
+            )
         ui.button(
             "Return to dashboard",
             on_click=lambda: ui.navigate.to("/admin/"),

--- a/src/_apps/admin/pages/login.py
+++ b/src/_apps/admin/pages/login.py
@@ -1,11 +1,13 @@
 from fastapi import Request
 from nicegui import app, ui
 
+from src._core.config import settings
 from src._core.infrastructure.admin.auth import (
     AdminAuthProvider,
     get_admin_auth_provider,
 )
 from src._core.infrastructure.admin.layout import button_loading
+from src._core.infrastructure.admin.theme import AdminClasses
 from src.admin_identity.domain.exceptions.admin_identity_exceptions import (
     AdminCredentialDisabledException,
     AdminInvalidCredentialsException,
@@ -20,12 +22,23 @@ def login_page(request: Request):
     # explicit proxy-trust configuration so we don't do it implicitly here.
     client_ip = request.client.host if request.client else None
 
-    with ui.card().classes("absolute-center w-80"):
-        ui.label("Admin Login").classes("text-h5 q-mb-md")
-        username = ui.input("Username").classes("full-width")
-        password = ui.input(
-            "Password", password=True, password_toggle_button=True
-        ).classes("full-width")
+    # Distinct dark background for the auth screen (page-scoped).
+    ui.query("body").classes(AdminClasses.LOGIN_BG)
+
+    with ui.card().classes(
+        f"absolute-center items-center q-pa-lg {AdminClasses.LOGIN_CARD}"
+    ):
+        ui.icon("smart_toy").classes("text-primary").style("font-size: 3rem")
+        ui.label(settings.admin_brand_name).classes("text-h6 text-weight-bold q-mt-sm")
+        ui.label("ADMIN").classes(f"{AdminClasses.MUTED} q-mb-md").style(
+            "letter-spacing: 0.25em; font-size: 0.7rem"
+        )
+        username = ui.input("Username").props("outlined").classes("full-width")
+        password = (
+            ui.input("Password", password=True, password_toggle_button=True)
+            .props("outlined")
+            .classes("full-width q-mt-sm")
+        )
 
         async def try_login():
             target: str | None = None
@@ -52,4 +65,8 @@ def login_page(request: Request):
                 ui.navigate.to(target)
 
         password.on("keydown.enter", try_login)
-        login_btn = ui.button("Login", on_click=try_login).classes("q-mt-md full-width")
+        login_btn = (
+            ui.button("Login", on_click=try_login)
+            .props("color=primary unelevated size=lg")
+            .classes("q-mt-md full-width")
+        )

--- a/src/_apps/admin/pages/setup.py
+++ b/src/_apps/admin/pages/setup.py
@@ -16,6 +16,7 @@ from src._core.infrastructure.admin.error_handler import (
     admin_error_boundary,
 )
 from src._core.infrastructure.admin.layout import button_loading
+from src._core.infrastructure.admin.theme import AdminClasses
 from src.admin_identity.domain.exceptions.admin_identity_exceptions import (
     AdminSetupForbiddenException,
 )
@@ -38,14 +39,16 @@ async def setup_page():
     with ui.card().classes("absolute-center w-96"):
         ui.label("Initial Admin Setup").classes("text-h5 q-mb-md")
         ui.label("Create the first administrator account.").classes(
-            "text-subtitle2 q-mb-md text-grey-7"
+            f"text-subtitle2 q-mb-md {AdminClasses.MUTED}"
         )
 
         username_input = ui.input("Username").classes("full-width")
         full_name_input = ui.input("Full Name").classes("full-width")
         email_input = ui.input("Email").classes("full-width")
 
-        result_card = ui.card().classes("w-full q-mt-md bg-green-1")
+        result_card = ui.card().classes(
+            f"w-full q-mt-md {AdminClasses.SUCCESS_SURFACE}"
+        )
         result_card.set_visibility(False)
 
         async def create_first_admin():
@@ -119,7 +122,7 @@ async def setup_page():
                 ui.label(f"Username: {new_admin.username}")
                 ui.separator().classes("q-my-sm")
                 ui.label("Temporary password (copy now — shown once):").classes(
-                    "text-caption text-grey-7"
+                    f"text-caption {AdminClasses.MUTED}"
                 )
                 ui.label(temp_password).classes(
                     "text-mono text-weight-bold text-body1 q-mt-xs"
@@ -132,7 +135,7 @@ async def setup_page():
                 ).props("flat size=sm color=primary").classes("q-mt-sm")
                 ui.separator().classes("q-my-sm")
                 ui.label("You will be redirected to login in 8 seconds.").classes(
-                    "text-caption text-grey-6"
+                    f"text-caption {AdminClasses.MUTED}"
                 )
                 ui.timer(8.0, lambda: ui.navigate.to("/admin/login"), once=True)
 

--- a/src/_core/config.py
+++ b/src/_core/config.py
@@ -87,6 +87,15 @@ class Settings(BaseSettings):
         default_factory=lambda: secrets.token_urlsafe(32),
         validation_alias="ADMIN_STORAGE_SECRET",
     )
+    # Initial dark-mode policy for the NiceGUI admin shell (#193). Decides the
+    # first-paint theme passed to ``ui.run_with(dark=...)``:
+    #   None  -> follow the browser/OS ``prefers-color-scheme`` (default)
+    #   False -> always start light · True -> always start dark
+    # The in-header toggle overrides this per session via ``app.storage.user``.
+    admin_dark_mode_default: bool | None = Field(
+        default=None,
+        validation_alias="ADMIN_DARK_MODE_DEFAULT",
+    )
     admin_bootstrap_enabled: bool = Field(
         default=False,
         validation_alias="ADMIN_BOOTSTRAP_ENABLED",

--- a/src/_core/config.py
+++ b/src/_core/config.py
@@ -104,6 +104,13 @@ class Settings(BaseSettings):
         default="default",
         validation_alias="ADMIN_THEME_PALETTE",
     )
+    # Brand name shown in the admin header + login card (#193). Rebrand per fork.
+    admin_brand_name: str = Field(
+        default="Admin Console",
+        validation_alias="ADMIN_BRAND_NAME",
+        min_length=1,
+        max_length=40,
+    )
     admin_bootstrap_enabled: bool = Field(
         default=False,
         validation_alias="ADMIN_BOOTSTRAP_ENABLED",

--- a/src/_core/config.py
+++ b/src/_core/config.py
@@ -96,10 +96,11 @@ class Settings(BaseSettings):
         default=None,
         validation_alias="ADMIN_DARK_MODE_DEFAULT",
     )
-    # Admin shell color palette preset (#193). "default" = classic blue,
-    # "slate" = modern slate + indigo. Drives the --q-*/--admin-* CSS variables;
-    # the look can be rebranded by adding a preset in admin/theme.py.
-    admin_theme_palette: Literal["default", "slate"] = Field(
+    # Admin shell style preset (#193). Bundles color + shape/elevation tokens:
+    # "default" (classic blue), "linear" (minimal flat), "shadcn" (clean rounded),
+    # "supabase" (dark header + green). Drives the --q-*/--admin-* CSS variables;
+    # add a preset in admin/theme.py to rebrand.
+    admin_theme_palette: Literal["default", "linear", "shadcn", "supabase"] = Field(
         default="default",
         validation_alias="ADMIN_THEME_PALETTE",
     )

--- a/src/_core/config.py
+++ b/src/_core/config.py
@@ -1,6 +1,6 @@
 import secrets
 import warnings
-from typing import Self
+from typing import Literal, Self
 
 from pydantic import AliasChoices, Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -95,6 +95,13 @@ class Settings(BaseSettings):
     admin_dark_mode_default: bool | None = Field(
         default=None,
         validation_alias="ADMIN_DARK_MODE_DEFAULT",
+    )
+    # Admin shell color palette preset (#193). "default" = classic blue,
+    # "slate" = modern slate + indigo. Drives the --q-*/--admin-* CSS variables;
+    # the look can be rebranded by adding a preset in admin/theme.py.
+    admin_theme_palette: Literal["default", "slate"] = Field(
+        default="default",
+        validation_alias="ADMIN_THEME_PALETTE",
     )
     admin_bootstrap_enabled: bool = Field(
         default=False,

--- a/src/_core/infrastructure/admin/base_admin_page.py
+++ b/src/_core/infrastructure/admin/base_admin_page.py
@@ -11,6 +11,7 @@ from src._core.domain.value_objects.query_filter import QueryFilter
 from src._core.infrastructure.admin.audit import AdminAction, AuditResult
 from src._core.infrastructure.admin.audit.logger import get_audit_logger
 from src._core.infrastructure.admin.error_handler import AdminErrorHandler
+from src._core.infrastructure.admin.theme import AdminClasses, AdminMetrics
 
 if TYPE_CHECKING:
     from src._core.application.dtos.base_response import PaginationInfo
@@ -248,18 +249,15 @@ class BaseAdminPage:
         masked_fields = self.get_masked_field_names()
         row_data = self.build_row_data(dtos, masked_fields)
 
-        grid = (
-            ui.aggrid(
-                {
-                    "columnDefs": column_defs,
-                    "rowData": row_data,
-                    "rowSelection": {"mode": "singleRow"},
-                    "defaultColDef": {"resizable": True, "filter": True},
-                }
-            )
-            .classes("w-full")
-            .style("height: 600px")
-        )
+        grid = ui.aggrid(
+            {
+                "columnDefs": column_defs,
+                "rowData": row_data,
+                "rowSelection": {"mode": "singleRow"},
+                "rowHeight": AdminMetrics.GRID_ROW_HEIGHT,
+                "defaultColDef": {"resizable": True, "filter": True},
+            }
+        ).classes(f"w-full {AdminClasses.GRID}")
 
         grid.on(
             "cellClicked",
@@ -317,9 +315,7 @@ class BaseAdminPage:
                     display_value = str(value) if value is not None else ""
 
                 with ui.row().classes("items-center q-py-xs"):
-                    ui.label(col.header_name).classes("text-weight-bold").style(
-                        "width: 160px"
-                    )
+                    ui.label(col.header_name).classes(AdminClasses.FIELD_LABEL)
                     ui.label(display_value)
 
     # ── Data transformation helpers ──
@@ -334,7 +330,13 @@ class BaseAdminPage:
                 "sortable": col.sortable,
             }
             if col.width:
+                # Honor the explicit width exactly — no minWidth floor that would
+                # silently widen a deliberately narrow column (e.g. an 80px ID).
                 col_def["width"] = col.width
+            else:
+                # Width-less columns flex to fill, with a sane minimum.
+                col_def["flex"] = 1
+                col_def["minWidth"] = AdminMetrics.GRID_MIN_COL_WIDTH
             if col.masked:
                 col_def["valueFormatter"] = "value ? '****' : ''"
             column_defs.append(col_def)

--- a/src/_core/infrastructure/admin/base_admin_page.py
+++ b/src/_core/infrastructure/admin/base_admin_page.py
@@ -11,7 +11,11 @@ from src._core.domain.value_objects.query_filter import QueryFilter
 from src._core.infrastructure.admin.audit import AdminAction, AuditResult
 from src._core.infrastructure.admin.audit.logger import get_audit_logger
 from src._core.infrastructure.admin.error_handler import AdminErrorHandler
-from src._core.infrastructure.admin.theme import AdminClasses, AdminMetrics
+from src._core.infrastructure.admin.theme import (
+    EMPTY_DISPLAY,
+    AdminClasses,
+    AdminMetrics,
+)
 
 if TYPE_CHECKING:
     from src._core.application.dtos.base_response import PaginationInfo
@@ -119,6 +123,9 @@ class BaseAdminPage:
 
         self.render_list_header()
         self.render_search_bar(search)
+        if not dtos:
+            self.render_empty_state(search)
+            return
         self.render_list_summary(pagination)
         self.render_grid(dtos)
         self.render_pagination(pagination, search)
@@ -235,6 +242,17 @@ class BaseAdminPage:
             "w-80 q-mb-sm"
         )
 
+    def render_empty_state(self, search: str = "") -> None:
+        """Hook: render a friendly placeholder when the list has no records."""
+        with ui.column().classes(f"w-full {AdminClasses.EMPTY_STATE}"):
+            ui.icon("inbox").classes("text-h2")
+            message = (
+                f'No results for "{search}"'
+                if search
+                else f"No {self.display_name.lower()} records yet"
+            )
+            ui.label(message).classes("text-subtitle1")
+
     def render_list_summary(self, pagination: PaginationInfo) -> None:
         """Hook: render total/page summary above grid."""
         with ui.row().classes("items-center q-mb-sm"):
@@ -275,7 +293,9 @@ class BaseAdminPage:
                 params += f"&search={search}"
             return f"/admin/{self.domain_name}?{params}"
 
-        with ui.row().classes("items-center q-mt-md q-gutter-sm"):
+        with ui.row().classes(
+            f"items-center q-mt-md q-gutter-sm {AdminClasses.PAGINATION}"
+        ):
             ui.button(
                 "Previous",
                 on_click=lambda: ui.navigate.to(
@@ -307,16 +327,21 @@ class BaseAdminPage:
         with ui.card().classes("w-full"):
             for col in self.columns:
                 value = data.get(col.field_name, "")
+                is_empty = value is None or value == ""
                 if col.field_name in masked_fields:
-                    display_value = "****" if value else ""
+                    display_value = "****" if value else EMPTY_DISPLAY
+                elif is_empty:
+                    display_value = EMPTY_DISPLAY
                 elif hasattr(value, "isoformat"):
                     display_value = value.isoformat()
                 else:
-                    display_value = str(value) if value is not None else ""
+                    display_value = str(value)
 
                 with ui.row().classes("items-center q-py-xs"):
                     ui.label(col.header_name).classes(AdminClasses.FIELD_LABEL)
-                    ui.label(display_value)
+                    value_label = ui.label(display_value)
+                    if is_empty:
+                        value_label.classes(AdminClasses.EMPTY_VALUE)
 
     # ── Data transformation helpers ──
 

--- a/src/_core/infrastructure/admin/layout.py
+++ b/src/_core/infrastructure/admin/layout.py
@@ -64,10 +64,10 @@ def admin_layout(
         f"items-center justify-between {AdminClasses.HEADER}"
     ):
         # Brand: an icon stands in for a project logo (swap for ui.image in a
-        # fork) + the dashboard name.
-        with ui.row().classes("items-center q-gutter-sm"):
-            ui.icon("space_dashboard").classes("text-h5")
-            ui.label("Admin Dashboard").classes("text-h6")
+        # fork) + the configurable brand name.
+        with ui.row().classes(f"items-center q-gutter-sm {AdminClasses.BRAND}"):
+            ui.icon("smart_toy").classes("text-h5")
+            ui.label(settings.admin_brand_name).classes("text-h6")
         with ui.row().classes("items-center q-gutter-xs"):
             _render_dark_mode_toggle()
             username = session.username if session else _app_username()
@@ -86,56 +86,60 @@ def admin_layout(
     with ui.left_drawer(top_corner=True, bottom_corner=True).classes(
         AdminClasses.DRAWER
     ):
-        ui.label("Navigation").classes("text-subtitle1 q-mb-md q-ml-sm")
+        _nav_item(
+            label="Dashboard",
+            icon="dashboard",
+            target="/admin/",
+            active=current_domain == "",
+        )
 
-        with ui.item(on_click=lambda: ui.navigate.to("/admin/")):
-            with ui.item_section().props("avatar"):
-                ui.icon("dashboard")
-            with ui.item_section():
-                ui.label("Dashboard")
+        if visible_configs:
+            _nav_section("Operations")
+            for page_config in visible_configs:
+                _nav_item(
+                    label=page_config.display_name,
+                    icon=page_config.icon,
+                    target=f"/admin/{page_config.domain_name}",
+                    active=page_config.domain_name == current_domain,
+                )
 
-        ui.separator()
+        show_accounts = permissions is None or "accounts" in permissions
+        show_audit = permissions is None or "audit_log" in permissions
+        if show_accounts or show_audit:
+            _nav_section("Management")
+            if show_accounts:
+                _nav_item(
+                    label="Accounts",
+                    icon="manage_accounts",
+                    target="/admin/accounts",
+                    active=current_domain == "accounts",
+                )
+            if show_audit:
+                _nav_item(
+                    label="Audit Log",
+                    icon="fact_check",
+                    target="/admin/audit-log",
+                    active=current_domain == "audit_log",
+                )
 
-        for page_config in visible_configs:
-            _is_active = page_config.domain_name == current_domain
-            with ui.item(
-                on_click=lambda p=page_config: ui.navigate.to(
-                    f"/admin/{p.domain_name}"
-                ),
-            ):
-                with ui.item_section().props("avatar"):
-                    ui.icon(page_config.icon).classes(
-                        AdminClasses.ACCENT_ICON if _is_active else ""
-                    )
-                with ui.item_section():
-                    _label = ui.label(page_config.display_name)
-                    if _is_active:
-                        _label.classes(AdminClasses.NAV_ACTIVE)
 
-        if permissions is None or "accounts" in permissions:
-            _is_accounts = current_domain == "accounts"
-            ui.separator()
-            with ui.item(on_click=lambda: ui.navigate.to("/admin/accounts")):
-                with ui.item_section().props("avatar"):
-                    ui.icon("manage_accounts").classes(
-                        AdminClasses.ACCENT_ICON if _is_accounts else ""
-                    )
-                with ui.item_section():
-                    _acc_label = ui.label("Accounts")
-                    if _is_accounts:
-                        _acc_label.classes(AdminClasses.NAV_ACTIVE)
+def _nav_section(title: str) -> None:
+    """Render a muted, uppercase section header in the sidebar."""
+    ui.label(title).classes(f"{AdminClasses.NAV_SECTION} q-mt-md q-mb-xs q-ml-md")
 
-        if permissions is None or "audit_log" in permissions:
-            _is_audit = current_domain == "audit_log"
-            with ui.item(on_click=lambda: ui.navigate.to("/admin/audit-log")):
-                with ui.item_section().props("avatar"):
-                    ui.icon("fact_check").classes(
-                        AdminClasses.ACCENT_ICON if _is_audit else ""
-                    )
-                with ui.item_section():
-                    _audit_label = ui.label("Audit Log")
-                    if _is_audit:
-                        _audit_label.classes(AdminClasses.NAV_ACTIVE)
+
+def _nav_item(*, label: str, icon: str, target: str, active: bool) -> None:
+    """Render one sidebar nav item, highlighted when it is the active route."""
+    item = ui.item(on_click=lambda: ui.navigate.to(target))
+    if active:
+        item.classes(AdminClasses.NAV_ACTIVE_ITEM)
+    with item:
+        with ui.item_section().props("avatar"):
+            ui.icon(icon).classes(AdminClasses.ACCENT_ICON if active else "")
+        with ui.item_section():
+            text = ui.label(label)
+            if active:
+                text.classes(AdminClasses.NAV_ACTIVE)
 
 
 def _render_dark_mode_toggle() -> None:

--- a/src/_core/infrastructure/admin/layout.py
+++ b/src/_core/infrastructure/admin/layout.py
@@ -72,9 +72,7 @@ def admin_layout(
             _render_dark_mode_toggle()
             username = session.username if session else _app_username()
             if username:
-                with ui.button(username, icon="account_circle").props(
-                    "flat color=white"
-                ):
+                with ui.button(username, icon="account_circle").props("flat"):
                     with ui.menu():
                         ui.menu_item(
                             "Change Password",
@@ -83,7 +81,7 @@ def admin_layout(
             ui.button(
                 icon="logout",
                 on_click=_handle_logout,
-            ).props("flat color=white")
+            ).props("flat")
 
     with ui.left_drawer(top_corner=True, bottom_corner=True).classes(
         AdminClasses.DRAWER
@@ -159,7 +157,7 @@ def _render_dark_mode_toggle() -> None:
         dark.value = _next_dark_value(dark.value)
         app.storage.user[_DARK_MODE_KEY] = dark.value
 
-    ui.button(icon="dark_mode", on_click=_toggle).props("flat color=white").tooltip(
+    ui.button(icon="dark_mode", on_click=_toggle).props("flat").tooltip(
         "Toggle light / dark"
     )
 

--- a/src/_core/infrastructure/admin/layout.py
+++ b/src/_core/infrastructure/admin/layout.py
@@ -60,12 +60,20 @@ def admin_layout(
         if permissions is None or pc.domain_name in permissions
     ]
 
+    # Create the drawer first so the header hamburger can toggle it. Quasar
+    # auto-overlays the drawer below its breakpoint (narrow viewports); the
+    # hamburger also lets desktop users collapse it.
+    drawer = ui.left_drawer(top_corner=True, bottom_corner=True).classes(
+        AdminClasses.DRAWER
+    )
+
     with ui.header(elevated=True).classes(
         f"items-center justify-between {AdminClasses.HEADER}"
     ):
-        # Brand: an icon stands in for a project logo (swap for ui.image in a
-        # fork) + the configurable brand name.
+        # Brand: a hamburger (responsive toggle) + an icon standing in for a
+        # project logo (swap for ui.image in a fork) + the brand name.
         with ui.row().classes(f"items-center q-gutter-sm {AdminClasses.BRAND}"):
+            ui.button(icon="menu", on_click=drawer.toggle).props("flat dense")
             ui.icon("smart_toy").classes("text-h5")
             ui.label(settings.admin_brand_name).classes("text-h6")
         with ui.row().classes("items-center q-gutter-xs"):
@@ -83,9 +91,7 @@ def admin_layout(
                 on_click=_handle_logout,
             ).props("flat")
 
-    with ui.left_drawer(top_corner=True, bottom_corner=True).classes(
-        AdminClasses.DRAWER
-    ):
+    with drawer:
         _nav_item(
             label="Dashboard",
             icon="dashboard",

--- a/src/_core/infrastructure/admin/layout.py
+++ b/src/_core/infrastructure/admin/layout.py
@@ -63,8 +63,12 @@ def admin_layout(
     with ui.header(elevated=True).classes(
         f"items-center justify-between {AdminClasses.HEADER}"
     ):
-        ui.label("Admin Dashboard").classes("text-h6")
-        with ui.row().classes("items-center"):
+        # Brand: an icon stands in for a project logo (swap for ui.image in a
+        # fork) + the dashboard name.
+        with ui.row().classes("items-center q-gutter-sm"):
+            ui.icon("space_dashboard").classes("text-h5")
+            ui.label("Admin Dashboard").classes("text-h6")
+        with ui.row().classes("items-center q-gutter-xs"):
             _render_dark_mode_toggle()
             username = session.username if session else _app_username()
             if username:

--- a/src/_core/infrastructure/admin/layout.py
+++ b/src/_core/infrastructure/admin/layout.py
@@ -4,12 +4,19 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
-from nicegui import ui
+from nicegui import app, ui
 
+from src._core.config import settings
 from src._core.infrastructure.admin.audit import AdminAction, AuditResult
 from src._core.infrastructure.admin.audit.logger import get_audit_logger
 from src._core.infrastructure.admin.auth import AdminAuthProvider
+from src._core.infrastructure.admin.theme import AdminClasses
 from src.admin_identity.domain.dtos.admin_identity_dto import AdminSessionDTO
+
+# Session key holding the operator's explicit dark-mode override (#193). Unset
+# means "no preference" → defer to ``admin_dark_mode_default`` (which may itself
+# be None = follow the browser's prefers-color-scheme).
+_DARK_MODE_KEY = "admin_dark_mode"
 
 if TYPE_CHECKING:
     from src._core.infrastructure.admin.base_admin_page import BaseAdminPage
@@ -53,9 +60,12 @@ def admin_layout(
         if permissions is None or pc.domain_name in permissions
     ]
 
-    with ui.header(elevated=True).classes("items-center justify-between bg-blue-800"):
-        ui.label("Admin Dashboard").classes("text-h6 text-white")
+    with ui.header(elevated=True).classes(
+        f"items-center justify-between {AdminClasses.HEADER}"
+    ):
+        ui.label("Admin Dashboard").classes("text-h6")
         with ui.row().classes("items-center"):
+            _render_dark_mode_toggle()
             username = session.username if session else _app_username()
             if username:
                 with ui.button(username, icon="account_circle").props(
@@ -71,7 +81,9 @@ def admin_layout(
                 on_click=_handle_logout,
             ).props("flat color=white")
 
-    with ui.left_drawer(top_corner=True, bottom_corner=True).classes("bg-blue-50"):
+    with ui.left_drawer(top_corner=True, bottom_corner=True).classes(
+        AdminClasses.DRAWER
+    ):
         ui.label("Navigation").classes("text-subtitle1 q-mb-md q-ml-sm")
 
         with ui.item(on_click=lambda: ui.navigate.to("/admin/")):
@@ -91,12 +103,12 @@ def admin_layout(
             ):
                 with ui.item_section().props("avatar"):
                     ui.icon(page_config.icon).classes(
-                        "text-blue-800" if _is_active else ""
+                        AdminClasses.ACCENT_ICON if _is_active else ""
                     )
                 with ui.item_section():
                     _label = ui.label(page_config.display_name)
                     if _is_active:
-                        _label.classes("text-weight-bold text-blue-800")
+                        _label.classes(AdminClasses.NAV_ACTIVE)
 
         if permissions is None or "accounts" in permissions:
             _is_accounts = current_domain == "accounts"
@@ -104,27 +116,73 @@ def admin_layout(
             with ui.item(on_click=lambda: ui.navigate.to("/admin/accounts")):
                 with ui.item_section().props("avatar"):
                     ui.icon("manage_accounts").classes(
-                        "text-blue-800" if _is_accounts else ""
+                        AdminClasses.ACCENT_ICON if _is_accounts else ""
                     )
                 with ui.item_section():
                     _acc_label = ui.label("Accounts")
                     if _is_accounts:
-                        _acc_label.classes("text-weight-bold text-blue-800")
+                        _acc_label.classes(AdminClasses.NAV_ACTIVE)
 
         if permissions is None or "audit_log" in permissions:
             _is_audit = current_domain == "audit_log"
             with ui.item(on_click=lambda: ui.navigate.to("/admin/audit-log")):
                 with ui.item_section().props("avatar"):
-                    ui.icon("fact_check").classes("text-blue-800" if _is_audit else "")
+                    ui.icon("fact_check").classes(
+                        AdminClasses.ACCENT_ICON if _is_audit else ""
+                    )
                 with ui.item_section():
                     _audit_label = ui.label("Audit Log")
                     if _is_audit:
-                        _audit_label.classes("text-weight-bold text-blue-800")
+                        _audit_label.classes(AdminClasses.NAV_ACTIVE)
+
+
+def _render_dark_mode_toggle() -> None:
+    """Render the header light/dark toggle (#193).
+
+    The ``ui.dark_mode`` handle is page-scoped, so it is created here on every
+    page that renders the shell. It is seeded from the operator's stored
+    preference, falling back to ``admin_dark_mode_default`` (which may be None =
+    follow the browser's prefers-color-scheme, matching ``ui.run_with(dark=)``).
+    Toggling flips Quasar's ``body--dark`` class live — no reload — and the new
+    value is persisted so it survives navigation.
+    """
+    stored = _stored_dark_preference()
+    dark = ui.dark_mode(value=stored)
+
+    def _toggle() -> None:
+        # ``dark.toggle()`` raises when the value is None (auto/system mode), so
+        # resolve the next state explicitly via _next_dark_value.
+        dark.value = _next_dark_value(dark.value)
+        app.storage.user[_DARK_MODE_KEY] = dark.value
+
+    ui.button(icon="dark_mode", on_click=_toggle).props("flat color=white").tooltip(
+        "Toggle light / dark"
+    )
+
+
+def _next_dark_value(current: bool | None) -> bool:
+    """Resolve the next dark-mode value for a toggle click.
+
+    From auto (None) the first toggle resolves to an explicit dark theme; from
+    an explicit state it flips. Always returns a concrete bool so the persisted
+    preference is unambiguous on the next page load.
+    """
+    return True if current is None else not current
+
+
+def _stored_dark_preference() -> bool | None:
+    """Read the operator's dark-mode override, defaulting to the global policy.
+
+    Defensive against an unconfigured ``storage_secret`` (``app.storage.user``
+    raises) — degrades to the configured default rather than 500-ing the page.
+    """
+    try:
+        return app.storage.user.get(_DARK_MODE_KEY, settings.admin_dark_mode_default)
+    except Exception:  # noqa: BLE001 - storage unavailable → fall back to default
+        return settings.admin_dark_mode_default
 
 
 def _app_username() -> str | None:
-    from nicegui import app
-
     return app.storage.user.get("username")  # type: ignore[return-value]
 
 
@@ -137,14 +195,12 @@ async def _handle_logout() -> None:
     # AdminAuthProvider.logout() is also called from several non-user cleanup
     # paths (forced-logout, setup tear-down, ...), so audit logging lives here
     # — the explicit button — rather than inside logout().
-    from nicegui import app as _app
-
     await get_audit_logger().log(
         action=AdminAction.LOGOUT,
         domain="auth",
         result=AuditResult.SUCCESS,
-        admin_user_id=_app.storage.user.get("user_id"),
-        admin_username=_app.storage.user.get("username") or "unknown",
+        admin_user_id=app.storage.user.get("user_id"),
+        admin_username=app.storage.user.get("username") or "unknown",
     )
     AdminAuthProvider.logout()
     ui.navigate.to("/admin/login")

--- a/src/_core/infrastructure/admin/theme.py
+++ b/src/_core/infrastructure/admin/theme.py
@@ -324,7 +324,8 @@ body, .q-page-container {
   text-align: center;
   padding: 48px 0;
 }
-.admin-login-bg {
+.admin-login-bg,
+.admin-login-bg .q-page-container {
   background: linear-gradient(135deg, #1e1b4b 0%, #0f172a 100%) !important;
 }
 .admin-login-card {

--- a/src/_core/infrastructure/admin/theme.py
+++ b/src/_core/infrastructure/admin/theme.py
@@ -70,6 +70,7 @@ class AdminVars:
     TEXT_MUTED: Final = "--admin-text-muted"
     SUCCESS_BG: Final = "--admin-success-bg"
     ROW_ALT: Final = "--admin-row-alt"
+    ROW_HOVER: Final = "--admin-row-hover"
     GRID_HEIGHT: Final = "--admin-grid-height"
     GRID_HEIGHT_COMPACT: Final = "--admin-grid-height-compact"
     LABEL_COL_WIDTH: Final = "--admin-label-col-width"
@@ -101,6 +102,8 @@ class AdminClasses:
     SUCCESS_SURFACE: Final = "admin-success-surface"
     GRID: Final = "admin-grid"
     GRID_COMPACT: Final = "admin-grid-compact"
+    PAGINATION: Final = "admin-pagination"
+    EMPTY_STATE: Final = "admin-empty-state"
     PRE: Final = "admin-pre"
     HIDDEN: Final = "admin-hidden"
 
@@ -133,6 +136,7 @@ def build_admin_css() -> str:
   {AdminVars.TEXT_MUTED}: #64748b;
   {AdminVars.SUCCESS_BG}: #f0fdf4;
   {AdminVars.ROW_ALT}: #f8fafc;
+  {AdminVars.ROW_HOVER}: #eef2ff;
   {AdminVars.GRID_HEIGHT}: calc(100vh - 240px);
   {AdminVars.GRID_HEIGHT_COMPACT}: calc(100vh - 360px);
   {AdminVars.LABEL_COL_WIDTH}: 160px;
@@ -149,6 +153,7 @@ def build_admin_css() -> str:
   {AdminVars.TEXT_MUTED}: #94a3b8;
   {AdminVars.SUCCESS_BG}: #052e16;
   {AdminVars.ROW_ALT}: #0f172a;
+  {AdminVars.ROW_HOVER}: #1e293b;
 }}
 
 /* === Helper classes consuming the tokens === */
@@ -185,9 +190,22 @@ def build_admin_css() -> str:
   width: 100%;
   height: var({AdminVars.GRID_HEIGHT_COMPACT});
 }}
-.{AdminClasses.GRID} .ag-row-odd,
-.{AdminClasses.GRID_COMPACT} .ag-row-odd {{
-  background-color: var({AdminVars.ROW_ALT});
+/* AG Grid (NiceGUI 3.x quartz theme) reads these CSS custom properties from
+   the new theming API — set them on the grid element rather than overriding
+   the legacy .ag-row-odd class (which the quartz theme no longer emits). */
+.{AdminClasses.GRID},
+.{AdminClasses.GRID_COMPACT} {{
+  --ag-odd-row-background-color: var({AdminVars.ROW_ALT});
+  --ag-row-hover-color: var({AdminVars.ROW_HOVER});
+}}
+.{AdminClasses.PAGINATION} {{
+  justify-content: flex-end;
+}}
+.{AdminClasses.EMPTY_STATE} {{
+  color: var({AdminVars.TEXT_MUTED});
+  align-items: center;
+  text-align: center;
+  padding: 48px 0;
 }}
 .{AdminClasses.PRE} {{
   white-space: pre-wrap;

--- a/src/_core/infrastructure/admin/theme.py
+++ b/src/_core/infrastructure/admin/theme.py
@@ -2,46 +2,39 @@
 
 Single source of truth for admin colors, **style tokens** (radius, shadow,
 border treatment), layout metrics, and the helper CSS classes + Quasar
-component overrides that every admin page inherits. Replaces the hardcoded
-Quasar/Tailwind color classes and inline grid heights that were previously
-scattered across the shell and domain pages.
+component overrides that every admin page inherits.
 
 Design (see plan #193 / Codex cross-review):
 
 * The look is driven by CSS custom properties: ``--q-*`` (Quasar brand) and
-  ``--admin-*`` (semantic + style) variables, declared under ``:root`` (light)
-  and ``.body--dark`` (dark). Quasar's ``body--dark`` toggle flips the whole
-  palette with no Python re-render, no reload, and no per-page ``ui.colors()``.
+  ``--admin-*`` (semantic + style) variables. The shell **chrome** (header +
+  sidebar) is dark and constant; the **content** area is light and flips to
+  dark via Quasar's ``body--dark`` class — a single toggle, no reload, no
+  per-page ``ui.colors()`` call.
 * Multiple **style presets** (``default``, ``linear``, ``shadcn``,
-  ``supabase``) bundle a full set of color + style tokens, selected at boot via
-  the ``ADMIN_THEME_PALETTE`` setting. The layout structure is identical across
-  presets — only the tokens (and thus the CSS-var-driven component look) differ.
+  ``supabase``) bundle a full token set, selected at boot via
+  ``ADMIN_THEME_PALETTE``. They share the dark-chrome + light-content structure
+  and differ mainly in accent color, radius and elevation.
 * The CSS is injected **once, app-wide** via ``ui.add_css(..., shared=True)`` so
-  it reaches every page — including login / setup / error, which never call
-  :func:`admin_layout`.
-* AG Grid dark theming is **built in** to NiceGUI (a ``body--dark`` observer
-  flips ``data-ag-theme-mode``); we only feed it ``--ag-*`` vars for row colors.
+  it reaches every page — including login / setup / error.
 
-Constants here are intentionally **import-free** (no ``from nicegui``); the
-nicegui + settings imports are lazy inside :func:`install_admin_theme_css` so
-the constants and :func:`build_admin_css` stay testable when the ``admin``
-extra is absent.
+Constants here are intentionally **import-free**; the nicegui + settings imports
+are lazy inside :func:`install_admin_theme_css`.
 """
 
 from __future__ import annotations
 
 from typing import Final
 
-# Uniform empty / null cell rendering (replaces the bare "" used before).
 EMPTY_DISPLAY: Final = "—"
 
 
 class AdminColors:
-    """Default brand palette — also the source of the ``default`` preset."""
+    """Default brand palette constants (referenced by the ``default`` preset)."""
 
-    PRIMARY: Final = "#1d4ed8"
-    SECONDARY: Final = "#475569"
-    ACCENT: Final = "#0ea5e9"
+    PRIMARY: Final = "#5b5bd6"
+    SECONDARY: Final = "#64748b"
+    ACCENT: Final = "#6366f1"
     POSITIVE: Final = "#16a34a"
     NEGATIVE: Final = "#dc2626"
     WARNING: Final = "#d97706"
@@ -51,7 +44,7 @@ class AdminColors:
 class AdminVars:
     """Names of the CSS custom properties consumed by the helper classes."""
 
-    # Quasar brand variables (override Quasar's defaults app-wide).
+    # Quasar brand.
     Q_PRIMARY: Final = "--q-primary"
     Q_SECONDARY: Final = "--q-secondary"
     Q_ACCENT: Final = "--q-accent"
@@ -60,20 +53,24 @@ class AdminVars:
     Q_WARNING: Final = "--q-warning"
     Q_INFO: Final = "--q-info"
 
-    # Semantic surfaces.
+    # Chrome (header + sidebar) — dark and constant across light/dark mode.
+    HEADER_BG: Final = "--admin-header-bg"
+    HEADER_TEXT: Final = "--admin-header-text"
+    DRAWER_BG: Final = "--admin-drawer-bg"
+    DRAWER_TEXT: Final = "--admin-drawer-text"
+    NAV_ACTIVE: Final = "--admin-nav-active"
+    NAV_ACTIVE_BG: Final = "--admin-nav-active-bg"
+
+    # Content surfaces — flip with dark mode.
     BG: Final = "--admin-bg"
     SURFACE: Final = "--admin-surface"
     BORDER: Final = "--admin-border"
     TEXT_MUTED: Final = "--admin-text-muted"
-    HEADER_BG: Final = "--admin-header-bg"
-    HEADER_TEXT: Final = "--admin-header-text"
-    DRAWER_BG: Final = "--admin-drawer-bg"
-    NAV_ACTIVE: Final = "--admin-nav-active"
     SUCCESS_BG: Final = "--admin-success-bg"
     ROW_ALT: Final = "--admin-row-alt"
     ROW_HOVER: Final = "--admin-row-hover"
 
-    # Style tokens (shape/elevation — theme-level, same in light + dark).
+    # Style tokens (shape/elevation).
     RADIUS: Final = "--admin-radius"
     SHADOW: Final = "--admin-shadow"
     CARD_BORDER: Final = "--admin-card-border"
@@ -95,8 +92,11 @@ class AdminClasses:
     """Helper CSS class names (all ``admin-`` prefixed for the AST guard)."""
 
     HEADER: Final = "admin-header"
+    BRAND: Final = "admin-brand"
     DRAWER: Final = "admin-drawer"
+    NAV_SECTION: Final = "admin-nav-section"
     NAV_ACTIVE: Final = "admin-nav-active"
+    NAV_ACTIVE_ITEM: Final = "admin-nav-active-item"
     ACCENT_ICON: Final = "admin-accent-icon"
     CARD: Final = "admin-card"
     FIELD_LABEL: Final = "admin-field-label"
@@ -108,15 +108,17 @@ class AdminClasses:
     GRID_COMPACT: Final = "admin-grid-compact"
     PAGINATION: Final = "admin-pagination"
     EMPTY_STATE: Final = "admin-empty-state"
+    LOGIN_BG: Final = "admin-login-bg"
+    LOGIN_CARD: Final = "admin-login-card"
     PRE: Final = "admin-pre"
     HIDDEN: Final = "admin-hidden"
 
 
 # ── Style presets (#193) ──
 #
-# Each preset bundles "style" (shape/elevation, theme-level), "light" (:root
-# colors) and "dark" (.body--dark colors). Layout metrics are shared. Selected
-# at boot via ADMIN_THEME_PALETTE; unknown names fall back to DEFAULT_PALETTE.
+# "chrome": dark header/sidebar tokens + brand + shape — emitted in :root only
+#   (constant across light/dark mode; the sidebar stays dark either way).
+# "light"/"dark": content surfaces that flip with Quasar's body--dark.
 DEFAULT_PALETTE: Final = "default"
 
 _LAYOUT_TOKENS: Final = {
@@ -125,206 +127,169 @@ _LAYOUT_TOKENS: Final = {
     AdminVars.LABEL_COL_WIDTH: "160px",
 }
 
+_CONTENT_DARK: Final = {
+    AdminVars.BG: "#0b1120",
+    AdminVars.SURFACE: "#161b2c",
+    AdminVars.BORDER: "#2a3142",
+    AdminVars.TEXT_MUTED: "#94a3b8",
+    AdminVars.SUCCESS_BG: "#052e16",
+    AdminVars.ROW_ALT: "#10172a",
+    AdminVars.ROW_HOVER: "#1c2438",
+}
+
+_CONTENT_LIGHT: Final = {
+    AdminVars.BG: "#f7f8fa",
+    AdminVars.SURFACE: "#ffffff",
+    AdminVars.BORDER: "#e5e7eb",
+    AdminVars.TEXT_MUTED: "#6b7280",
+    AdminVars.SUCCESS_BG: "#f0fdf4",
+    AdminVars.ROW_ALT: "#f8fafc",
+    AdminVars.ROW_HOVER: "#f1f5f9",
+}
+
+
+def _chrome(
+    *,
+    primary: str,
+    accent: str,
+    nav_active: str,
+    header_bg: str,
+    radius: str,
+    shadow: str,
+    card_border: str,
+    negative: str = AdminColors.NEGATIVE,
+) -> dict[str, str]:
+    """Build a preset's :root token block (dark chrome + brand + shape)."""
+    return {
+        AdminVars.Q_PRIMARY: primary,
+        AdminVars.Q_SECONDARY: AdminColors.SECONDARY,
+        AdminVars.Q_ACCENT: accent,
+        AdminVars.Q_POSITIVE: AdminColors.POSITIVE,
+        AdminVars.Q_NEGATIVE: negative,
+        AdminVars.Q_WARNING: AdminColors.WARNING,
+        AdminVars.Q_INFO: AdminColors.INFO,
+        AdminVars.HEADER_BG: header_bg,
+        AdminVars.HEADER_TEXT: "#e5e7eb",
+        AdminVars.DRAWER_BG: header_bg,
+        AdminVars.DRAWER_TEXT: "#cbd2e0",
+        AdminVars.NAV_ACTIVE: nav_active,
+        AdminVars.NAV_ACTIVE_BG: "rgba(255,255,255,0.10)",
+        AdminVars.RADIUS: radius,
+        AdminVars.SHADOW: shadow,
+        AdminVars.CARD_BORDER: card_border,
+    }
+
+
 _PALETTES: Final = {
-    # Classic blue — the original corporate look.
+    # Indigo on navy chrome — the default modern look.
     "default": {
-        "style": {
-            AdminVars.RADIUS: "4px",
-            AdminVars.SHADOW: "0 1px 4px rgba(0,0,0,0.12)",
-            AdminVars.CARD_BORDER: "none",
-        },
-        "light": {
-            AdminVars.Q_PRIMARY: AdminColors.PRIMARY,
-            AdminVars.Q_SECONDARY: AdminColors.SECONDARY,
-            AdminVars.Q_ACCENT: AdminColors.ACCENT,
-            AdminVars.Q_POSITIVE: AdminColors.POSITIVE,
-            AdminVars.Q_NEGATIVE: AdminColors.NEGATIVE,
-            AdminVars.Q_WARNING: AdminColors.WARNING,
-            AdminVars.Q_INFO: AdminColors.INFO,
-            AdminVars.BG: "#f1f5f9",
-            AdminVars.SURFACE: "#ffffff",
-            AdminVars.BORDER: "#e2e8f0",
-            AdminVars.TEXT_MUTED: "#64748b",
-            AdminVars.HEADER_BG: AdminColors.PRIMARY,
-            AdminVars.HEADER_TEXT: "#ffffff",
-            AdminVars.DRAWER_BG: "#eff6ff",
-            AdminVars.NAV_ACTIVE: "#1e40af",
-            AdminVars.SUCCESS_BG: "#f0fdf4",
-            AdminVars.ROW_ALT: "#f8fafc",
-            AdminVars.ROW_HOVER: "#eef2ff",
-        },
-        "dark": {
-            AdminVars.BG: "#0b1220",
-            AdminVars.SURFACE: "#1e293b",
-            AdminVars.BORDER: "#334155",
-            AdminVars.TEXT_MUTED: "#94a3b8",
-            AdminVars.HEADER_BG: "#1e293b",
-            AdminVars.HEADER_TEXT: "#f1f5f9",
-            AdminVars.DRAWER_BG: "#0f172a",
-            AdminVars.NAV_ACTIVE: "#60a5fa",
-            AdminVars.SUCCESS_BG: "#052e16",
-            AdminVars.ROW_ALT: "#0f172a",
-            AdminVars.ROW_HOVER: "#1e293b",
-        },
+        "chrome": _chrome(
+            primary=AdminColors.PRIMARY,
+            accent=AdminColors.ACCENT,
+            nav_active="#a5b4fc",
+            header_bg="#1a1d2e",
+            radius="10px",
+            shadow="0 1px 3px rgba(0,0,0,0.08)",
+            card_border="1px solid var(--admin-border)",
+        ),
     },
-    # Linear / Vercel — minimal, flat, border-based, indigo accent, light header.
+    # Linear / Vercel — flat, border-based, indigo-violet.
     "linear": {
-        "style": {
-            AdminVars.RADIUS: "6px",
-            AdminVars.SHADOW: "none",
-            AdminVars.CARD_BORDER: "1px solid var(--admin-border)",
-        },
-        "light": {
-            AdminVars.Q_PRIMARY: "#5e6ad2",
-            AdminVars.Q_SECONDARY: "#6b6f76",
-            AdminVars.Q_ACCENT: "#5e6ad2",
-            AdminVars.Q_POSITIVE: "#4cb782",
-            AdminVars.Q_NEGATIVE: "#eb5757",
-            AdminVars.Q_WARNING: "#d99e00",
-            AdminVars.Q_INFO: "#4ea7fc",
-            AdminVars.BG: "#fbfbfb",
-            AdminVars.SURFACE: "#ffffff",
-            AdminVars.BORDER: "#ebebed",
-            AdminVars.TEXT_MUTED: "#8a8f98",
-            AdminVars.HEADER_BG: "#ffffff",
-            AdminVars.HEADER_TEXT: "#232529",
-            AdminVars.DRAWER_BG: "#fbfbfb",
-            AdminVars.NAV_ACTIVE: "#5e6ad2",
-            AdminVars.SUCCESS_BG: "#edf7f2",
-            AdminVars.ROW_ALT: "#fafafa",
-            AdminVars.ROW_HOVER: "#f4f4f5",
-        },
-        "dark": {
-            AdminVars.BG: "#0d0d0f",
-            AdminVars.SURFACE: "#161618",
-            AdminVars.BORDER: "#232326",
-            AdminVars.TEXT_MUTED: "#8a8f98",
-            AdminVars.HEADER_BG: "#0d0d0f",
-            AdminVars.HEADER_TEXT: "#e6e6e8",
-            AdminVars.DRAWER_BG: "#0d0d0f",
-            AdminVars.NAV_ACTIVE: "#8b87ff",
-            AdminVars.SUCCESS_BG: "#0f2a1f",
-            AdminVars.ROW_ALT: "#161618",
-            AdminVars.ROW_HOVER: "#1c1c1f",
-        },
+        "chrome": _chrome(
+            primary="#5e6ad2",
+            accent="#5e6ad2",
+            nav_active="#8b87ff",
+            header_bg="#0d0d0f",
+            radius="6px",
+            shadow="none",
+            card_border="1px solid var(--admin-border)",
+            negative="#eb5757",
+        ),
     },
-    # shadcn / Notion — clean light, rounded, soft shadow, near-black primary.
+    # shadcn / Notion — rounded, soft shadow, indigo accent.
     "shadcn": {
-        "style": {
-            AdminVars.RADIUS: "12px",
-            AdminVars.SHADOW: "0 1px 3px 0 rgba(0,0,0,0.1), 0 1px 2px -1px rgba(0,0,0,0.1)",
-            AdminVars.CARD_BORDER: "1px solid var(--admin-border)",
-        },
-        "light": {
-            AdminVars.Q_PRIMARY: "#18181b",
-            AdminVars.Q_SECONDARY: "#71717a",
-            AdminVars.Q_ACCENT: "#6366f1",
-            AdminVars.Q_POSITIVE: "#16a34a",
-            AdminVars.Q_NEGATIVE: "#ef4444",
-            AdminVars.Q_WARNING: "#f59e0b",
-            AdminVars.Q_INFO: "#3b82f6",
-            AdminVars.BG: "#fafafa",
-            AdminVars.SURFACE: "#ffffff",
-            AdminVars.BORDER: "#e4e4e7",
-            AdminVars.TEXT_MUTED: "#71717a",
-            AdminVars.HEADER_BG: "#ffffff",
-            AdminVars.HEADER_TEXT: "#18181b",
-            AdminVars.DRAWER_BG: "#fafafa",
-            AdminVars.NAV_ACTIVE: "#18181b",
-            AdminVars.SUCCESS_BG: "#f0fdf4",
-            AdminVars.ROW_ALT: "#fafafa",
-            AdminVars.ROW_HOVER: "#f4f4f5",
-        },
-        "dark": {
-            AdminVars.BG: "#09090b",
-            AdminVars.SURFACE: "#18181b",
-            AdminVars.BORDER: "#27272a",
-            AdminVars.TEXT_MUTED: "#a1a1aa",
-            AdminVars.HEADER_BG: "#09090b",
-            AdminVars.HEADER_TEXT: "#fafafa",
-            AdminVars.DRAWER_BG: "#09090b",
-            AdminVars.NAV_ACTIVE: "#fafafa",
-            AdminVars.SUCCESS_BG: "#052e16",
-            AdminVars.ROW_ALT: "#18181b",
-            AdminVars.ROW_HOVER: "#27272a",
-        },
+        "chrome": _chrome(
+            primary="#6366f1",
+            accent="#6366f1",
+            nav_active="#a5b4fc",
+            header_bg="#18181b",
+            radius="14px",
+            shadow="0 1px 3px 0 rgba(0,0,0,0.1), 0 1px 2px -1px rgba(0,0,0,0.1)",
+            card_border="1px solid var(--admin-border)",
+            negative="#ef4444",
+        ),
     },
-    # Supabase / Stripe — dark header, green accent, clean data tables.
+    # Supabase / Stripe — green accent, charcoal chrome.
     "supabase": {
-        "style": {
-            AdminVars.RADIUS: "8px",
-            AdminVars.SHADOW: "0 1px 2px rgba(0,0,0,0.08)",
-            AdminVars.CARD_BORDER: "1px solid var(--admin-border)",
-        },
-        "light": {
-            AdminVars.Q_PRIMARY: "#3ecf8e",
-            AdminVars.Q_SECONDARY: "#64748b",
-            AdminVars.Q_ACCENT: "#3ecf8e",
-            AdminVars.Q_POSITIVE: "#3ecf8e",
-            AdminVars.Q_NEGATIVE: "#ef4444",
-            AdminVars.Q_WARNING: "#f59e0b",
-            AdminVars.Q_INFO: "#3b82f6",
-            AdminVars.BG: "#f8f9fa",
-            AdminVars.SURFACE: "#ffffff",
-            AdminVars.BORDER: "#e6e8eb",
-            AdminVars.TEXT_MUTED: "#6b7280",
-            AdminVars.HEADER_BG: "#1c1c1c",
-            AdminVars.HEADER_TEXT: "#ededed",
-            AdminVars.DRAWER_BG: "#fbfcfd",
-            AdminVars.NAV_ACTIVE: "#3ecf8e",
-            AdminVars.SUCCESS_BG: "#ecfdf5",
-            AdminVars.ROW_ALT: "#f8f9fa",
-            AdminVars.ROW_HOVER: "#f0fdf8",
-        },
-        "dark": {
-            AdminVars.BG: "#121212",
-            AdminVars.SURFACE: "#1c1c1c",
-            AdminVars.BORDER: "#2e2e2e",
-            AdminVars.TEXT_MUTED: "#a0a0a0",
-            AdminVars.HEADER_BG: "#121212",
-            AdminVars.HEADER_TEXT: "#ededed",
-            AdminVars.DRAWER_BG: "#1c1c1c",
-            AdminVars.NAV_ACTIVE: "#3ecf8e",
-            AdminVars.SUCCESS_BG: "#06281d",
-            AdminVars.ROW_ALT: "#1c1c1c",
-            AdminVars.ROW_HOVER: "#262626",
-        },
+        "chrome": _chrome(
+            primary="#3ecf8e",
+            accent="#3ecf8e",
+            nav_active="#3ecf8e",
+            header_bg="#1c1c1c",
+            radius="8px",
+            shadow="0 1px 2px rgba(0,0,0,0.08)",
+            card_border="1px solid var(--admin-border)",
+            negative="#ef4444",
+        ),
     },
 }
 
 PALETTES: Final = tuple(_PALETTES)
 
 
-# Palette-independent rules: helper classes + Quasar component overrides that
-# read the tokens above. Plain string (literal class/var names) so there are no
-# f-string brace-escaping hazards.
 _HELPER_CSS: Final = """
 /* === Helper classes + Quasar component overrides (token-driven) === */
 body, .q-page-container {
   background-color: var(--admin-bg) !important;
 }
+/* Chrome: dark header + sidebar, light text. */
 .admin-header {
   background-color: var(--admin-header-bg) !important;
   color: var(--admin-header-text) !important;
   box-shadow: none !important;
-  border-bottom: 1px solid var(--admin-border);
+  border-bottom: 1px solid rgba(255,255,255,0.06);
 }
 .admin-header .q-btn,
 .admin-header .q-icon,
-.admin-header .q-toolbar__title {
+.admin-brand,
+.admin-brand .q-icon {
   color: var(--admin-header-text) !important;
+}
+.admin-brand {
+  font-weight: 700;
 }
 .admin-drawer {
   background-color: var(--admin-drawer-bg) !important;
-  border-right: 1px solid var(--admin-border);
+  color: var(--admin-drawer-text) !important;
+  border-right: 1px solid rgba(255,255,255,0.06);
 }
-.admin-nav-active {
+.admin-drawer .q-item,
+.admin-drawer .q-item__label,
+.admin-drawer .q-icon {
+  color: var(--admin-drawer-text);
+}
+.admin-nav-section {
+  color: var(--admin-drawer-text);
+  opacity: 0.5;
+  font-size: 0.68rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+.admin-nav-active,
+.admin-drawer .admin-nav-active,
+.admin-drawer .admin-nav-active .q-icon {
   color: var(--admin-nav-active) !important;
   font-weight: 700;
+}
+.admin-nav-active-item {
+  background-color: var(--admin-nav-active-bg);
+  border-radius: var(--admin-radius);
 }
 .admin-accent-icon {
   color: var(--admin-nav-active) !important;
 }
+/* Content helpers. */
 .admin-field-label {
   width: var(--admin-label-col-width);
   font-weight: 700;
@@ -344,9 +309,6 @@ body, .q-page-container {
   width: 100%;
   height: var(--admin-grid-height-compact);
 }
-/* AG Grid (NiceGUI 3.x quartz theme) reads these CSS custom properties from the
-   new theming API — set them on the grid element rather than overriding the
-   legacy .ag-row-odd class (which the quartz theme no longer emits). */
 .admin-grid,
 .admin-grid-compact {
   --ag-odd-row-background-color: var(--admin-row-alt);
@@ -362,14 +324,20 @@ body, .q-page-container {
   text-align: center;
   padding: 48px 0;
 }
+.admin-login-bg {
+  background: linear-gradient(135deg, #1e1b4b 0%, #0f172a 100%) !important;
+}
+.admin-login-card {
+  width: 360px;
+  max-width: 92vw;
+}
 .admin-pre {
   white-space: pre-wrap;
 }
 .admin-hidden {
   display: none;
 }
-/* Shape/elevation applied to standard Quasar components so every page inherits
-   the preset look without per-page styling. */
+/* Shape/elevation on standard Quasar components. */
 .q-card {
   border-radius: var(--admin-radius) !important;
   box-shadow: var(--admin-shadow) !important;
@@ -392,18 +360,21 @@ def _emit_vars(mapping: dict[str, str]) -> str:
 def build_admin_css(palette: str = DEFAULT_PALETTE) -> str:
     """Return the single CSS payload injected app-wide for the admin theme.
 
-    Pure string builder (no nicegui import) so it is unit-testable without the
-    ``admin`` extra. Emits ``:root`` (light) + ``.body--dark`` (dark) blocks for
-    the selected preset, then the palette-independent helper/component CSS.
+    Pure string builder (no nicegui import). Emits ``:root`` (dark chrome +
+    brand + shape + light content) and ``.body--dark`` (content dark overrides)
+    blocks for the selected preset, then the palette-independent helper CSS.
     Unknown palette names fall back to :data:`DEFAULT_PALETTE`.
     """
     name = palette if palette in _PALETTES else DEFAULT_PALETTE
-    preset = _PALETTES[name]
-    root_vars = {**preset["style"], **preset["light"], **_LAYOUT_TOKENS}
+    root_vars = {
+        **_PALETTES[name]["chrome"],
+        **_CONTENT_LIGHT,
+        **_LAYOUT_TOKENS,
+    }
     return (
         f"/* === Admin theme (#193) — palette: {name} === */\n"
         ":root {\n" + _emit_vars(root_vars) + "\n}\n"
-        ".body--dark {\n" + _emit_vars(preset["dark"]) + "\n}\n" + _HELPER_CSS
+        ".body--dark {\n" + _emit_vars(_CONTENT_DARK) + "\n}\n" + _HELPER_CSS
     )
 
 
@@ -416,8 +387,7 @@ def install_admin_theme_css() -> None:
     Calls ``ui.add_css(..., shared=True)`` so the stylesheet lands in every
     page's ``<head>`` — including login / setup / error which never render
     :func:`admin_layout`. Guarded so repeated ``bootstrap_admin()`` calls (test
-    reloads) do not double-inject, mirroring the exception-handler guard in
-    ``bootstrap.py``.
+    reloads) do not double-inject.
     """
     global _theme_css_installed
     if _theme_css_installed:

--- a/src/_core/infrastructure/admin/theme.py
+++ b/src/_core/infrastructure/admin/theme.py
@@ -1,0 +1,219 @@
+"""Centralized theme for the NiceGUI admin dashboard (#193).
+
+Single source of truth for admin colors, layout metrics, and the helper CSS
+classes that every admin page consumes. Replaces the hardcoded Quasar/Tailwind
+color classes (``bg-blue-800``, ``text-blue-800``, ``bg-blue-50`` …) and inline
+grid heights that were previously scattered across the shell and domain pages.
+
+Design (see plan #193 / Codex cross-review):
+
+* **Quasar brand** is overridden via the ``--q-*`` CSS variables, and our own
+  **semantic tokens** via ``--admin-*`` variables. Both are declared under
+  ``:root`` (light) and ``.body--dark`` (dark), so the whole palette flips with
+  Quasar's ``body--dark`` class — no Python re-render, no reload, and no
+  per-page ``ui.colors()`` call (which is page-scoped in NiceGUI 3.x).
+* The CSS is injected **once, app-wide** via ``ui.add_css(..., shared=True)``
+  so it reaches *every* page — including login / setup / error, which never
+  call :func:`admin_layout`.
+* AG Grid dark theming is **built in** to NiceGUI (a ``body--dark`` observer
+  flips ``data-ag-theme-mode`` + ``colorSchemeVariable``), so this module does
+  not ship AG Grid dark overrides — only neutral layout helpers.
+
+Constants here are intentionally **import-free** (no ``from nicegui``); the
+nicegui import is lazy inside :func:`install_admin_theme_css` so the constants
+and :func:`build_admin_css` remain testable when the ``admin`` extra is absent.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+# Uniform empty / null cell rendering (replaces the bare "" used before).
+EMPTY_DISPLAY: Final = "—"
+
+
+class AdminColors:
+    """Brand palette — the single source of truth for admin colors.
+
+    Light/dark concrete values live in the CSS blocks below; these names are
+    the canonical references used when wiring Quasar brand variables.
+    """
+
+    PRIMARY: Final = "#1d4ed8"  # was bg-blue-800 / text-blue-800
+    SECONDARY: Final = "#475569"
+    ACCENT: Final = "#0ea5e9"
+    POSITIVE: Final = "#16a34a"  # success surfaces (was bg-green-1)
+    NEGATIVE: Final = "#dc2626"  # errors (was text-red-700)
+    WARNING: Final = "#d97706"
+    INFO: Final = "#0284c7"
+
+
+class AdminVars:
+    """Names of the CSS custom properties consumed by the helper classes."""
+
+    # Quasar brand variables (override Quasar's defaults app-wide).
+    Q_PRIMARY: Final = "--q-primary"
+    Q_SECONDARY: Final = "--q-secondary"
+    Q_ACCENT: Final = "--q-accent"
+    Q_POSITIVE: Final = "--q-positive"
+    Q_NEGATIVE: Final = "--q-negative"
+    Q_WARNING: Final = "--q-warning"
+    Q_INFO: Final = "--q-info"
+
+    # Semantic admin tokens (our own surfaces).
+    HEADER_BG: Final = "--admin-header-bg"
+    HEADER_TEXT: Final = "--admin-header-text"
+    DRAWER_BG: Final = "--admin-drawer-bg"
+    NAV_ACTIVE: Final = "--admin-nav-active"
+    SURFACE: Final = "--admin-surface"
+    BORDER: Final = "--admin-border"
+    TEXT_MUTED: Final = "--admin-text-muted"
+    SUCCESS_BG: Final = "--admin-success-bg"
+    ROW_ALT: Final = "--admin-row-alt"
+    GRID_HEIGHT: Final = "--admin-grid-height"
+    GRID_HEIGHT_COMPACT: Final = "--admin-grid-height-compact"
+    LABEL_COL_WIDTH: Final = "--admin-label-col-width"
+
+
+class AdminMetrics:
+    """Layout metrics (numbers, not colors)."""
+
+    GRID_ROW_HEIGHT: Final = 44
+    GRID_MIN_COL_WIDTH: Final = 120
+
+
+class AdminClasses:
+    """Helper CSS class names (all ``admin-`` prefixed for the AST guard).
+
+    Pages reference these instead of hardcoded ``bg-*`` / ``text-*`` colors.
+    """
+
+    HEADER: Final = "admin-header"
+    DRAWER: Final = "admin-drawer"
+    NAV_ACTIVE: Final = "admin-nav-active"
+    ACCENT_ICON: Final = "admin-accent-icon"
+    CARD: Final = "admin-card"
+    FIELD_LABEL: Final = "admin-field-label"
+    FIELD_VALUE: Final = "admin-field-value"
+    # Muted/caption text — flips with dark mode (unlike fixed Quasar greys).
+    MUTED: Final = "admin-text-muted"
+    EMPTY_VALUE: Final = "admin-empty-value"
+    SUCCESS_SURFACE: Final = "admin-success-surface"
+    GRID: Final = "admin-grid"
+    GRID_COMPACT: Final = "admin-grid-compact"
+    PRE: Final = "admin-pre"
+    HIDDEN: Final = "admin-hidden"
+
+
+def build_admin_css() -> str:
+    """Return the single CSS payload injected app-wide for the admin theme.
+
+    Pure string builder (no nicegui import) so it is unit-testable without the
+    ``admin`` extra. Defines ``:root`` (light) + ``.body--dark`` (dark) blocks
+    for every Quasar brand and ``--admin-*`` token, then the helper classes that
+    consume them.
+    """
+    return f"""
+/* === Admin theme (#193) — light defaults === */
+:root {{
+  {AdminVars.Q_PRIMARY}: {AdminColors.PRIMARY};
+  {AdminVars.Q_SECONDARY}: {AdminColors.SECONDARY};
+  {AdminVars.Q_ACCENT}: {AdminColors.ACCENT};
+  {AdminVars.Q_POSITIVE}: {AdminColors.POSITIVE};
+  {AdminVars.Q_NEGATIVE}: {AdminColors.NEGATIVE};
+  {AdminVars.Q_WARNING}: {AdminColors.WARNING};
+  {AdminVars.Q_INFO}: {AdminColors.INFO};
+
+  {AdminVars.HEADER_BG}: {AdminColors.PRIMARY};
+  {AdminVars.HEADER_TEXT}: #ffffff;
+  {AdminVars.DRAWER_BG}: #eff6ff;
+  {AdminVars.NAV_ACTIVE}: #1e40af;
+  {AdminVars.SURFACE}: #ffffff;
+  {AdminVars.BORDER}: #e2e8f0;
+  {AdminVars.TEXT_MUTED}: #64748b;
+  {AdminVars.SUCCESS_BG}: #f0fdf4;
+  {AdminVars.ROW_ALT}: #f8fafc;
+  {AdminVars.GRID_HEIGHT}: calc(100vh - 240px);
+  {AdminVars.GRID_HEIGHT_COMPACT}: calc(100vh - 360px);
+  {AdminVars.LABEL_COL_WIDTH}: 160px;
+}}
+
+/* === Admin theme (#193) — dark overrides (Quasar body--dark) === */
+.body--dark {{
+  {AdminVars.HEADER_BG}: #1e293b;
+  {AdminVars.HEADER_TEXT}: #f1f5f9;
+  {AdminVars.DRAWER_BG}: #0f172a;
+  {AdminVars.NAV_ACTIVE}: #60a5fa;
+  {AdminVars.SURFACE}: #1e293b;
+  {AdminVars.BORDER}: #334155;
+  {AdminVars.TEXT_MUTED}: #94a3b8;
+  {AdminVars.SUCCESS_BG}: #052e16;
+  {AdminVars.ROW_ALT}: #0f172a;
+}}
+
+/* === Helper classes consuming the tokens === */
+.{AdminClasses.HEADER} {{
+  background-color: var({AdminVars.HEADER_BG}) !important;
+  color: var({AdminVars.HEADER_TEXT}) !important;
+}}
+.{AdminClasses.DRAWER} {{
+  background-color: var({AdminVars.DRAWER_BG}) !important;
+}}
+.{AdminClasses.NAV_ACTIVE} {{
+  color: var({AdminVars.NAV_ACTIVE}) !important;
+  font-weight: 700;
+}}
+.{AdminClasses.ACCENT_ICON} {{
+  color: var({AdminVars.NAV_ACTIVE}) !important;
+}}
+.{AdminClasses.FIELD_LABEL} {{
+  width: var({AdminVars.LABEL_COL_WIDTH});
+  font-weight: 700;
+}}
+.{AdminClasses.MUTED},
+.{AdminClasses.EMPTY_VALUE} {{
+  color: var({AdminVars.TEXT_MUTED});
+}}
+.{AdminClasses.SUCCESS_SURFACE} {{
+  background-color: var({AdminVars.SUCCESS_BG}) !important;
+}}
+.{AdminClasses.GRID} {{
+  width: 100%;
+  height: var({AdminVars.GRID_HEIGHT});
+}}
+.{AdminClasses.GRID_COMPACT} {{
+  width: 100%;
+  height: var({AdminVars.GRID_HEIGHT_COMPACT});
+}}
+.{AdminClasses.GRID} .ag-row-odd,
+.{AdminClasses.GRID_COMPACT} .ag-row-odd {{
+  background-color: var({AdminVars.ROW_ALT});
+}}
+.{AdminClasses.PRE} {{
+  white-space: pre-wrap;
+}}
+.{AdminClasses.HIDDEN} {{
+  display: none;
+}}
+"""
+
+
+_theme_css_installed = False
+
+
+def install_admin_theme_css() -> None:
+    """Inject the admin theme CSS app-wide (once per process).
+
+    Calls ``ui.add_css(..., shared=True)`` so the stylesheet lands in every
+    page's ``<head>`` — including login / setup / error which never render
+    :func:`admin_layout`. Guarded so repeated ``bootstrap_admin()`` calls (test
+    reloads) do not double-inject, mirroring the exception-handler guard in
+    ``bootstrap.py``.
+    """
+    global _theme_css_installed
+    if _theme_css_installed:
+        return
+    from nicegui import ui
+
+    ui.add_css(build_admin_css(), shared=True)
+    _theme_css_installed = True

--- a/src/_core/infrastructure/admin/theme.py
+++ b/src/_core/infrastructure/admin/theme.py
@@ -108,55 +108,122 @@ class AdminClasses:
     HIDDEN: Final = "admin-hidden"
 
 
-def build_admin_css() -> str:
+# ── Palette presets (#193) ──
+#
+# Each palette supplies the light (:root) and dark (.body--dark) values for the
+# Quasar brand + semantic tokens. Layout tokens (grid height, label width) are
+# palette-independent and emitted separately. Selected at boot via the
+# ``ADMIN_THEME_PALETTE`` setting so the look can be compared/rebranded without
+# touching code.
+DEFAULT_PALETTE: Final = "default"
+
+_LAYOUT_TOKENS: Final = {
+    AdminVars.GRID_HEIGHT: "calc(100vh - 240px)",
+    AdminVars.GRID_HEIGHT_COMPACT: "calc(100vh - 360px)",
+    AdminVars.LABEL_COL_WIDTH: "160px",
+}
+
+_PALETTES: Final = {
+    # Classic blue — the original look, brand from AdminColors.
+    "default": {
+        "light": {
+            AdminVars.Q_PRIMARY: AdminColors.PRIMARY,
+            AdminVars.Q_SECONDARY: AdminColors.SECONDARY,
+            AdminVars.Q_ACCENT: AdminColors.ACCENT,
+            AdminVars.Q_POSITIVE: AdminColors.POSITIVE,
+            AdminVars.Q_NEGATIVE: AdminColors.NEGATIVE,
+            AdminVars.Q_WARNING: AdminColors.WARNING,
+            AdminVars.Q_INFO: AdminColors.INFO,
+            AdminVars.HEADER_BG: AdminColors.PRIMARY,
+            AdminVars.HEADER_TEXT: "#ffffff",
+            AdminVars.DRAWER_BG: "#eff6ff",
+            AdminVars.NAV_ACTIVE: "#1e40af",
+            AdminVars.SURFACE: "#ffffff",
+            AdminVars.BORDER: "#e2e8f0",
+            AdminVars.TEXT_MUTED: "#64748b",
+            AdminVars.SUCCESS_BG: "#f0fdf4",
+            AdminVars.ROW_ALT: "#f8fafc",
+            AdminVars.ROW_HOVER: "#eef2ff",
+        },
+        "dark": {
+            AdminVars.HEADER_BG: "#1e293b",
+            AdminVars.HEADER_TEXT: "#f1f5f9",
+            AdminVars.DRAWER_BG: "#0f172a",
+            AdminVars.NAV_ACTIVE: "#60a5fa",
+            AdminVars.SURFACE: "#1e293b",
+            AdminVars.BORDER: "#334155",
+            AdminVars.TEXT_MUTED: "#94a3b8",
+            AdminVars.SUCCESS_BG: "#052e16",
+            AdminVars.ROW_ALT: "#0f172a",
+            AdminVars.ROW_HOVER: "#1e293b",
+        },
+    },
+    # Modern slate + indigo — neutral slate surfaces, indigo accent, dark header.
+    "slate": {
+        "light": {
+            AdminVars.Q_PRIMARY: "#4f46e5",
+            AdminVars.Q_SECONDARY: "#64748b",
+            AdminVars.Q_ACCENT: "#6366f1",
+            AdminVars.Q_POSITIVE: "#16a34a",
+            AdminVars.Q_NEGATIVE: "#e11d48",
+            AdminVars.Q_WARNING: "#d97706",
+            AdminVars.Q_INFO: "#0ea5e9",
+            AdminVars.HEADER_BG: "#1e293b",
+            AdminVars.HEADER_TEXT: "#f8fafc",
+            AdminVars.DRAWER_BG: "#f8fafc",
+            AdminVars.NAV_ACTIVE: "#4f46e5",
+            AdminVars.SURFACE: "#ffffff",
+            AdminVars.BORDER: "#e2e8f0",
+            AdminVars.TEXT_MUTED: "#64748b",
+            AdminVars.SUCCESS_BG: "#f0fdf4",
+            AdminVars.ROW_ALT: "#f1f5f9",
+            AdminVars.ROW_HOVER: "#eef2ff",
+        },
+        "dark": {
+            AdminVars.HEADER_BG: "#020617",
+            AdminVars.HEADER_TEXT: "#e2e8f0",
+            AdminVars.DRAWER_BG: "#0f172a",
+            AdminVars.NAV_ACTIVE: "#818cf8",
+            AdminVars.SURFACE: "#1e293b",
+            AdminVars.BORDER: "#334155",
+            AdminVars.TEXT_MUTED: "#94a3b8",
+            AdminVars.SUCCESS_BG: "#052e16",
+            AdminVars.ROW_ALT: "#0f172a",
+            AdminVars.ROW_HOVER: "#1e293b",
+        },
+    },
+}
+
+PALETTES: Final = tuple(_PALETTES)
+
+
+def _emit_vars(mapping: dict[str, str]) -> str:
+    return "\n".join(f"  {name}: {value};" for name, value in mapping.items())
+
+
+def build_admin_css(palette: str = DEFAULT_PALETTE) -> str:
     """Return the single CSS payload injected app-wide for the admin theme.
 
     Pure string builder (no nicegui import) so it is unit-testable without the
-    ``admin`` extra. Defines ``:root`` (light) + ``.body--dark`` (dark) blocks
-    for every Quasar brand and ``--admin-*`` token, then the helper classes that
-    consume them.
+    ``admin`` extra. Emits ``:root`` (light) + ``.body--dark`` (dark) blocks for
+    the selected palette, then the palette-independent helper classes.
+    Unknown palette names fall back to :data:`DEFAULT_PALETTE`.
     """
+    name = palette if palette in _PALETTES else DEFAULT_PALETTE
+    preset = _PALETTES[name]
+    root_vars = {**preset["light"], **_LAYOUT_TOKENS}
     return f"""
-/* === Admin theme (#193) — light defaults === */
+/* === Admin theme (#193) — palette: {name} (light) === */
 :root {{
-  {AdminVars.Q_PRIMARY}: {AdminColors.PRIMARY};
-  {AdminVars.Q_SECONDARY}: {AdminColors.SECONDARY};
-  {AdminVars.Q_ACCENT}: {AdminColors.ACCENT};
-  {AdminVars.Q_POSITIVE}: {AdminColors.POSITIVE};
-  {AdminVars.Q_NEGATIVE}: {AdminColors.NEGATIVE};
-  {AdminVars.Q_WARNING}: {AdminColors.WARNING};
-  {AdminVars.Q_INFO}: {AdminColors.INFO};
-
-  {AdminVars.HEADER_BG}: {AdminColors.PRIMARY};
-  {AdminVars.HEADER_TEXT}: #ffffff;
-  {AdminVars.DRAWER_BG}: #eff6ff;
-  {AdminVars.NAV_ACTIVE}: #1e40af;
-  {AdminVars.SURFACE}: #ffffff;
-  {AdminVars.BORDER}: #e2e8f0;
-  {AdminVars.TEXT_MUTED}: #64748b;
-  {AdminVars.SUCCESS_BG}: #f0fdf4;
-  {AdminVars.ROW_ALT}: #f8fafc;
-  {AdminVars.ROW_HOVER}: #eef2ff;
-  {AdminVars.GRID_HEIGHT}: calc(100vh - 240px);
-  {AdminVars.GRID_HEIGHT_COMPACT}: calc(100vh - 360px);
-  {AdminVars.LABEL_COL_WIDTH}: 160px;
+{_emit_vars(root_vars)}
 }}
 
 /* === Admin theme (#193) — dark overrides (Quasar body--dark) === */
 .body--dark {{
-  {AdminVars.HEADER_BG}: #1e293b;
-  {AdminVars.HEADER_TEXT}: #f1f5f9;
-  {AdminVars.DRAWER_BG}: #0f172a;
-  {AdminVars.NAV_ACTIVE}: #60a5fa;
-  {AdminVars.SURFACE}: #1e293b;
-  {AdminVars.BORDER}: #334155;
-  {AdminVars.TEXT_MUTED}: #94a3b8;
-  {AdminVars.SUCCESS_BG}: #052e16;
-  {AdminVars.ROW_ALT}: #0f172a;
-  {AdminVars.ROW_HOVER}: #1e293b;
+{_emit_vars(preset["dark"])}
 }}
 
-/* === Helper classes consuming the tokens === */
+/* === Helper classes consuming the tokens (palette-independent) === */
 .{AdminClasses.HEADER} {{
   background-color: var({AdminVars.HEADER_BG}) !important;
   color: var({AdminVars.HEADER_TEXT}) !important;
@@ -233,5 +300,7 @@ def install_admin_theme_css() -> None:
         return
     from nicegui import ui
 
-    ui.add_css(build_admin_css(), shared=True)
+    from src._core.config import settings
+
+    ui.add_css(build_admin_css(settings.admin_theme_palette), shared=True)
     _theme_css_installed = True

--- a/src/_core/infrastructure/admin/theme.py
+++ b/src/_core/infrastructure/admin/theme.py
@@ -1,27 +1,31 @@
-"""Centralized theme for the NiceGUI admin dashboard (#193).
+"""Centralized theme + style system for the NiceGUI admin dashboard (#193).
 
-Single source of truth for admin colors, layout metrics, and the helper CSS
-classes that every admin page consumes. Replaces the hardcoded Quasar/Tailwind
-color classes (``bg-blue-800``, ``text-blue-800``, ``bg-blue-50`` …) and inline
-grid heights that were previously scattered across the shell and domain pages.
+Single source of truth for admin colors, **style tokens** (radius, shadow,
+border treatment), layout metrics, and the helper CSS classes + Quasar
+component overrides that every admin page inherits. Replaces the hardcoded
+Quasar/Tailwind color classes and inline grid heights that were previously
+scattered across the shell and domain pages.
 
 Design (see plan #193 / Codex cross-review):
 
-* **Quasar brand** is overridden via the ``--q-*`` CSS variables, and our own
-  **semantic tokens** via ``--admin-*`` variables. Both are declared under
-  ``:root`` (light) and ``.body--dark`` (dark), so the whole palette flips with
-  Quasar's ``body--dark`` class — no Python re-render, no reload, and no
-  per-page ``ui.colors()`` call (which is page-scoped in NiceGUI 3.x).
-* The CSS is injected **once, app-wide** via ``ui.add_css(..., shared=True)``
-  so it reaches *every* page — including login / setup / error, which never
-  call :func:`admin_layout`.
+* The look is driven by CSS custom properties: ``--q-*`` (Quasar brand) and
+  ``--admin-*`` (semantic + style) variables, declared under ``:root`` (light)
+  and ``.body--dark`` (dark). Quasar's ``body--dark`` toggle flips the whole
+  palette with no Python re-render, no reload, and no per-page ``ui.colors()``.
+* Multiple **style presets** (``default``, ``linear``, ``shadcn``,
+  ``supabase``) bundle a full set of color + style tokens, selected at boot via
+  the ``ADMIN_THEME_PALETTE`` setting. The layout structure is identical across
+  presets — only the tokens (and thus the CSS-var-driven component look) differ.
+* The CSS is injected **once, app-wide** via ``ui.add_css(..., shared=True)`` so
+  it reaches every page — including login / setup / error, which never call
+  :func:`admin_layout`.
 * AG Grid dark theming is **built in** to NiceGUI (a ``body--dark`` observer
-  flips ``data-ag-theme-mode`` + ``colorSchemeVariable``), so this module does
-  not ship AG Grid dark overrides — only neutral layout helpers.
+  flips ``data-ag-theme-mode``); we only feed it ``--ag-*`` vars for row colors.
 
 Constants here are intentionally **import-free** (no ``from nicegui``); the
-nicegui import is lazy inside :func:`install_admin_theme_css` so the constants
-and :func:`build_admin_css` remain testable when the ``admin`` extra is absent.
+nicegui + settings imports are lazy inside :func:`install_admin_theme_css` so
+the constants and :func:`build_admin_css` stay testable when the ``admin``
+extra is absent.
 """
 
 from __future__ import annotations
@@ -33,17 +37,13 @@ EMPTY_DISPLAY: Final = "—"
 
 
 class AdminColors:
-    """Brand palette — the single source of truth for admin colors.
+    """Default brand palette — also the source of the ``default`` preset."""
 
-    Light/dark concrete values live in the CSS blocks below; these names are
-    the canonical references used when wiring Quasar brand variables.
-    """
-
-    PRIMARY: Final = "#1d4ed8"  # was bg-blue-800 / text-blue-800
+    PRIMARY: Final = "#1d4ed8"
     SECONDARY: Final = "#475569"
     ACCENT: Final = "#0ea5e9"
-    POSITIVE: Final = "#16a34a"  # success surfaces (was bg-green-1)
-    NEGATIVE: Final = "#dc2626"  # errors (was text-red-700)
+    POSITIVE: Final = "#16a34a"
+    NEGATIVE: Final = "#dc2626"
     WARNING: Final = "#d97706"
     INFO: Final = "#0284c7"
 
@@ -60,17 +60,25 @@ class AdminVars:
     Q_WARNING: Final = "--q-warning"
     Q_INFO: Final = "--q-info"
 
-    # Semantic admin tokens (our own surfaces).
+    # Semantic surfaces.
+    BG: Final = "--admin-bg"
+    SURFACE: Final = "--admin-surface"
+    BORDER: Final = "--admin-border"
+    TEXT_MUTED: Final = "--admin-text-muted"
     HEADER_BG: Final = "--admin-header-bg"
     HEADER_TEXT: Final = "--admin-header-text"
     DRAWER_BG: Final = "--admin-drawer-bg"
     NAV_ACTIVE: Final = "--admin-nav-active"
-    SURFACE: Final = "--admin-surface"
-    BORDER: Final = "--admin-border"
-    TEXT_MUTED: Final = "--admin-text-muted"
     SUCCESS_BG: Final = "--admin-success-bg"
     ROW_ALT: Final = "--admin-row-alt"
     ROW_HOVER: Final = "--admin-row-hover"
+
+    # Style tokens (shape/elevation — theme-level, same in light + dark).
+    RADIUS: Final = "--admin-radius"
+    SHADOW: Final = "--admin-shadow"
+    CARD_BORDER: Final = "--admin-card-border"
+
+    # Layout metrics.
     GRID_HEIGHT: Final = "--admin-grid-height"
     GRID_HEIGHT_COMPACT: Final = "--admin-grid-height-compact"
     LABEL_COL_WIDTH: Final = "--admin-label-col-width"
@@ -84,10 +92,7 @@ class AdminMetrics:
 
 
 class AdminClasses:
-    """Helper CSS class names (all ``admin-`` prefixed for the AST guard).
-
-    Pages reference these instead of hardcoded ``bg-*`` / ``text-*`` colors.
-    """
+    """Helper CSS class names (all ``admin-`` prefixed for the AST guard)."""
 
     HEADER: Final = "admin-header"
     DRAWER: Final = "admin-drawer"
@@ -96,7 +101,6 @@ class AdminClasses:
     CARD: Final = "admin-card"
     FIELD_LABEL: Final = "admin-field-label"
     FIELD_VALUE: Final = "admin-field-value"
-    # Muted/caption text — flips with dark mode (unlike fixed Quasar greys).
     MUTED: Final = "admin-text-muted"
     EMPTY_VALUE: Final = "admin-empty-value"
     SUCCESS_SURFACE: Final = "admin-success-surface"
@@ -108,13 +112,11 @@ class AdminClasses:
     HIDDEN: Final = "admin-hidden"
 
 
-# ── Palette presets (#193) ──
+# ── Style presets (#193) ──
 #
-# Each palette supplies the light (:root) and dark (.body--dark) values for the
-# Quasar brand + semantic tokens. Layout tokens (grid height, label width) are
-# palette-independent and emitted separately. Selected at boot via the
-# ``ADMIN_THEME_PALETTE`` setting so the look can be compared/rebranded without
-# touching code.
+# Each preset bundles "style" (shape/elevation, theme-level), "light" (:root
+# colors) and "dark" (.body--dark colors). Layout metrics are shared. Selected
+# at boot via ADMIN_THEME_PALETTE; unknown names fall back to DEFAULT_PALETTE.
 DEFAULT_PALETTE: Final = "default"
 
 _LAYOUT_TOKENS: Final = {
@@ -124,8 +126,13 @@ _LAYOUT_TOKENS: Final = {
 }
 
 _PALETTES: Final = {
-    # Classic blue — the original look, brand from AdminColors.
+    # Classic blue — the original corporate look.
     "default": {
+        "style": {
+            AdminVars.RADIUS: "4px",
+            AdminVars.SHADOW: "0 1px 4px rgba(0,0,0,0.12)",
+            AdminVars.CARD_BORDER: "none",
+        },
         "light": {
             AdminVars.Q_PRIMARY: AdminColors.PRIMARY,
             AdminVars.Q_SECONDARY: AdminColors.SECONDARY,
@@ -134,67 +141,248 @@ _PALETTES: Final = {
             AdminVars.Q_NEGATIVE: AdminColors.NEGATIVE,
             AdminVars.Q_WARNING: AdminColors.WARNING,
             AdminVars.Q_INFO: AdminColors.INFO,
+            AdminVars.BG: "#f1f5f9",
+            AdminVars.SURFACE: "#ffffff",
+            AdminVars.BORDER: "#e2e8f0",
+            AdminVars.TEXT_MUTED: "#64748b",
             AdminVars.HEADER_BG: AdminColors.PRIMARY,
             AdminVars.HEADER_TEXT: "#ffffff",
             AdminVars.DRAWER_BG: "#eff6ff",
             AdminVars.NAV_ACTIVE: "#1e40af",
-            AdminVars.SURFACE: "#ffffff",
-            AdminVars.BORDER: "#e2e8f0",
-            AdminVars.TEXT_MUTED: "#64748b",
             AdminVars.SUCCESS_BG: "#f0fdf4",
             AdminVars.ROW_ALT: "#f8fafc",
             AdminVars.ROW_HOVER: "#eef2ff",
         },
         "dark": {
+            AdminVars.BG: "#0b1220",
+            AdminVars.SURFACE: "#1e293b",
+            AdminVars.BORDER: "#334155",
+            AdminVars.TEXT_MUTED: "#94a3b8",
             AdminVars.HEADER_BG: "#1e293b",
             AdminVars.HEADER_TEXT: "#f1f5f9",
             AdminVars.DRAWER_BG: "#0f172a",
             AdminVars.NAV_ACTIVE: "#60a5fa",
-            AdminVars.SURFACE: "#1e293b",
-            AdminVars.BORDER: "#334155",
-            AdminVars.TEXT_MUTED: "#94a3b8",
             AdminVars.SUCCESS_BG: "#052e16",
             AdminVars.ROW_ALT: "#0f172a",
             AdminVars.ROW_HOVER: "#1e293b",
         },
     },
-    # Modern slate + indigo — neutral slate surfaces, indigo accent, dark header.
-    "slate": {
+    # Linear / Vercel — minimal, flat, border-based, indigo accent, light header.
+    "linear": {
+        "style": {
+            AdminVars.RADIUS: "6px",
+            AdminVars.SHADOW: "none",
+            AdminVars.CARD_BORDER: "1px solid var(--admin-border)",
+        },
         "light": {
-            AdminVars.Q_PRIMARY: "#4f46e5",
-            AdminVars.Q_SECONDARY: "#64748b",
-            AdminVars.Q_ACCENT: "#6366f1",
-            AdminVars.Q_POSITIVE: "#16a34a",
-            AdminVars.Q_NEGATIVE: "#e11d48",
-            AdminVars.Q_WARNING: "#d97706",
-            AdminVars.Q_INFO: "#0ea5e9",
-            AdminVars.HEADER_BG: "#1e293b",
-            AdminVars.HEADER_TEXT: "#f8fafc",
-            AdminVars.DRAWER_BG: "#f8fafc",
-            AdminVars.NAV_ACTIVE: "#4f46e5",
+            AdminVars.Q_PRIMARY: "#5e6ad2",
+            AdminVars.Q_SECONDARY: "#6b6f76",
+            AdminVars.Q_ACCENT: "#5e6ad2",
+            AdminVars.Q_POSITIVE: "#4cb782",
+            AdminVars.Q_NEGATIVE: "#eb5757",
+            AdminVars.Q_WARNING: "#d99e00",
+            AdminVars.Q_INFO: "#4ea7fc",
+            AdminVars.BG: "#fbfbfb",
             AdminVars.SURFACE: "#ffffff",
-            AdminVars.BORDER: "#e2e8f0",
-            AdminVars.TEXT_MUTED: "#64748b",
-            AdminVars.SUCCESS_BG: "#f0fdf4",
-            AdminVars.ROW_ALT: "#f1f5f9",
-            AdminVars.ROW_HOVER: "#eef2ff",
+            AdminVars.BORDER: "#ebebed",
+            AdminVars.TEXT_MUTED: "#8a8f98",
+            AdminVars.HEADER_BG: "#ffffff",
+            AdminVars.HEADER_TEXT: "#232529",
+            AdminVars.DRAWER_BG: "#fbfbfb",
+            AdminVars.NAV_ACTIVE: "#5e6ad2",
+            AdminVars.SUCCESS_BG: "#edf7f2",
+            AdminVars.ROW_ALT: "#fafafa",
+            AdminVars.ROW_HOVER: "#f4f4f5",
         },
         "dark": {
-            AdminVars.HEADER_BG: "#020617",
-            AdminVars.HEADER_TEXT: "#e2e8f0",
-            AdminVars.DRAWER_BG: "#0f172a",
-            AdminVars.NAV_ACTIVE: "#818cf8",
-            AdminVars.SURFACE: "#1e293b",
-            AdminVars.BORDER: "#334155",
-            AdminVars.TEXT_MUTED: "#94a3b8",
+            AdminVars.BG: "#0d0d0f",
+            AdminVars.SURFACE: "#161618",
+            AdminVars.BORDER: "#232326",
+            AdminVars.TEXT_MUTED: "#8a8f98",
+            AdminVars.HEADER_BG: "#0d0d0f",
+            AdminVars.HEADER_TEXT: "#e6e6e8",
+            AdminVars.DRAWER_BG: "#0d0d0f",
+            AdminVars.NAV_ACTIVE: "#8b87ff",
+            AdminVars.SUCCESS_BG: "#0f2a1f",
+            AdminVars.ROW_ALT: "#161618",
+            AdminVars.ROW_HOVER: "#1c1c1f",
+        },
+    },
+    # shadcn / Notion — clean light, rounded, soft shadow, near-black primary.
+    "shadcn": {
+        "style": {
+            AdminVars.RADIUS: "12px",
+            AdminVars.SHADOW: "0 1px 3px 0 rgba(0,0,0,0.1), 0 1px 2px -1px rgba(0,0,0,0.1)",
+            AdminVars.CARD_BORDER: "1px solid var(--admin-border)",
+        },
+        "light": {
+            AdminVars.Q_PRIMARY: "#18181b",
+            AdminVars.Q_SECONDARY: "#71717a",
+            AdminVars.Q_ACCENT: "#6366f1",
+            AdminVars.Q_POSITIVE: "#16a34a",
+            AdminVars.Q_NEGATIVE: "#ef4444",
+            AdminVars.Q_WARNING: "#f59e0b",
+            AdminVars.Q_INFO: "#3b82f6",
+            AdminVars.BG: "#fafafa",
+            AdminVars.SURFACE: "#ffffff",
+            AdminVars.BORDER: "#e4e4e7",
+            AdminVars.TEXT_MUTED: "#71717a",
+            AdminVars.HEADER_BG: "#ffffff",
+            AdminVars.HEADER_TEXT: "#18181b",
+            AdminVars.DRAWER_BG: "#fafafa",
+            AdminVars.NAV_ACTIVE: "#18181b",
+            AdminVars.SUCCESS_BG: "#f0fdf4",
+            AdminVars.ROW_ALT: "#fafafa",
+            AdminVars.ROW_HOVER: "#f4f4f5",
+        },
+        "dark": {
+            AdminVars.BG: "#09090b",
+            AdminVars.SURFACE: "#18181b",
+            AdminVars.BORDER: "#27272a",
+            AdminVars.TEXT_MUTED: "#a1a1aa",
+            AdminVars.HEADER_BG: "#09090b",
+            AdminVars.HEADER_TEXT: "#fafafa",
+            AdminVars.DRAWER_BG: "#09090b",
+            AdminVars.NAV_ACTIVE: "#fafafa",
             AdminVars.SUCCESS_BG: "#052e16",
-            AdminVars.ROW_ALT: "#0f172a",
-            AdminVars.ROW_HOVER: "#1e293b",
+            AdminVars.ROW_ALT: "#18181b",
+            AdminVars.ROW_HOVER: "#27272a",
+        },
+    },
+    # Supabase / Stripe — dark header, green accent, clean data tables.
+    "supabase": {
+        "style": {
+            AdminVars.RADIUS: "8px",
+            AdminVars.SHADOW: "0 1px 2px rgba(0,0,0,0.08)",
+            AdminVars.CARD_BORDER: "1px solid var(--admin-border)",
+        },
+        "light": {
+            AdminVars.Q_PRIMARY: "#3ecf8e",
+            AdminVars.Q_SECONDARY: "#64748b",
+            AdminVars.Q_ACCENT: "#3ecf8e",
+            AdminVars.Q_POSITIVE: "#3ecf8e",
+            AdminVars.Q_NEGATIVE: "#ef4444",
+            AdminVars.Q_WARNING: "#f59e0b",
+            AdminVars.Q_INFO: "#3b82f6",
+            AdminVars.BG: "#f8f9fa",
+            AdminVars.SURFACE: "#ffffff",
+            AdminVars.BORDER: "#e6e8eb",
+            AdminVars.TEXT_MUTED: "#6b7280",
+            AdminVars.HEADER_BG: "#1c1c1c",
+            AdminVars.HEADER_TEXT: "#ededed",
+            AdminVars.DRAWER_BG: "#fbfcfd",
+            AdminVars.NAV_ACTIVE: "#3ecf8e",
+            AdminVars.SUCCESS_BG: "#ecfdf5",
+            AdminVars.ROW_ALT: "#f8f9fa",
+            AdminVars.ROW_HOVER: "#f0fdf8",
+        },
+        "dark": {
+            AdminVars.BG: "#121212",
+            AdminVars.SURFACE: "#1c1c1c",
+            AdminVars.BORDER: "#2e2e2e",
+            AdminVars.TEXT_MUTED: "#a0a0a0",
+            AdminVars.HEADER_BG: "#121212",
+            AdminVars.HEADER_TEXT: "#ededed",
+            AdminVars.DRAWER_BG: "#1c1c1c",
+            AdminVars.NAV_ACTIVE: "#3ecf8e",
+            AdminVars.SUCCESS_BG: "#06281d",
+            AdminVars.ROW_ALT: "#1c1c1c",
+            AdminVars.ROW_HOVER: "#262626",
         },
     },
 }
 
 PALETTES: Final = tuple(_PALETTES)
+
+
+# Palette-independent rules: helper classes + Quasar component overrides that
+# read the tokens above. Plain string (literal class/var names) so there are no
+# f-string brace-escaping hazards.
+_HELPER_CSS: Final = """
+/* === Helper classes + Quasar component overrides (token-driven) === */
+body, .q-page-container {
+  background-color: var(--admin-bg) !important;
+}
+.admin-header {
+  background-color: var(--admin-header-bg) !important;
+  color: var(--admin-header-text) !important;
+  box-shadow: none !important;
+  border-bottom: 1px solid var(--admin-border);
+}
+.admin-header .q-btn,
+.admin-header .q-icon,
+.admin-header .q-toolbar__title {
+  color: var(--admin-header-text) !important;
+}
+.admin-drawer {
+  background-color: var(--admin-drawer-bg) !important;
+  border-right: 1px solid var(--admin-border);
+}
+.admin-nav-active {
+  color: var(--admin-nav-active) !important;
+  font-weight: 700;
+}
+.admin-accent-icon {
+  color: var(--admin-nav-active) !important;
+}
+.admin-field-label {
+  width: var(--admin-label-col-width);
+  font-weight: 700;
+}
+.admin-text-muted,
+.admin-empty-value {
+  color: var(--admin-text-muted);
+}
+.admin-success-surface {
+  background-color: var(--admin-success-bg) !important;
+}
+.admin-grid {
+  width: 100%;
+  height: var(--admin-grid-height);
+}
+.admin-grid-compact {
+  width: 100%;
+  height: var(--admin-grid-height-compact);
+}
+/* AG Grid (NiceGUI 3.x quartz theme) reads these CSS custom properties from the
+   new theming API — set them on the grid element rather than overriding the
+   legacy .ag-row-odd class (which the quartz theme no longer emits). */
+.admin-grid,
+.admin-grid-compact {
+  --ag-odd-row-background-color: var(--admin-row-alt);
+  --ag-row-hover-color: var(--admin-row-hover);
+  --ag-border-radius: var(--admin-radius);
+}
+.admin-pagination {
+  justify-content: flex-end;
+}
+.admin-empty-state {
+  color: var(--admin-text-muted);
+  align-items: center;
+  text-align: center;
+  padding: 48px 0;
+}
+.admin-pre {
+  white-space: pre-wrap;
+}
+.admin-hidden {
+  display: none;
+}
+/* Shape/elevation applied to standard Quasar components so every page inherits
+   the preset look without per-page styling. */
+.q-card {
+  border-radius: var(--admin-radius) !important;
+  box-shadow: var(--admin-shadow) !important;
+  border: var(--admin-card-border) !important;
+}
+.q-btn {
+  border-radius: var(--admin-radius);
+}
+.q-field--outlined .q-field__control,
+.q-field__control {
+  border-radius: var(--admin-radius);
+}
+"""
 
 
 def _emit_vars(mapping: dict[str, str]) -> str:
@@ -206,81 +394,17 @@ def build_admin_css(palette: str = DEFAULT_PALETTE) -> str:
 
     Pure string builder (no nicegui import) so it is unit-testable without the
     ``admin`` extra. Emits ``:root`` (light) + ``.body--dark`` (dark) blocks for
-    the selected palette, then the palette-independent helper classes.
+    the selected preset, then the palette-independent helper/component CSS.
     Unknown palette names fall back to :data:`DEFAULT_PALETTE`.
     """
     name = palette if palette in _PALETTES else DEFAULT_PALETTE
     preset = _PALETTES[name]
-    root_vars = {**preset["light"], **_LAYOUT_TOKENS}
-    return f"""
-/* === Admin theme (#193) — palette: {name} (light) === */
-:root {{
-{_emit_vars(root_vars)}
-}}
-
-/* === Admin theme (#193) — dark overrides (Quasar body--dark) === */
-.body--dark {{
-{_emit_vars(preset["dark"])}
-}}
-
-/* === Helper classes consuming the tokens (palette-independent) === */
-.{AdminClasses.HEADER} {{
-  background-color: var({AdminVars.HEADER_BG}) !important;
-  color: var({AdminVars.HEADER_TEXT}) !important;
-}}
-.{AdminClasses.DRAWER} {{
-  background-color: var({AdminVars.DRAWER_BG}) !important;
-}}
-.{AdminClasses.NAV_ACTIVE} {{
-  color: var({AdminVars.NAV_ACTIVE}) !important;
-  font-weight: 700;
-}}
-.{AdminClasses.ACCENT_ICON} {{
-  color: var({AdminVars.NAV_ACTIVE}) !important;
-}}
-.{AdminClasses.FIELD_LABEL} {{
-  width: var({AdminVars.LABEL_COL_WIDTH});
-  font-weight: 700;
-}}
-.{AdminClasses.MUTED},
-.{AdminClasses.EMPTY_VALUE} {{
-  color: var({AdminVars.TEXT_MUTED});
-}}
-.{AdminClasses.SUCCESS_SURFACE} {{
-  background-color: var({AdminVars.SUCCESS_BG}) !important;
-}}
-.{AdminClasses.GRID} {{
-  width: 100%;
-  height: var({AdminVars.GRID_HEIGHT});
-}}
-.{AdminClasses.GRID_COMPACT} {{
-  width: 100%;
-  height: var({AdminVars.GRID_HEIGHT_COMPACT});
-}}
-/* AG Grid (NiceGUI 3.x quartz theme) reads these CSS custom properties from
-   the new theming API — set them on the grid element rather than overriding
-   the legacy .ag-row-odd class (which the quartz theme no longer emits). */
-.{AdminClasses.GRID},
-.{AdminClasses.GRID_COMPACT} {{
-  --ag-odd-row-background-color: var({AdminVars.ROW_ALT});
-  --ag-row-hover-color: var({AdminVars.ROW_HOVER});
-}}
-.{AdminClasses.PAGINATION} {{
-  justify-content: flex-end;
-}}
-.{AdminClasses.EMPTY_STATE} {{
-  color: var({AdminVars.TEXT_MUTED});
-  align-items: center;
-  text-align: center;
-  padding: 48px 0;
-}}
-.{AdminClasses.PRE} {{
-  white-space: pre-wrap;
-}}
-.{AdminClasses.HIDDEN} {{
-  display: none;
-}}
-"""
+    root_vars = {**preset["style"], **preset["light"], **_LAYOUT_TOKENS}
+    return (
+        f"/* === Admin theme (#193) — palette: {name} === */\n"
+        ":root {\n" + _emit_vars(root_vars) + "\n}\n"
+        ".body--dark {\n" + _emit_vars(preset["dark"]) + "\n}\n" + _HELPER_CSS
+    )
 
 
 _theme_css_installed = False

--- a/src/ai_usage/interface/admin/pages/ai_usage_page.py
+++ b/src/ai_usage/interface/admin/pages/ai_usage_page.py
@@ -9,6 +9,7 @@ from src._core.infrastructure.admin.error_handler import (
     admin_error_boundary,
 )
 from src._core.infrastructure.admin.layout import admin_layout
+from src._core.infrastructure.admin.theme import AdminClasses
 from src.ai_usage.interface.admin.configs.ai_usage_admin_config import (
     ai_usage_admin_page,
 )
@@ -67,7 +68,7 @@ async def ai_usage_summary_page() -> None:
             "rowData": rows,
             "defaultColDef": {"resizable": True, "sortable": True},
         }
-    ).classes("w-full").style("height: 420px")
+    ).classes(f"w-full {AdminClasses.GRID_COMPACT}")
 
 
 @ui.page("/admin/ai_usage/{record_id}")

--- a/src/docs/interface/admin/pages/docs_page.py
+++ b/src/docs/interface/admin/pages/docs_page.py
@@ -9,6 +9,7 @@ from src._core.infrastructure.admin.error_handler import (
     admin_error_boundary,
 )
 from src._core.infrastructure.admin.layout import admin_layout, button_loading
+from src._core.infrastructure.admin.theme import AdminClasses
 from src.docs.interface.admin.configs.docs_admin_config import docs_admin_page
 
 # page_configs is injected by bootstrap_admin() after discovery
@@ -48,7 +49,7 @@ async def docs_query_page() -> None:
         .classes("w-40")
     )
 
-    answer_card = ui.card().classes("w-full q-mt-md").style("display: none")
+    answer_card = ui.card().classes(f"w-full q-mt-md {AdminClasses.HIDDEN}")
 
     async def _run_query() -> None:
         question = (question_input.value or "").strip()
@@ -66,10 +67,10 @@ async def docs_query_page() -> None:
                 return
 
         answer_card.clear()
-        answer_card.style("display: block")
+        answer_card.classes(remove=AdminClasses.HIDDEN)
         with answer_card:
             ui.label("Answer").classes("text-subtitle1 text-weight-bold")
-            ui.label(answer.answer).style("white-space: pre-wrap")
+            ui.label(answer.answer).classes(AdminClasses.PRE)
             ui.separator().classes("q-my-md")
             ui.label("Citations (" + str(retrieved_count) + " retrieved)").classes(
                 "text-subtitle1 text-weight-bold"

--- a/tests/unit/_core/infrastructure/admin/test_dark_mode_toggle.py
+++ b/tests/unit/_core/infrastructure/admin/test_dark_mode_toggle.py
@@ -1,0 +1,29 @@
+"""Unit tests for the admin dark-mode toggle resolution (#193).
+
+``ui.dark_mode.toggle()`` raises when the value is None (auto), so the header
+toggle resolves the next state via ``_next_dark_value`` instead. These tests
+pin that logic without needing a nicegui client context.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("nicegui")
+
+from src._core.infrastructure.admin.layout import _next_dark_value  # noqa: E402
+
+
+def test_next_value_from_auto_is_dark():
+    # From system/auto (None) the first toggle resolves to an explicit dark.
+    assert _next_dark_value(None) is True
+
+
+def test_next_value_flips_explicit_state():
+    assert _next_dark_value(True) is False
+    assert _next_dark_value(False) is True
+
+
+def test_next_value_is_always_concrete_bool():
+    for current in (None, True, False):
+        assert isinstance(_next_dark_value(current), bool)

--- a/tests/unit/_core/infrastructure/admin/test_no_hardcoded_styles.py
+++ b/tests/unit/_core/infrastructure/admin/test_no_hardcoded_styles.py
@@ -1,0 +1,138 @@
+"""AST guard: admin pages must use centralized theme classes, not hardcoded
+Quasar/Tailwind color classes or inline grid heights (#193).
+
+Scope: every ``@ui.page`` admin page file PLUS the two shared shell modules
+(``layout.py``, ``base_admin_page.py``) that previously held hardcoded colors.
+``theme.py`` is the single allowed home for raw color/metric values and is
+excluded.
+
+Pure AST + regex (no nicegui import) so it runs under ``make check-core``
+regardless of the ``admin`` extra.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import re
+
+import pytest
+
+_SRC_ROOT = pathlib.Path("src")
+
+# Named Quasar palette colors. Hardcoding any of these (with or without a
+# numeric shade) bypasses the theme tokens and does not flip in dark mode.
+# Semantic classes (``text-negative`` / ``text-warning`` / ``color=primary``)
+# resolve via the ``--q-*`` vars and are intentionally NOT listed here.
+# Order matters: longer names precede the prefixes they contain (e.g.
+# ``light-blue`` before ``blue``, ``blue-grey`` before ``grey``).
+_PALETTE = (
+    r"(?:red|pink|deep-purple|purple|indigo|light-blue|blue-grey|blue-gray|blue"
+    r"|cyan|teal|light-green|green|lime|yellow|amber|deep-orange|orange|brown"
+    r"|grey|gray)"
+)
+_COLOR_CLASS_RE = re.compile(rf"\b(?:bg|text|border)-{_PALETTE}(?:-\d+)?\b")
+
+# Inline grid height, e.g. ``.style("height: 600px")``. Note skeleton sizing uses
+# the ``height="44px"`` kwarg form (a bare "44px" literal, no "height:" prefix),
+# which is intentionally NOT matched here.
+_INLINE_HEIGHT_RE = re.compile(r"height:\s*\d+px")
+
+# Shared shell modules to guard in addition to the page files.
+_EXTRA_GUARDED = (
+    _SRC_ROOT / "_core" / "infrastructure" / "admin" / "layout.py",
+    _SRC_ROOT / "_core" / "infrastructure" / "admin" / "base_admin_page.py",
+)
+
+
+def _find_admin_page_files() -> list[pathlib.Path]:
+    return [
+        p
+        for p in _SRC_ROOT.rglob("*.py")
+        if "admin" in p.parts and "pages" in p.parts and "__init__" not in p.name
+    ]
+
+
+def _guarded_files() -> list[pathlib.Path]:
+    files = _find_admin_page_files()
+    files.extend(p for p in _EXTRA_GUARDED if p.exists())
+    return files
+
+
+def _string_literals(source: str):
+    """Yield (lineno, value) for every string literal, including the static
+    text parts of f-strings (which ``ast.walk`` exposes as ``ast.Constant``)."""
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            yield node.lineno, node.value
+
+
+def _find_style_violations(filepath: pathlib.Path) -> list[str]:
+    source = filepath.read_text(encoding="utf-8")
+    violations: list[str] = []
+    for lineno, value in _string_literals(source):
+        if _COLOR_CLASS_RE.search(value):
+            violations.append(
+                f"{filepath}:{lineno}: hardcoded color class -> {value!r}"
+            )
+        if _INLINE_HEIGHT_RE.search(value):
+            violations.append(f"{filepath}:{lineno}: inline grid height -> {value!r}")
+    return violations
+
+
+def test_admin_pages_have_no_hardcoded_styles():
+    """No admin page (or shared shell module) hardcodes brand colors or grid
+    heights — they must reference AdminClasses / AdminMetrics from theme.py."""
+    violations: list[str] = []
+    for filepath in _guarded_files():
+        violations.extend(_find_style_violations(filepath))
+
+    assert not violations, (
+        "Hardcoded styles found — use theme.py AdminClasses / AdminMetrics:\n  "
+        + "\n  ".join(violations)
+    )
+
+
+def test_theme_module_is_not_in_guard_scope():
+    """theme.py is the single allowed home for raw values; it must be excluded."""
+    theme_path = _SRC_ROOT / "_core" / "infrastructure" / "admin" / "theme.py"
+    assert theme_path.exists()
+    assert theme_path not in _guarded_files()
+
+
+# ── Detector unit tests (self-check the guard logic) ──
+
+
+@pytest.mark.parametrize(
+    "snippet",
+    [
+        'ui.icon("a").classes("text-blue-800")',
+        'ui.label("x").classes("text-orange")',  # named color, no shade
+        'ui.card().classes("bg-light-blue-1")',
+        'ui.label("y").classes("text-blue-grey-7")',
+    ],
+)
+def test_detector_flags_planted_color_class(tmp_path: pathlib.Path, snippet: str):
+    bad = tmp_path / "bad_page.py"
+    bad.write_text(snippet + "\n", encoding="utf-8")
+    assert _find_style_violations(bad)
+
+
+def test_detector_flags_planted_grid_height(tmp_path: pathlib.Path):
+    bad = tmp_path / "bad_grid.py"
+    bad.write_text('g = ui.aggrid({}).style("height: 600px")\n', encoding="utf-8")
+    assert _find_style_violations(bad)
+
+
+def test_detector_allows_theme_and_semantic_classes(tmp_path: pathlib.Path):
+    """Theme classes, Quasar semantic colors, and skeleton heights are allowed."""
+    good = tmp_path / "good_page.py"
+    good.write_text(
+        'a = ui.element().classes("admin-grid admin-text-muted")\n'
+        'b = ui.label("x").classes("text-negative text-warning text-positive")\n'
+        'c = ui.label("y").classes("text-h5 text-caption text-weight-bold")\n'
+        'd = ui.skeleton(type="rect", width="100%", height="44px")\n',
+        encoding="utf-8",
+    )
+    assert _find_style_violations(good) == []

--- a/tests/unit/_core/infrastructure/admin/test_theme.py
+++ b/tests/unit/_core/infrastructure/admin/test_theme.py
@@ -1,0 +1,107 @@
+"""Pure-constant tests for the admin theme module (#193).
+
+These intentionally import nothing from nicegui — ``theme.py`` keeps its nicegui
+import lazy inside ``install_admin_theme_css`` — so they run under
+``make check-core`` even when the ``admin`` extra is not installed.
+"""
+
+from __future__ import annotations
+
+from src._core.infrastructure.admin.theme import (
+    EMPTY_DISPLAY,
+    AdminClasses,
+    AdminColors,
+    AdminMetrics,
+    AdminVars,
+    build_admin_css,
+)
+
+
+def _public_values(cls: type) -> list:
+    return [v for k, v in vars(cls).items() if not k.startswith("_")]
+
+
+def test_empty_display_is_em_dash():
+    assert EMPTY_DISPLAY == "—"
+
+
+def test_brand_colors_are_hex():
+    values = _public_values(AdminColors)
+    assert values, "AdminColors must define at least one color"
+    assert all(isinstance(v, str) and v.startswith("#") for v in values)
+
+
+def test_css_var_names_are_custom_properties():
+    values = _public_values(AdminVars)
+    assert values
+    assert all(isinstance(v, str) and v.startswith("--") for v in values)
+
+
+def test_helper_class_names_are_admin_prefixed():
+    values = _public_values(AdminClasses)
+    assert values
+    assert all(isinstance(v, str) and v.startswith("admin-") for v in values)
+
+
+def test_metrics_are_numeric():
+    values = _public_values(AdminMetrics)
+    assert values
+    assert all(isinstance(v, int) for v in values)
+
+
+def test_css_defines_light_and_dark_blocks():
+    css = build_admin_css()
+    assert ":root {" in css
+    assert ".body--dark {" in css
+
+
+def test_css_defines_every_token_in_both_themes():
+    """Each Quasar brand + semantic var must be set, and every dark-flippable
+    token must also appear in the .body--dark block."""
+    css = build_admin_css()
+    root_block = css.split(".body--dark")[0]
+    dark_block = css[css.index(".body--dark") :]
+
+    # Quasar brand vars live in :root (brand is theme-independent here).
+    for var in (
+        AdminVars.Q_PRIMARY,
+        AdminVars.Q_NEGATIVE,
+        AdminVars.Q_POSITIVE,
+    ):
+        assert var in root_block
+
+    # Semantic surfaces must be defined in BOTH light and dark so they flip.
+    for var in (
+        AdminVars.HEADER_BG,
+        AdminVars.DRAWER_BG,
+        AdminVars.NAV_ACTIVE,
+        AdminVars.SURFACE,
+        AdminVars.TEXT_MUTED,
+        AdminVars.SUCCESS_BG,
+        AdminVars.ROW_ALT,
+    ):
+        assert var in root_block, f"{var} missing from :root"
+        assert var in dark_block, f"{var} missing from .body--dark"
+
+
+def test_css_defines_helper_class_selectors():
+    css = build_admin_css()
+    for cls in (
+        AdminClasses.HEADER,
+        AdminClasses.DRAWER,
+        AdminClasses.NAV_ACTIVE,
+        AdminClasses.ACCENT_ICON,
+        AdminClasses.FIELD_LABEL,
+        AdminClasses.MUTED,
+        AdminClasses.SUCCESS_SURFACE,
+        AdminClasses.GRID,
+        AdminClasses.GRID_COMPACT,
+        AdminClasses.PRE,
+        AdminClasses.HIDDEN,
+    ):
+        assert f".{cls}" in css, f"selector .{cls} missing from CSS"
+
+
+def test_css_styles_alternating_grid_rows():
+    css = build_admin_css()
+    assert ".ag-row-odd" in css

--- a/tests/unit/_core/infrastructure/admin/test_theme.py
+++ b/tests/unit/_core/infrastructure/admin/test_theme.py
@@ -8,7 +8,9 @@ import lazy inside ``install_admin_theme_css`` — so they run under
 from __future__ import annotations
 
 from src._core.infrastructure.admin.theme import (
+    DEFAULT_PALETTE,
     EMPTY_DISPLAY,
+    PALETTES,
     AdminClasses,
     AdminColors,
     AdminMetrics,
@@ -109,3 +111,25 @@ def test_css_styles_alternating_grid_rows_via_theming_vars():
     css = build_admin_css()
     assert "--ag-odd-row-background-color" in css
     assert "--ag-row-hover-color" in css
+
+
+def test_default_palette_is_known():
+    assert DEFAULT_PALETTE in PALETTES
+
+
+def test_each_palette_builds_valid_css_with_both_blocks():
+    for palette in PALETTES:
+        css = build_admin_css(palette)
+        assert ":root {" in css and ".body--dark {" in css
+        # Every semantic surface defined in both themes for every palette.
+        for var in (AdminVars.HEADER_BG, AdminVars.SURFACE, AdminVars.ROW_ALT):
+            assert css.count(var) >= 2, f"{var} not in both blocks for {palette}"
+
+
+def test_palettes_are_visually_distinct():
+    """The two presets must differ (so previewing them is meaningful)."""
+    assert build_admin_css("default") != build_admin_css("slate")
+
+
+def test_unknown_palette_falls_back_to_default():
+    assert build_admin_css("does-not-exist") == build_admin_css(DEFAULT_PALETTE)

--- a/tests/unit/_core/infrastructure/admin/test_theme.py
+++ b/tests/unit/_core/infrastructure/admin/test_theme.py
@@ -126,10 +126,30 @@ def test_each_palette_builds_valid_css_with_both_blocks():
             assert css.count(var) >= 2, f"{var} not in both blocks for {palette}"
 
 
-def test_palettes_are_visually_distinct():
-    """The two presets must differ (so previewing them is meaningful)."""
-    assert build_admin_css("default") != build_admin_css("slate")
+def test_all_presets_present():
+    assert set(PALETTES) == {"default", "linear", "shadcn", "supabase"}
+
+
+def test_presets_are_visually_distinct():
+    """Every preset must render distinct CSS (so previewing them is meaningful)."""
+    rendered = {p: build_admin_css(p) for p in PALETTES}
+    assert len(set(rendered.values())) == len(PALETTES)
 
 
 def test_unknown_palette_falls_back_to_default():
     assert build_admin_css("does-not-exist") == build_admin_css(DEFAULT_PALETTE)
+
+
+def test_css_defines_style_tokens_and_component_overrides():
+    """Style presets drive shape/elevation tokens + Quasar component overrides."""
+    css = build_admin_css()
+    for var in (
+        AdminVars.RADIUS,
+        AdminVars.SHADOW,
+        AdminVars.CARD_BORDER,
+        AdminVars.BG,
+    ):
+        assert var in css, f"{var} missing from CSS"
+    # Quasar components are restyled globally so every page inherits the look.
+    assert ".q-card" in css
+    assert ".admin-header .q-btn" in css  # header text is token-driven, not white

--- a/tests/unit/_core/infrastructure/admin/test_theme.py
+++ b/tests/unit/_core/infrastructure/admin/test_theme.py
@@ -96,12 +96,16 @@ def test_css_defines_helper_class_selectors():
         AdminClasses.SUCCESS_SURFACE,
         AdminClasses.GRID,
         AdminClasses.GRID_COMPACT,
+        AdminClasses.PAGINATION,
+        AdminClasses.EMPTY_STATE,
         AdminClasses.PRE,
         AdminClasses.HIDDEN,
     ):
         assert f".{cls}" in css, f"selector .{cls} missing from CSS"
 
 
-def test_css_styles_alternating_grid_rows():
+def test_css_styles_alternating_grid_rows_via_theming_vars():
+    """NiceGUI 3.x quartz theme reads --ag-* custom properties, not .ag-row-odd."""
     css = build_admin_css()
-    assert ".ag-row-odd" in css
+    assert "--ag-odd-row-background-color" in css
+    assert "--ag-row-hover-color" in css

--- a/tests/unit/_core/infrastructure/admin/test_theme.py
+++ b/tests/unit/_core/infrastructure/admin/test_theme.py
@@ -58,26 +58,26 @@ def test_css_defines_light_and_dark_blocks():
 
 
 def test_css_defines_every_token_in_both_themes():
-    """Each Quasar brand + semantic var must be set, and every dark-flippable
-    token must also appear in the .body--dark block."""
+    """Chrome + brand live in :root (constant); content surfaces flip in dark."""
     css = build_admin_css()
     root_block = css.split(".body--dark")[0]
     dark_block = css[css.index(".body--dark") :]
 
-    # Quasar brand vars live in :root (brand is theme-independent here).
+    # Brand + dark-chrome tokens are :root-only (constant across light/dark).
     for var in (
         AdminVars.Q_PRIMARY,
         AdminVars.Q_NEGATIVE,
-        AdminVars.Q_POSITIVE,
-    ):
-        assert var in root_block
-
-    # Semantic surfaces must be defined in BOTH light and dark so they flip.
-    for var in (
         AdminVars.HEADER_BG,
         AdminVars.DRAWER_BG,
+        AdminVars.DRAWER_TEXT,
         AdminVars.NAV_ACTIVE,
+    ):
+        assert var in root_block, f"{var} missing from :root"
+
+    # Content surfaces must be defined in BOTH light and dark so they flip.
+    for var in (
         AdminVars.SURFACE,
+        AdminVars.BORDER,
         AdminVars.TEXT_MUTED,
         AdminVars.SUCCESS_BG,
         AdminVars.ROW_ALT,

--- a/tests/unit/_core/infrastructure/admin/test_theme_smoke.py
+++ b/tests/unit/_core/infrastructure/admin/test_theme_smoke.py
@@ -1,0 +1,57 @@
+"""Smoke tests that exercise theme code paths needing nicegui (#193).
+
+Gated on the ``admin`` extra via ``importorskip`` so they are skipped on a
+minimal install, matching the per-domain admin config tests.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("nicegui")
+
+from src._core.infrastructure.admin import theme  # noqa: E402
+from src._core.infrastructure.admin.base_admin_page import (  # noqa: E402
+    BaseAdminPage,
+    ColumnConfig,
+)
+from src._core.infrastructure.admin.theme import AdminMetrics  # noqa: E402
+
+
+def test_install_admin_theme_css_is_idempotent(monkeypatch: pytest.MonkeyPatch):
+    """install_admin_theme_css injects once and no-ops on repeat calls."""
+    calls: list[bool] = []
+
+    def _fake_add_css(content: str, *, shared: bool = False) -> None:
+        calls.append(shared)
+
+    from nicegui import ui
+
+    monkeypatch.setattr(ui, "add_css", _fake_add_css)
+    # Reset the module-level guard so the test is order-independent.
+    monkeypatch.setattr(theme, "_theme_css_installed", False)
+
+    theme.install_admin_theme_css()
+    theme.install_admin_theme_css()
+
+    assert calls == [True], "CSS must be injected exactly once, with shared=True"
+
+
+def test_build_column_defs_apply_min_width_and_flex():
+    page = BaseAdminPage(
+        domain_name="t",
+        display_name="T",
+        columns=[
+            ColumnConfig(field_name="id", header_name="ID", width=80),
+            ColumnConfig(field_name="name", header_name="Name"),
+        ],
+    )
+    defs = {d["field"]: d for d in page.build_column_defs()}
+
+    # Explicit width is honored exactly; no flex / minWidth floor applied.
+    assert defs["id"]["width"] == 80
+    assert "flex" not in defs["id"]
+    assert "minWidth" not in defs["id"]
+    # Width-less column flexes to fill, with a sane minimum.
+    assert defs["name"]["flex"] == 1
+    assert defs["name"]["minWidth"] == AdminMetrics.GRID_MIN_COL_WIDTH


### PR DESCRIPTION
## Related Issue
- Closes #193

## Change Summary
Centralizes the NiceGUI admin dashboard styling and adds a modern shell, replacing the hardcoded Quasar/Tailwind classes scattered across the shell and every page.

- **Theme tokens** (`src/_core/infrastructure/admin/theme.py`): `--q-*` (Quasar brand) + `--admin-*` (semantic + style) CSS variables under `:root` / `.body--dark`, injected once app-wide via `ui.add_css(shared=True)` so they reach every page (login/setup/error included). Four style presets (`default`/`linear`/`shadcn`/`supabase`) via `ADMIN_THEME_PALETTE`.
- **Dark mode**: `ui.run_with(dark=ADMIN_DARK_MODE_DEFAULT)` controls first paint (None = follow OS); a header toggle flips `body--dark` with no reload, persisted in `app.storage.user`.
- **Shell redesign**: dark sidebar with section grouping (Operations / Management), branded header (`ADMIN_BRAND_NAME`), responsive hamburger, branded login.
- **Centralization**: grid height / row-height / column defaults in `BaseAdminPage`; all pages de-hardcoded; empty-state, `—` null display, alternating rows.
- **Enforcement**: AST guards — no hardcoded color classes / inline grid heights (`test_no_hardcoded_styles.py`); existing auth-first + no-`str(exc)`-leak guards stay green.

New settings: `ADMIN_DARK_MODE_DEFAULT`, `ADMIN_THEME_PALETTE`, `ADMIN_BRAND_NAME` (env examples documented). `admin` extra stays optional.

## Type of Change
- [x] feat: New feature

## Checklist
- [x] Architecture rules followed (no Domain -> Infrastructure imports)
- [x] Tests pass (`make check-core`: 1128 passed)
- [x] Linting passes (`ruff check src/`)

## How to Test
```
uv sync --extra admin && ADMIN_THEME_PALETTE=default make quickstart
```
Toggle dark in the header (flips with no reload); reload follows OS preference. Verify login/dashboard/list/detail render themed.

## Review provenance
Codex (gpt-5.5, xhigh) cross-reviewed the plan (initial NO-GO): corrected the dark-flash, per-page-`ui.colors`, and AG-Grid-theme premises against installed NiceGUI 3.9; persisted-dark-no-flash deferred (documented follow-up).

## Governor Footer
- trigger: no
- reviewer: codex-cli
- rounds: 1
- r-points-fixed: 3
- r-points-deferred: 1
- r-points-rejected: 0
- touched-adr-consequences: none
- pr-scope-notes: src-only theming; touches no Tier A/B/C governor paths (design-system docs/skills land in the stacked PR)
- final-verdict: merge-ready
- links: n/a
