### PR TITLE
feat(admin): admin design system — component library + Wanted Sans + conventions (#193)

### DIFF
--- a/.agents/skills/add-admin-page/SKILL.md
+++ b/.agents/skills/add-admin-page/SKILL.md
@@ -19,3 +19,7 @@ metadata:
 4. Create config file and page route file in separate directories.
 5. Keep `BaseAdminPage` in config only; keep `@ui.page` in page only.
 6. Mask sensitive fields and do not add manual bootstrap registration.
+7. Custom / non-CRUD pages compose `admin.components` builders (never raw
+   `ui.card`/`ui.aggrid`/`ui.dialog`); every route uses `@admin_error_boundary`
+   and `require_auth*` as its first statement. See
+   `docs/ai/shared/admin-design-system.md`.

--- a/.claude/rules/commands.md
+++ b/.claude/rules/commands.md
@@ -1,6 +1,6 @@
 # Suggested Commands
 
-> Last synced: 2026-06-01 via #218 (admin login note re-pointed to the admin_identity realm; no new CLI/make targets).
+> Last synced: 2026-06-02 via #193 (admin UI/UX + design system; added ADMIN_THEME_PALETTE / ADMIN_BRAND_NAME / ADMIN_DARK_MODE_DEFAULT env vars to the Admin Dashboard section; no new make targets).
 > Purpose: Quick reference for Claude Code when executing shell commands.
 > Also referenced when running Skills.
 > Default Flow context: see [`AGENTS.md` § Default Coding Flow](../../AGENTS.md#default-coding-flow). The commands below are consulted by the `implement` and `verify` steps; this file is **not** a primary entry point in the Default Flow.
@@ -139,4 +139,9 @@ uv sync --extra admin   # install; → http://127.0.0.1:8001/admin
 # Login: admin_identity-realm credential check (#218/ADR 049; separate from customer auth)
 # Seed admin: ADMIN_BOOTSTRAP_USERNAME/EMAIL/PASSWORD env vars (idempotent on boot, into admin_identity)
 # If not installed: server boots normally, emits admin_mount_skipped log
+
+# UI theming (#193): style preset + brand + initial dark mode
+ADMIN_THEME_PALETTE=slate uv run python run_server_local.py --env local   # default|linear|shadcn|supabase
+ADMIN_BRAND_NAME="Acme Admin" ...      # header/login brand text
+ADMIN_DARK_MODE_DEFAULT=true ...       # unset=follow OS; true/false to force
 ```

--- a/.claude/rules/project-overview.md
+++ b/.claude/rules/project-overview.md
@@ -1,6 +1,7 @@
 # Project Overview
 
-> Last synced: 2026-06-01 via #218 (admin-identity realm separation reviewed; App Entrypoints unchanged — the new `admin_identity` domain is auto-discovered, and the `src/_apps/admin/` entrypoint is unchanged. New `ADMIN_JWT_*` settings + realm-collapse validation added to `src/_core/config.py`; admin login provider now backed by `admin_identity` instead of the user table.)
+> Last synced: 2026-06-02 via #193 (admin UI/UX + design system). Admin shell is now token-driven: `src/_core/infrastructure/admin/theme.py` (4 style presets + dark mode + Wanted Sans) + a `components/` builder library; pages compose builders (see `docs/ai/shared/admin-design-system.md`). New admin-shell settings in `config.py`: `ADMIN_DARK_MODE_DEFAULT` (None=follow OS), `ADMIN_THEME_PALETTE` (default|linear|shadcn|supabase), `ADMIN_BRAND_NAME`. Entrypoints unchanged.
+> Prior: 2026-06-01 via #218 (admin-identity realm separation; `ADMIN_JWT_*` settings + realm-collapse validation; admin login backed by `admin_identity`).
 > For tech stack, refer to project-dna.md §8; for layer structure, refer to §1.
 > For the Optional infra toggle surface (env var → disabled behavior per infra), see AGENTS.md "Optional Infrastructure Toggles" + [ADR 042](../../docs/history/042-optional-infrastructure-di-pattern.md).
 > This file only contains **project-level context** not covered in project-dna.md.
@@ -11,7 +12,7 @@ AI Agent Backend Platform built on FastAPI with DDD modular layered architecture
 ## App Entrypoints
 - Server: `src/_apps/server/` — FastAPI (uvicorn)
 - Worker: `src/_apps/worker/` — Taskiq (broker abstraction: SQS/RabbitMQ/InMemory)
-- Admin: `src/_apps/admin/` — NiceGUI (mounted on server via ui.run_with) — **mounted only when the `admin` extra is installed**; otherwise the server boots normally and emits only an `admin_mount_skipped` structured log line (#104)
+- Admin: `src/_apps/admin/` — NiceGUI (mounted on server via ui.run_with) — **mounted only when the `admin` extra is installed**; otherwise the server boots normally and emits only an `admin_mount_skipped` structured log line (#104). UI follows the admin design system (token theme + `components/` builders, #193).
 - AWS infrastructure (ObjectStorage/DynamoDB/S3Vectors) requires the `aws` extra. If the relevant env vars are unset, the lazy import never fires, so boot succeeds without the extra (#104 Part 2)
 
 ## Dependency Direction

--- a/.claude/skills/add-admin-page/SKILL.md
+++ b/.claude/skills/add-admin-page/SKILL.md
@@ -21,5 +21,16 @@ Domain name: $ARGUMENTS
 2. Implementation — directory structure → admin config → page routes
 3. Verification — pre-commit, import check, server start
 
+## Core Rules
+- CRUD pages are config-only `BaseAdminPage` instances — they inherit the design
+  system automatically (the base class renders via the component builders).
+- **Custom / non-CRUD pages MUST compose `admin.components` builders** (`c.page_header`,
+  `c.card`, `c.stat_card`, `c.data_grid`, `c.confirm_dialog`, …) — never raw
+  `ui.card` / `ui.aggrid` / `ui.dialog` for those shapes, and never hardcoded
+  color classes or inline grid heights (AST-guarded).
+- Every route: `@admin_error_boundary(...)` + `require_auth*` as the first statement.
+- A new shared UI shape gets a builder in `components/`, not an inline page helper.
+
 Read `docs/ai/shared/skills/add-admin-page.md` for detailed steps and code templates.
-Also refer to `docs/ai/shared/project-dna.md` §11 for admin page pattern.
+Refer to `docs/ai/shared/admin-design-system.md` for the component catalog + DO/DON'T,
+and `docs/ai/shared/project-dna.md` §11 for the admin page DI pattern.

--- a/docs/ai/shared/admin-design-system.md
+++ b/docs/ai/shared/admin-design-system.md
@@ -1,0 +1,101 @@
+# Admin Design System
+
+How to build NiceGUI admin pages so they share one consistent, modern look and
+stay easy to extend. Introduced with #193.
+
+## Principles
+
+- **Intuitive over classic.** Favor clear hierarchy, whitespace, and modern
+  affordances over dense, rigid forms.
+- **Token-driven.** All color / shape / elevation / typography come from
+  `theme.py` tokens. Pages reference `AdminClasses` / `AdminMetrics` or Quasar
+  semantic props (`color=primary`, `text-negative`) — **never** raw hex or
+  Quasar palette classes (`bg-blue-800`, `text-grey-7`, …). This is enforced by
+  `tests/unit/_core/infrastructure/admin/test_no_hardcoded_styles.py`.
+- **One implementation per shape.** Every repeated UI shape has exactly one
+  builder in the component library. If you reach for `ui.card()` / `ui.dialog()`
+  / `ui.aggrid()` directly in a page, check the catalog first.
+- **Small, sharp set.** Prefer extending an existing builder's kwargs over
+  adding a near-duplicate. A new builder needs a second real call site.
+
+## Layering
+
+```
+theme.py            tokens (AdminColors / AdminVars / AdminMetrics / AdminClasses)
+   ▲ consumed by    + build_admin_css() presets + Wanted Sans font
+components/         builders — the ONLY place tokens become elements
+   ▲ consumed by
+base_admin_page.py  layout.py        interface/admin + _apps/admin pages
+```
+
+The dependency is one-directional: `components/` consumes `theme.py`; pages and
+`BaseAdminPage` consume `components/`. **Components must never import
+`base_admin_page`** (cycle). Value formatting / masking / column selection stay
+in the caller; builders only render what they are given.
+
+## Component catalog
+
+Import surface: `from src._core.infrastructure.admin import components as c`.
+
+| Builder | Kind | Use |
+|---------|------|-----|
+| `c.page_header(title, *, subtitle=, back_to=, actions=)` | leaf | Page heading; `back_to` adds a back button, `actions` a right-aligned slot |
+| `c.card(*, clickable_to=, classes=)` | context mgr | A themed card; `clickable_to` makes the whole card navigate |
+| `c.section(title=)` | context mgr | A titled content section |
+| `c.stat_card(label, value, *, icon=)` | leaf | Metric tile (caption + value) |
+| `c.field_row(label, value, *, is_empty=)` | leaf | One label/value detail row (value pre-formatted) |
+| `c.text_field / textarea_field / number_field / select_field` | leaf | Form inputs — always `outlined` |
+| `c.action_dialog(title, *, width=, subtitle=)` | context mgr | Dialog with arbitrary body; yields `(dialog, card)`; opens on exit |
+| `c.confirm_dialog(title, message, *, on_confirm, on_success=, danger=)` | async | Confirm-an-action; see contract below |
+| `c.data_grid(column_defs, row_data, *, compact=, row_click_to=, on_cell_click=, on_row_click=)` | leaf | AG Grid with the admin theme + shared defaults |
+| `c.pagination(*, current, total_pages, on_prev, on_next)` | leaf | Prev / page / next row |
+| `c.empty_state(icon=)` | context mgr | Centered empty placeholder; add the message inside |
+| `c.toast_success / toast_warning / toast_error(message)` | leaf | Standardized `ui.notify` |
+| `c.report_error(exc, *, context)` | async | Route a caught exception through the sanitizing `AdminErrorHandler` |
+
+### `confirm_dialog` contract (important)
+
+`on_confirm()` does the work, owns its own try/except + audit + notifications,
+and **returns `success: bool`**. The builder owns only the loading state and
+ordering: it wraps `on_confirm` in `button_loading`, and **only on `True`**
+closes the dialog and then awaits `on_success` (e.g. a list refresh). On
+`False` the dialog stays open. Never close / navigate from inside `on_confirm`.
+
+## Recipe: build a new admin page
+
+1. **Standard CRUD** → just a `BaseAdminPage` config (no custom rendering). The
+   base class already routes through the component builders, so you get the
+   system for free. Use `/add-admin-page`.
+2. **Custom page** (summary, dashboard widget, playground):
+   - `require_auth*` is the **first statement** (enforced by
+     `test_route_coverage.py`).
+   - `@admin_error_boundary(context=...)` on the route.
+   - `admin_layout(...)` for the shell, then compose `c.page_header`, `c.card` /
+     `c.section`, `c.stat_card`, `c.data_grid`, … — never raw `ui.card` /
+     `ui.aggrid` for these shapes.
+3. **Write actions** → `c.confirm_dialog` (destructive) / `c.action_dialog`
+   (forms). `on_confirm` owns audit + notify; the builder owns close/refresh.
+
+## DO / DON'T
+
+**DO**
+- Use `c.text_field` (outlined enforced) and the other form builders.
+- Use `c.confirm_dialog` for destructive actions.
+- Surface caught exceptions via `c.report_error` (sanitized).
+- Add a new shared shape as a builder in `components/`, not an inline page helper.
+
+**DON'T**
+- Hardcode `bg-*` / `text-*` / `border-*` palette classes or inline `height: Npx`
+  on a grid (the AST guard fails).
+- Call `ui.notify(str(exc))` / `c.toast_error(str(exc))` — leaks internals.
+- Put `require_auth` anywhere but the first statement of the route.
+- Add a builder that wraps a single `ui.label` with no shared behavior.
+
+## Reference
+
+- Tokens: `src/_core/infrastructure/admin/theme.py`
+- Builders: `src/_core/infrastructure/admin/components/`
+- Base page: `src/_core/infrastructure/admin/base_admin_page.py`
+- Guards: `tests/unit/_core/infrastructure/admin/test_no_hardcoded_styles.py`,
+  `test_route_coverage.py`
+- Admin page DI pattern: `docs/ai/shared/project-dna.md` §11

--- a/docs/ai/shared/harness-asset-matrix.md
+++ b/docs/ai/shared/harness-asset-matrix.md
@@ -164,6 +164,7 @@ rather than primary entry points (`Overlay`).
 | `ai-infrastructure-overview.md` | Keep | Low | Medium |
 | `repo-facts.md` | Keep | Low | Medium |
 | `test-files.md` | Keep | Low | Medium |
+| `admin-design-system.md` | Keep | Low | Medium |
 | `planning-checklists.md` | Overlay | Low | Medium |
 | `drift-checklist.md` | Overlay | Low | Medium |
 | `onboarding-role-tracks.md` | Overlay | Low | Low |
@@ -745,13 +746,13 @@ Six rule files (5 Claude + 1 Codex). All `Keep` except `commands.md` which becom
 
 | Bucket | Count | Share | Notes |
 |---|---|---|---|
-| Keep | 52 | ~79% | Project-specific architecture / safety / reference value (incl. 4 design + 3 self-coherence-recovery process-governor artefacts + 2 Phase 2 #121 hooks + Phase 5 #124 shared governor package now extended by ADR 047 PR B-F with `sync_cosmetic.py`; ADR 047 PR B-F also added `tools/check_governor_footer.py` + `.github/workflows/governor-footer-lint.yml` in place of the removed `tools/check_g_closure.py`) |
+| Keep | 53 | ~79% | Project-specific architecture / safety / reference value (incl. admin-design-system.md #193 + 4 design + 3 self-coherence-recovery process-governor artefacts + 2 Phase 2 #121 hooks + Phase 5 #124 shared governor package now extended by ADR 047 PR B-F with `sync_cosmetic.py`; ADR 047 PR B-F also added `tools/check_governor_footer.py` + `.github/workflows/governor-footer-lint.yml` in place of the removed `tools/check_g_closure.py`) |
 | Overlay | 13 | ~20% | Process discipline now routed by Default Flow (Phase 3 #122 adds 3 verify-first; Phase 4 #123 adds 2 completion-gate hooks; Phase 5 #124 reduces those hooks to thin shims without changing buckets) |
 | Replace | 0 | 0% | None in initial inventory; reserved for future passes |
 | Drop | 1 | ~1% | `tools/check_g_closure.py` retired by ADR 047 PR B-F (Guard G enforcement target moved to PR-description Governor Footer; `tools/check_governor_footer.py` is the replacement and is counted under `Keep`). |
-| **Total** | **66** | 100% | |
+| **Total** | **67** | 100% | |
 
-Counting note: `Tier 0=9` (8 + ADR 045 + `.github/pull_request_template.md`), `Tier 1=20` (12 reference + 3 design living docs + `governor-review-log/` directory + `governor-paths.md` + `.agents/shared/governor/` package + `tools/check_g_closure.py` historical-Drop + `tools/check_governor_footer.py` + `docs/history/047-governor-review-provenance-consolidation.md`), `Tier 2=14` (skill rows; each row covers all 3 wrapper layers), `Tier 3=18` (Phase 4 #123 added `.claude/hooks/completion_gate.py` + `.codex/hooks/completion_gate.py`; Phase 3 = 16, Phase 2 = 13, Phase 1 = 10; Phase 5 #124 converts 6 of these to thin shims without changing the count), `Tier 4=6` — sum 67. The 66 figure above excludes `.claude/settings.local.json` from the active-share count because it is `.gitignore`d. The bucket-share percentages use 66 as the denominator.
+Counting note: `Tier 0=9` (8 + ADR 045 + `.github/pull_request_template.md`), `Tier 1=21` (13 reference incl. `admin-design-system.md` + 3 design living docs + `governor-review-log/` directory + `governor-paths.md` + `.agents/shared/governor/` package + `tools/check_g_closure.py` historical-Drop + `tools/check_governor_footer.py` + `docs/history/047-governor-review-provenance-consolidation.md`), `Tier 2=14` (skill rows; each row covers all 3 wrapper layers), `Tier 3=18` (Phase 4 #123 added `.claude/hooks/completion_gate.py` + `.codex/hooks/completion_gate.py`; Phase 3 = 16, Phase 2 = 13, Phase 1 = 10; Phase 5 #124 converts 6 of these to thin shims without changing the count), `Tier 4=6` — sum 68. The 67 figure above excludes `.claude/settings.local.json` from the active-share count because it is `.gitignore`d. The bucket-share percentages use 67 as the denominator.
 
 This distribution matches the "Mostly Local with Philosophy Overlay" model declared in [ADR 045 §D4](../../history/045-hybrid-harness-target-architecture.md). The `Replace` and `Drop` columns are both empty: no asset's content is being rewritten, and self-verification during cross-link work showed that the only `Drop` candidate identified during the first triage was actually an active component (a sh-wrapper `.py` pair).
 
@@ -793,3 +794,4 @@ The following self-checks must pass before this matrix is treated as authoritati
 - 2026-04-29 — `/sync-guidelines` table parity pass: added `.claude/hooks/completion_gate.py` and `.codex/hooks/completion_gate.py` to the Tier 3 quick-reference table. Detail sections and counts were already present from Phase 4, so there is no count change.
 - 2026-05-02 — ADR 047 PR B-F (#159): `tools/check_g_closure.py` retired (Drop); `tools/check_governor_footer.py` + `.github/workflows/governor-footer-lint.yml` added; `docs/history/047-governor-review-provenance-consolidation.md` added to Tier 1; `.agents/shared/governor/sync_cosmetic.py` added to Phase 5 package. `governor-review-log/` relocated to `docs/history/archive/governor-review-log/` (PR #161). Bucket-share ~79% Keep / ~20% Overlay / ~1% Drop.
 - 2026-05-06 — PR-B.2: LOC corrections (project-dna.md 906→976, scaffolding-layers.md 295→299, ai-infrastructure-overview.md 117→162, drift-checklist.md 189→220, test-files.md 27→33); governor-paths.md Notes updated to reference Governor Footer model (ADR 047, `governor-review-log/` per-PR obligation retired); stop-sync-reminder.sh Notes updated past-tense for Phase 4 + IC-11 Option A; stop-sync-reminder.py role description refreshed for AGENT_LOCALE 5-responsibility orchestrator (#133).
+- 2026-06-02 — #193: added `docs/ai/shared/admin-design-system.md` (Tier 1, Keep) — the admin design-system guide (tokens + component builders + conventions) backing the `/add-admin-page` skill. Total 66 → 67 (Keep 52 → 53); Tier 1 20 → 21. Bucket-share remains ~79% Keep / ~20% Overlay.

--- a/docs/ai/shared/project-dna.md
+++ b/docs/ai/shared/project-dna.md
@@ -653,6 +653,11 @@ class {Name}AlreadyExistsException(BaseCustomException):
 
 ## §11. Admin Page Pattern
 
+> Design system (#193): admin UI is token-driven (`_core/infrastructure/admin/theme.py`)
+> and composed from the component builders in `_core/infrastructure/admin/components/`.
+> CRUD pages are config-only and inherit it via `BaseAdminPage`; custom pages compose
+> the builders. Catalog + DO/DON'T: [`admin-design-system.md`](admin-design-system.md).
+
 ### File Structure & Naming Convention
 
 ```

--- a/docs/ai/shared/skills/add-admin-page.md
+++ b/docs/ai/shared/skills/add-admin-page.md
@@ -27,6 +27,7 @@ After implementation, route to:
 - `src/user/interface/admin/configs/user_admin_config.py` — config pattern
 - `src/user/interface/admin/pages/user_page.py` — page route pattern
 - Admin Page Pattern: refer to `docs/ai/shared/project-dna.md` section 11
+- **Design system** (tokens + component builders + DO/DON'T): `docs/ai/shared/admin-design-system.md`. Custom (non-CRUD) pages MUST compose `admin.components` builders, not raw `ui.*`.
 
 ## Implementation Order
 
@@ -79,6 +80,7 @@ from nicegui import ui
 
 from src._core.infrastructure.admin.auth import require_auth
 from src._core.infrastructure.admin.base_admin_page import BaseAdminPage
+from src._core.infrastructure.admin.error_handler import admin_error_boundary
 from src._core.infrastructure.admin.layout import admin_layout
 from src.{name}.interface.admin.configs.{name}_admin_config import {name}_admin_page
 
@@ -87,8 +89,9 @@ page_configs: list[BaseAdminPage] = []
 
 
 @ui.page("/admin/{name}")
+@admin_error_boundary(context="{name}_list")
 async def {name}_list_page(page: int = 1, search: str = ""):
-    session = await require_auth(page_key="{name}")
+    session = await require_auth(page_key="{name}")  # MUST be the first statement
     if session is None:
         return
     admin_layout(page_configs, current_domain="{name}", session=session)
@@ -96,13 +99,42 @@ async def {name}_list_page(page: int = 1, search: str = ""):
 
 
 @ui.page("/admin/{name}/{record_id}")
+@admin_error_boundary(context="{name}_detail")
 async def {name}_detail_page(record_id: int):
-    session = await require_auth(page_key="{name}")
+    session = await require_auth(page_key="{name}")  # MUST be the first statement
     if session is None:
         return
     admin_layout(page_configs, current_domain="{name}", session=session)
     await {name}_admin_page.render_detail(record_id=record_id)
 ```
+
+> `@admin_error_boundary` is required on every admin route (project-dna §). The
+> auth gate must be the route's **first statement** — enforced by
+> `tests/unit/_core/infrastructure/admin/test_route_coverage.py`.
+
+### Custom / non-CRUD pages
+
+For summary pages, dashboard widgets, playgrounds, or write actions, do **not**
+hand-roll `ui.card` / `ui.aggrid` / `ui.dialog`. Compose the design-system
+builders so the page matches every other admin surface:
+
+```python
+from src._core.infrastructure.admin import components as c
+
+@ui.page("/admin/{name}/summary")
+@admin_error_boundary(context="{name}_summary")
+async def {name}_summary_page():
+    session = await require_auth(page_key="{name}")
+    if session is None:
+        return
+    admin_layout(page_configs, current_domain="{name}", session=session)
+    c.page_header("{Name} Summary")
+    with ui.row().classes("q-gutter-md q-mb-md"):
+        c.stat_card("Total", total)
+    c.data_grid(column_defs, rows, compact=True)
+```
+
+Catalog + DO/DON'T + the `confirm_dialog` contract: `docs/ai/shared/admin-design-system.md`.
 
 ## Core Rules
 - Config file contains ONLY the `BaseAdminPage` instance declaration (no routes, no `ui` import)

--- a/src/_apps/admin/pages/accounts.py
+++ b/src/_apps/admin/pages/accounts.py
@@ -1,5 +1,6 @@
 from nicegui import ui
 
+from src._core.infrastructure.admin import components as c
 from src._core.infrastructure.admin.audit import (
     AdminAction,
     AuditResult,
@@ -59,9 +60,9 @@ async def accounts_page():
 
     # ── Create admin form ──
     with ui.expansion("Create New Admin", icon="person_add").classes("w-full q-mb-md"):
-        new_username = ui.input("Username").classes("full-width")
-        new_full_name = ui.input("Full Name").classes("full-width")
-        new_email = ui.input("Email").classes("full-width")
+        new_username = c.text_field("Username").classes("full-width")
+        new_full_name = c.text_field("Full Name").classes("full-width")
+        new_email = c.text_field("Email").classes("full-width")
 
         ui.label("Permissions").classes("text-subtitle2 q-mt-sm")
         perm_checkboxes: dict[str, ui.checkbox] = {}
@@ -154,10 +155,10 @@ def _render_admin_list(
                 with ui.row().classes("q-gutter-sm"):
                     # ── Edit permissions button ──
                     async def open_edit_perms(a=admin):
-                        with ui.dialog() as dlg, ui.card():
-                            ui.label("Edit permissions: " + a.username).classes(
-                                "text-h6 q-mb-sm"
-                            )
+                        with c.action_dialog("Edit permissions: " + a.username) as (
+                            dlg,
+                            _card,
+                        ):
                             perm_cbs: dict[str, ui.checkbox] = {}
                             with ui.row().classes("q-gutter-sm"):
                                 for key in all_keys:
@@ -221,12 +222,11 @@ def _render_admin_list(
                                 dlg.close()
                                 await refresh_cb()
 
-                            with ui.row().classes("q-mt-md"):
+                            with ui.row().classes("q-mt-md justify-end q-gutter-sm"):
+                                ui.button("Cancel", on_click=dlg.close).props("flat")
                                 save_btn = ui.button("Save", on_click=save_perms).props(
                                     "color=primary"
                                 )
-                                ui.button("Cancel", on_click=dlg.close).props("flat")
-                        dlg.open()
 
                     ui.button(icon="edit", on_click=open_edit_perms).props(
                         "flat round"
@@ -234,71 +234,57 @@ def _render_admin_list(
 
                     # ── Remove admin button ──
                     async def open_remove_confirm(a=admin):
-                        with ui.dialog() as dlg, ui.card():
-                            ui.label("Remove admin: " + a.username + "?").classes(
-                                "text-h6"
-                            )
-                            ui.label("This action cannot be undone.").classes(
-                                "text-caption text-negative q-mb-md"
-                            )
-
-                            async def confirm_remove(a=a):
-                                success = False
-                                audit_failure_reason: str | None = None
-                                async with button_loading(remove_btn):
-                                    try:
-                                        await use_case.delete_account(
-                                            admin_id=a.id,
-                                            requesting_admin_id=requesting_admin_id,
-                                        )
-                                        success = True
-                                    except AdminSelfActionForbiddenException as exc:
-                                        audit_failure_reason = exc.error_code
-                                        ui.notify(
-                                            "Cannot remove your own account",
-                                            type="negative",
-                                        )
-                                    except AdminLastAccountsGuardException as exc:
-                                        audit_failure_reason = exc.error_code
-                                        ui.notify(
-                                            "Cannot remove the last accounts-permission holder",
-                                            type="negative",
-                                        )
-                                    except Exception as exc:  # noqa: BLE001 - delegated
-                                        audit_failure_reason = (
-                                            getattr(exc, "error_code", None)
-                                            or type(exc).__name__
-                                        )
-                                        await AdminErrorHandler.handle(
-                                            exc, context="admin_account_delete"
-                                        )
-                                # Audit + dlg.close() / refresh outside the loading
-                                # context (§11 convention).
-                                await get_audit_logger().log(
-                                    action=AdminAction.ACCOUNT_DELETE,
-                                    domain="user",
-                                    result=AuditResult.SUCCESS
-                                    if success
-                                    else AuditResult.FAILURE,
-                                    record_id=str(a.id),
-                                    before_state=safe_user_snapshot(a),
-                                    failure_reason=audit_failure_reason,
+                        # confirm_dialog owns loading + close/refresh ordering;
+                        # on_confirm owns the work, audit, and notifications and
+                        # returns success so the dialog closes + refreshes only
+                        # then (stays open on failure).
+                        async def _on_confirm(a=a) -> bool:
+                            success = False
+                            audit_failure_reason: str | None = None
+                            try:
+                                await use_case.delete_account(
+                                    admin_id=a.id,
+                                    requesting_admin_id=requesting_admin_id,
                                 )
-                                if success:
-                                    ui.notify(
-                                        "Admin '" + a.username + "' removed",
-                                        type="positive",
-                                    )
-                                dlg.close()
-                                if success:
-                                    await refresh_cb()
+                                success = True
+                            except AdminSelfActionForbiddenException as exc:
+                                audit_failure_reason = exc.error_code
+                                c.toast_error("Cannot remove your own account")
+                            except AdminLastAccountsGuardException as exc:
+                                audit_failure_reason = exc.error_code
+                                c.toast_error(
+                                    "Cannot remove the last accounts-permission holder"
+                                )
+                            except Exception as exc:  # noqa: BLE001 - delegated
+                                audit_failure_reason = (
+                                    getattr(exc, "error_code", None)
+                                    or type(exc).__name__
+                                )
+                                await c.report_error(
+                                    exc, context="admin_account_delete"
+                                )
+                            await get_audit_logger().log(
+                                action=AdminAction.ACCOUNT_DELETE,
+                                domain="user",
+                                result=AuditResult.SUCCESS
+                                if success
+                                else AuditResult.FAILURE,
+                                record_id=str(a.id),
+                                before_state=safe_user_snapshot(a),
+                                failure_reason=audit_failure_reason,
+                            )
+                            if success:
+                                c.toast_success("Admin '" + a.username + "' removed")
+                            return success
 
-                            with ui.row():
-                                remove_btn = ui.button(
-                                    "Remove", on_click=confirm_remove
-                                ).props("color=negative")
-                                ui.button("Cancel", on_click=dlg.close).props("flat")
-                        dlg.open()
+                        await c.confirm_dialog(
+                            "Remove admin: " + a.username + "?",
+                            "This action cannot be undone.",
+                            on_confirm=_on_confirm,
+                            on_success=refresh_cb,
+                            danger=True,
+                            confirm_label="Remove",
+                        )
 
                     is_self = admin.id == requesting_admin_id
                     disable_prop = "disable" if is_self else ""

--- a/src/_apps/admin/pages/audit_log.py
+++ b/src/_apps/admin/pages/audit_log.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from nicegui import ui
 
+from src._core.infrastructure.admin import components as c
 from src._core.infrastructure.admin.audit import (
     AdminAction,
     AuditLogDTO,
@@ -53,27 +54,20 @@ async def audit_log_page() -> None:
 
     # ── Filter bar ──────────────────────────────────────────────────────────
     with ui.row().classes("q-gutter-md q-mb-md items-end"):
-        username_input = (
-            ui.input("Username contains").props("outlined dense").classes("w-40")
-        )
-        action_select = (
-            ui.select(
-                {a.value: a.value for a in AdminAction},
-                label="Action",
-                multiple=True,
-                value=[],
-            )
-            .props("outlined dense use-chips")
-            .classes("w-56")
-        )
-        domain_input = (
-            ui.input("Domain (comma-sep)").props("outlined dense").classes("w-44")
-        )
+        username_input = c.text_field("Username contains").classes("w-40")
+        action_select = c.select_field(
+            "Action",
+            {a.value: a.value for a in AdminAction},
+            value=[],
+            multiple=True,
+            use_chips=True,
+        ).classes("w-56")
+        domain_input = c.text_field("Domain (comma-sep)").classes("w-44")
         result_toggle = ui.toggle(
             {"": "All", "SUCCESS": "Success", "FAILURE": "Failure"}, value=""
         )
-        since_input = ui.input("Since (ISO)").props("outlined dense").classes("w-44")
-        until_input = ui.input("Until (ISO)").props("outlined dense").classes("w-44")
+        since_input = c.text_field("Since (ISO)").classes("w-44")
+        until_input = c.text_field("Until (ISO)").classes("w-44")
         apply_btn = ui.button("Apply", on_click=lambda: _apply()).props("color=primary")
 
     grid_container = ui.column().classes("w-full")
@@ -154,30 +148,26 @@ def _render_grid(
     show_detail_cb,
 ) -> None:
     row_data = [r.model_dump(mode="json") for r in rows]
-    grid = ui.aggrid(
-        {
-            "columnDefs": [
-                {"headerName": "Time (UTC)", "field": "created_at", "width": 200},
-                {"headerName": "User", "field": "admin_username", "width": 140},
-                {"headerName": "Action", "field": "action", "width": 160},
-                {"headerName": "Domain", "field": "domain", "width": 100},
-                {"headerName": "Record", "field": "record_id", "width": 100},
-                {"headerName": "Result", "field": "result", "width": 100},
-                {"headerName": "Reason", "field": "failure_reason", "width": 180},
-                {"headerName": "IP", "field": "ip_address", "width": 130},
-            ],
-            "rowData": row_data,
-            "defaultColDef": {"resizable": True, "sortable": True},
-            "rowSelection": "single",
-        }
-    ).classes(f"w-full {AdminClasses.GRID}")
 
     async def _on_row_clicked(event) -> None:
         audit_id = event.args.get("data", {}).get("id")
         if isinstance(audit_id, int):
             await show_detail_cb(audit_id)
 
-    grid.on("rowClicked", _on_row_clicked)
+    c.data_grid(
+        [
+            {"headerName": "Time (UTC)", "field": "created_at", "width": 200},
+            {"headerName": "User", "field": "admin_username", "width": 140},
+            {"headerName": "Action", "field": "action", "width": 160},
+            {"headerName": "Domain", "field": "domain", "width": 100},
+            {"headerName": "Record", "field": "record_id", "width": 100},
+            {"headerName": "Result", "field": "result", "width": 100},
+            {"headerName": "Reason", "field": "failure_reason", "width": 180},
+            {"headerName": "IP", "field": "ip_address", "width": 130},
+        ],
+        row_data,
+        on_row_click=_on_row_clicked,
+    )
 
 
 def _render_pagination(state: dict[str, Any], on_prev, on_next) -> None:
@@ -195,14 +185,12 @@ def _render_pagination(state: dict[str, Any], on_prev, on_next) -> None:
 
 
 def _open_detail_dialog(dto: AuditLogDTO) -> None:
-    with ui.dialog() as dlg, ui.card().style("width: 800px; max-width: 95vw"):
-        ui.label(f"#{dto.id} · {dto.action.value} · {dto.result.value}").classes(
-            "text-h6"
-        )
-        created_iso = dto.created_at.isoformat() if dto.created_at else "—"
-        ui.label(f"{dto.admin_username} · {created_iso}").classes(
-            f"text-caption {AdminClasses.MUTED} q-mb-sm"
-        )
+    created_iso = dto.created_at.isoformat() if dto.created_at else "—"
+    with c.action_dialog(
+        f"#{dto.id} · {dto.action.value} · {dto.result.value}",
+        width="800px",
+        subtitle=f"{dto.admin_username} · {created_iso}",
+    ) as (dlg, _card):
         if dto.correlation_id:
             with ui.row().classes("items-center q-gutter-sm q-mb-sm"):
                 ui.label(f"Correlation: {dto.correlation_id}").classes("text-caption")
@@ -233,7 +221,6 @@ def _open_detail_dialog(dto: AuditLogDTO) -> None:
                     _safe_json(dto.after_state) or "(none)", language="json"
                 ).classes("w-full")
         ui.button("Close", on_click=dlg.close).props("color=primary").classes("q-mt-md")
-    dlg.open()
 
 
 def _safe_json(value: dict | None) -> str | None:

--- a/src/_apps/admin/pages/change_password.py
+++ b/src/_apps/admin/pages/change_password.py
@@ -1,5 +1,6 @@
 from nicegui import ui
 
+from src._core.infrastructure.admin import components as c
 from src._core.infrastructure.admin.audit import AdminAction, AuditResult
 from src._core.infrastructure.admin.audit.logger import get_audit_logger
 from src._core.infrastructure.admin.auth import (
@@ -42,15 +43,15 @@ async def change_password_page():
         else:
             ui.label("Change Password").classes("text-h5 q-mb-md")
 
-        current_pw = ui.input(
-            "Current password", password=True, password_toggle_button=True
-        ).classes("full-width")
-        new_pw = ui.input(
-            "New password (min 8 chars)", password=True, password_toggle_button=True
-        ).classes("full-width")
-        confirm_pw = ui.input(
-            "Confirm new password", password=True, password_toggle_button=True
-        ).classes("full-width")
+        current_pw = c.text_field("Current password", password=True).classes(
+            "full-width"
+        )
+        new_pw = c.text_field("New password (min 8 chars)", password=True).classes(
+            "full-width"
+        )
+        confirm_pw = c.text_field("Confirm new password", password=True).classes(
+            "full-width"
+        )
 
         async def do_change():
             if len(new_pw.value) < 8:

--- a/src/_apps/admin/pages/dashboard.py
+++ b/src/_apps/admin/pages/dashboard.py
@@ -1,5 +1,6 @@
 from nicegui import ui
 
+from src._core.infrastructure.admin import components as c
 from src._core.infrastructure.admin.auth import require_auth_allowlisted
 from src._core.infrastructure.admin.base_admin_page import BaseAdminPage
 from src._core.infrastructure.admin.error_handler import admin_error_boundary
@@ -16,42 +17,21 @@ async def dashboard_page():
     if session is None:
         return
     admin_layout(page_configs, current_domain="", session=session)
-    ui.label("Dashboard").classes("text-h4 q-mb-lg")
-    ui.label("Welcome to the Admin Dashboard").classes("text-subtitle1 q-mb-lg")
+    c.page_header("Dashboard", subtitle="Welcome to the Admin Dashboard")
 
     permissions = set(session.permissions)
     visible_configs = [pc for pc in page_configs if pc.domain_name in permissions]
 
+    def _nav_card(icon: str, label: str, target: str) -> None:
+        with c.card(clickable_to=target):
+            with ui.row().classes("items-center q-pa-sm"):
+                ui.icon(icon).classes("text-h4 text-primary")
+                ui.label(label).classes("text-h6")
+
     with ui.row().classes("q-gutter-md"):
         for pc in visible_configs:
-            with (
-                ui.card()
-                .classes("cursor-pointer")
-                .on(
-                    "click",
-                    lambda p=pc: ui.navigate.to(f"/admin/{p.domain_name}"),
-                )
-            ):
-                with ui.row().classes("items-center q-pa-sm"):
-                    ui.icon(pc.icon).classes("text-h4 text-primary")
-                    ui.label(pc.display_name).classes("text-h6")
-
+            _nav_card(pc.icon, pc.display_name, f"/admin/{pc.domain_name}")
         if "accounts" in permissions:
-            with (
-                ui.card()
-                .classes("cursor-pointer")
-                .on("click", lambda: ui.navigate.to("/admin/accounts"))
-            ):
-                with ui.row().classes("items-center q-pa-sm"):
-                    ui.icon("manage_accounts").classes("text-h4 text-primary")
-                    ui.label("Accounts").classes("text-h6")
-
+            _nav_card("manage_accounts", "Accounts", "/admin/accounts")
         if "audit_log" in permissions:
-            with (
-                ui.card()
-                .classes("cursor-pointer")
-                .on("click", lambda: ui.navigate.to("/admin/audit-log"))
-            ):
-                with ui.row().classes("items-center q-pa-sm"):
-                    ui.icon("fact_check").classes("text-h4 text-primary")
-                    ui.label("Audit Log").classes("text-h6")
+            _nav_card("fact_check", "Audit Log", "/admin/audit-log")

--- a/src/_apps/admin/pages/login.py
+++ b/src/_apps/admin/pages/login.py
@@ -2,6 +2,7 @@ from fastapi import Request
 from nicegui import app, ui
 
 from src._core.config import settings
+from src._core.infrastructure.admin import components as c
 from src._core.infrastructure.admin.auth import (
     AdminAuthProvider,
     get_admin_auth_provider,
@@ -33,12 +34,8 @@ def login_page(request: Request):
         ui.label("ADMIN").classes(f"{AdminClasses.MUTED} q-mb-md").style(
             "letter-spacing: 0.25em; font-size: 0.7rem"
         )
-        username = ui.input("Username").props("outlined").classes("full-width")
-        password = (
-            ui.input("Password", password=True, password_toggle_button=True)
-            .props("outlined")
-            .classes("full-width q-mt-sm")
-        )
+        username = c.text_field("Username").classes("full-width")
+        password = c.text_field("Password", password=True).classes("full-width q-mt-sm")
 
         async def try_login():
             target: str | None = None

--- a/src/_apps/admin/pages/setup.py
+++ b/src/_apps/admin/pages/setup.py
@@ -1,6 +1,7 @@
 from nicegui import app, ui
 
 from src._core.config import settings
+from src._core.infrastructure.admin import components as c
 from src._core.infrastructure.admin.audit import (
     AdminAction,
     AuditResult,
@@ -42,9 +43,9 @@ async def setup_page():
             f"text-subtitle2 q-mb-md {AdminClasses.MUTED}"
         )
 
-        username_input = ui.input("Username").classes("full-width")
-        full_name_input = ui.input("Full Name").classes("full-width")
-        email_input = ui.input("Email").classes("full-width")
+        username_input = c.text_field("Username").classes("full-width")
+        full_name_input = c.text_field("Full Name").classes("full-width")
+        email_input = c.text_field("Email").classes("full-width")
 
         result_card = ui.card().classes(
             f"w-full q-mt-md {AdminClasses.SUCCESS_SURFACE}"

--- a/src/_core/infrastructure/admin/base_admin_page.py
+++ b/src/_core/infrastructure/admin/base_admin_page.py
@@ -8,14 +8,11 @@ from nicegui import ui
 
 from src._core.domain.protocols.admin_service_protocol import AdminCrudServiceProtocol
 from src._core.domain.value_objects.query_filter import QueryFilter
+from src._core.infrastructure.admin import components as c
 from src._core.infrastructure.admin.audit import AdminAction, AuditResult
 from src._core.infrastructure.admin.audit.logger import get_audit_logger
 from src._core.infrastructure.admin.error_handler import AdminErrorHandler
-from src._core.infrastructure.admin.theme import (
-    EMPTY_DISPLAY,
-    AdminClasses,
-    AdminMetrics,
-)
+from src._core.infrastructure.admin.theme import EMPTY_DISPLAY, AdminMetrics
 
 if TYPE_CHECKING:
     from src._core.application.dtos.base_response import PaginationInfo
@@ -220,7 +217,7 @@ class BaseAdminPage:
 
     def render_list_header(self) -> None:
         """Hook: render list page heading."""
-        ui.label(f"{self.display_name} Management").classes("text-h5 q-mb-md")
+        c.page_header(f"{self.display_name} Management")
 
     def render_search_bar(self, search: str) -> None:
         """Hook: render search input if searchable_fields configured."""
@@ -234,23 +231,21 @@ class BaseAdminPage:
             params = f"?search={query}" if query else ""
             ui.navigate.to(f"/admin/{self.domain_name}{params}")
 
-        ui.input(
-            placeholder=f"Search by {field_labels}...",
+        c.text_field(
+            "Search",
             value=search,
-            on_change=lambda: None,
-        ).on("keydown.enter", _on_search).props("outlined dense clearable").classes(
-            "w-80 q-mb-sm"
-        )
+            placeholder=f"Search by {field_labels}...",
+            clearable=True,
+        ).on("keydown.enter", _on_search).classes("w-80 q-mb-sm")
 
     def render_empty_state(self, search: str = "") -> None:
         """Hook: render a friendly placeholder when the list has no records."""
-        with ui.column().classes(f"w-full {AdminClasses.EMPTY_STATE}"):
-            ui.icon("inbox").classes("text-h2")
-            message = (
-                f'No results for "{search}"'
-                if search
-                else f"No {self.display_name.lower()} records yet"
-            )
+        message = (
+            f'No results for "{search}"'
+            if search
+            else f"No {self.display_name.lower()} records yet"
+        )
+        with c.empty_state():
             ui.label(message).classes("text-subtitle1")
 
     def render_list_summary(self, pagination: PaginationInfo) -> None:
@@ -262,30 +257,16 @@ class BaseAdminPage:
             ).classes("text-caption")
 
     def render_grid(self, dtos: list) -> None:
-        """Hook: render AG Grid table."""
-        column_defs = self.build_column_defs()
+        """Hook: render AG Grid table (delegates to the data_grid builder)."""
         masked_fields = self.get_masked_field_names()
-        row_data = self.build_row_data(dtos, masked_fields)
-
-        grid = ui.aggrid(
-            {
-                "columnDefs": column_defs,
-                "rowData": row_data,
-                "rowSelection": {"mode": "singleRow"},
-                "rowHeight": AdminMetrics.GRID_ROW_HEIGHT,
-                "defaultColDef": {"resizable": True, "filter": True},
-            }
-        ).classes(f"w-full {AdminClasses.GRID}")
-
-        grid.on(
-            "cellClicked",
-            lambda e: ui.navigate.to(
-                f"/admin/{self.domain_name}/{e.args['data']['id']}"
-            ),
+        c.data_grid(
+            self.build_column_defs(),
+            self.build_row_data(dtos, masked_fields),
+            row_click_to=lambda row: f"/admin/{self.domain_name}/{row['id']}",
         )
 
     def render_pagination(self, pagination: PaginationInfo, search: str) -> None:
-        """Hook: render prev/next pagination buttons."""
+        """Hook: render prev/next pagination (delegates to the pagination builder)."""
 
         def _build_page_url(target_page: int) -> str:
             params = f"page={target_page}"
@@ -293,38 +274,28 @@ class BaseAdminPage:
                 params += f"&search={search}"
             return f"/admin/{self.domain_name}?{params}"
 
-        with ui.row().classes(
-            f"items-center q-mt-md q-gutter-sm {AdminClasses.PAGINATION}"
-        ):
-            ui.button(
-                "Previous",
-                on_click=lambda: ui.navigate.to(
-                    _build_page_url(pagination.previous_page)
-                ),
-            ).props("flat" if pagination.has_previous else "flat disable")
-            ui.label(f"{pagination.current_page} / {pagination.total_pages}")
-            ui.button(
-                "Next",
-                on_click=lambda: ui.navigate.to(_build_page_url(pagination.next_page)),
-            ).props("flat" if pagination.has_next else "flat disable")
+        c.pagination(
+            current=pagination.current_page,
+            total_pages=pagination.total_pages,
+            on_prev=lambda: ui.navigate.to(_build_page_url(pagination.previous_page)),
+            on_next=lambda: ui.navigate.to(_build_page_url(pagination.next_page)),
+        )
 
     # ── Detail page hooks ──
 
     def render_detail_header(self, record_id: int) -> None:
         """Hook: render detail page heading with back button."""
-        with ui.row().classes("items-center q-mb-md q-gutter-sm"):
-            ui.button(
-                icon="arrow_back",
-                on_click=lambda: ui.navigate.to(f"/admin/{self.domain_name}"),
-            ).props("flat round")
-            ui.label(f"{self.display_name} #{record_id}").classes("text-h5")
+        c.page_header(
+            f"{self.display_name} #{record_id}",
+            back_to=f"/admin/{self.domain_name}",
+        )
 
     def render_detail_card(self, dto) -> None:
         """Hook: render detail card with all fields."""
         masked_fields = self.get_masked_field_names()
         data = dto.model_dump()
 
-        with ui.card().classes("w-full"):
+        with c.card(classes="w-full"):
             for col in self.columns:
                 value = data.get(col.field_name, "")
                 is_empty = value is None or value == ""
@@ -337,11 +308,7 @@ class BaseAdminPage:
                 else:
                     display_value = str(value)
 
-                with ui.row().classes("items-center q-py-xs"):
-                    ui.label(col.header_name).classes(AdminClasses.FIELD_LABEL)
-                    value_label = ui.label(display_value)
-                    if is_empty:
-                        value_label.classes(AdminClasses.EMPTY_VALUE)
+                c.field_row(col.header_name, display_value, is_empty=is_empty)
 
     # ── Data transformation helpers ──
 

--- a/src/_core/infrastructure/admin/components/__init__.py
+++ b/src/_core/infrastructure/admin/components/__init__.py
@@ -1,0 +1,65 @@
+"""Admin design-system component library (#193 follow-up).
+
+The single place that turns design tokens (``theme.py``) into NiceGUI elements.
+Pages compose these builders instead of hand-writing ``ui.*`` + class strings,
+so every admin surface shares one look and new pages stay consistent.
+
+Import surface::
+
+    from src._core.infrastructure.admin import components as c
+    c.page_header("Users", subtitle="Manage accounts")
+    with c.card():
+        ...
+
+Layering: theme.py (tokens) → components (builders) → base_admin_page + pages.
+Components must NEVER import base_admin_page (cycle).
+"""
+
+from __future__ import annotations
+
+from src._core.infrastructure.admin.components.containers import (
+    card,
+    field_row,
+    section,
+    stat_card,
+)
+from src._core.infrastructure.admin.components.data import data_grid, pagination
+from src._core.infrastructure.admin.components.dialogs import (
+    action_dialog,
+    confirm_dialog,
+)
+from src._core.infrastructure.admin.components.feedback import (
+    empty_state,
+    report_error,
+    toast_error,
+    toast_success,
+    toast_warning,
+)
+from src._core.infrastructure.admin.components.forms import (
+    number_field,
+    select_field,
+    text_field,
+    textarea_field,
+)
+from src._core.infrastructure.admin.components.headers import page_header
+
+__all__ = [
+    "action_dialog",
+    "card",
+    "confirm_dialog",
+    "data_grid",
+    "empty_state",
+    "field_row",
+    "number_field",
+    "page_header",
+    "pagination",
+    "report_error",
+    "section",
+    "select_field",
+    "stat_card",
+    "text_field",
+    "textarea_field",
+    "toast_error",
+    "toast_success",
+    "toast_warning",
+]

--- a/src/_core/infrastructure/admin/components/containers.py
+++ b/src/_core/infrastructure/admin/components/containers.py
@@ -1,0 +1,55 @@
+"""Container + content builders for the admin design system (#193 follow-up).
+
+``card`` / ``section`` are context managers (they hold children); ``stat_card``
+and ``field_row`` are leaf builders that return the element.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from nicegui import ui
+
+from src._core.infrastructure.admin.theme import AdminClasses
+
+
+@contextmanager
+def card(*, clickable_to: str | None = None, classes: str = "") -> Iterator[ui.card]:
+    """A themed card container. ``clickable_to`` makes the whole card navigate."""
+    element = ui.card().classes(classes)
+    if clickable_to is not None:
+        element.classes("cursor-pointer").on(
+            "click", lambda: ui.navigate.to(clickable_to)
+        )
+    with element:
+        yield element
+
+
+@contextmanager
+def section(title: str | None = None, *, classes: str = "") -> Iterator[ui.column]:
+    """A vertical content section with an optional heading."""
+    with ui.column().classes(f"w-full q-gutter-sm {classes}".strip()) as column:
+        if title:
+            ui.label(title).classes("text-subtitle1 text-weight-bold")
+        yield column
+
+
+def stat_card(label: str, value: str | int, *, icon: str | None = None) -> ui.card:
+    """A metric tile: caption label + large value (replaces ai_usage tiles)."""
+    with ui.card().classes("q-pa-md") as element:
+        if icon is not None:
+            ui.icon(icon).classes("text-h5 text-primary")
+        ui.label(str(label)).classes(f"text-caption {AdminClasses.MUTED}")
+        ui.label(str(value)).classes("text-h6")
+    return element
+
+
+def field_row(label: str, value: str, *, is_empty: bool = False) -> ui.row:
+    """One label/value detail row. ``value`` is pre-formatted by the caller."""
+    with ui.row().classes("items-center q-py-xs") as row:
+        ui.label(label).classes(AdminClasses.FIELD_LABEL)
+        value_label = ui.label(value)
+        if is_empty:
+            value_label.classes(AdminClasses.EMPTY_VALUE)
+    return row

--- a/src/_core/infrastructure/admin/components/data.py
+++ b/src/_core/infrastructure/admin/components/data.py
@@ -1,0 +1,86 @@
+"""Data-display builders for the admin design system (#193 follow-up).
+
+``data_grid`` is the single place that turns column defs + row data into an
+AG Grid with the admin theme + shared defaults. Masking / formatting / column
+selection stay in the caller (e.g. BaseAdminPage) — this builder only renders.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from nicegui import ui
+
+from src._core.infrastructure.admin.theme import AdminClasses, AdminMetrics
+
+_SHARED_DEFAULT_COL_DEF: dict[str, Any] = {
+    "resizable": True,
+    "filter": True,
+    "sortable": True,
+}
+
+
+def data_grid(
+    column_defs: list[dict],
+    row_data: list[dict],
+    *,
+    compact: bool = False,
+    row_click_to: Callable[[dict], str] | None = None,
+    on_cell_click: Callable[[Any], Any] | None = None,
+    on_row_click: Callable[[Any], Awaitable[None]] | Callable[[Any], Any] | None = None,
+    default_col_def: dict | None = None,
+    selection: str = "single",
+) -> ui.aggrid:
+    """Render an AG Grid with the admin theme class + shared defaults.
+
+    Click handling (all optional, async-safe):
+    - ``row_click_to``: row dict → route; navigates on cellClicked (the common
+      list→detail case).
+    - ``on_cell_click`` / ``on_row_click``: raw handlers (sync or async) for the
+      cellClicked / rowClicked events (e.g. opening a detail dialog).
+    """
+    col_def = {**_SHARED_DEFAULT_COL_DEF, **(default_col_def or {})}
+    grid = ui.aggrid(
+        {
+            "columnDefs": column_defs,
+            "rowData": row_data,
+            "rowSelection": {"mode": "singleRow"}
+            if selection == "single"
+            else selection,
+            "rowHeight": AdminMetrics.GRID_ROW_HEIGHT,
+            "defaultColDef": col_def,
+        }
+    ).classes(f"w-full {AdminClasses.GRID_COMPACT if compact else AdminClasses.GRID}")
+
+    if row_click_to is not None:
+        grid.on(
+            "cellClicked",
+            lambda e: ui.navigate.to(row_click_to(e.args["data"])),
+        )
+    elif on_cell_click is not None:
+        grid.on("cellClicked", on_cell_click)
+    if on_row_click is not None:
+        grid.on("rowClicked", on_row_click)
+    return grid
+
+
+def pagination(
+    *,
+    current: int,
+    total_pages: int,
+    on_prev: Callable[..., Any],
+    on_next: Callable[..., Any],
+) -> ui.row:
+    """Prev / page-label / next row, right-aligned, with disabled end states."""
+    with ui.row().classes(
+        f"items-center q-mt-md q-gutter-sm {AdminClasses.PAGINATION}"
+    ) as row:
+        prev_btn = ui.button("Previous", on_click=on_prev).props("flat")
+        if current <= 1:
+            prev_btn.props("disable")
+        ui.label(f"{current} / {total_pages}")
+        next_btn = ui.button("Next", on_click=on_next).props("flat")
+        if current >= total_pages:
+            next_btn.props("disable")
+    return row

--- a/src/_core/infrastructure/admin/components/dialogs.py
+++ b/src/_core/infrastructure/admin/components/dialogs.py
@@ -1,0 +1,85 @@
+"""Dialog builders for the admin design system (#193 follow-up).
+
+``action_dialog`` is a context manager for arbitrary dialog bodies.
+``confirm_dialog`` is an async coroutine for the common confirm-an-action flow;
+it owns ONLY the loading + close/ordering — ``on_confirm`` owns its own
+try/except + audit + notify and returns ``success`` so the dialog stays open on
+failure and closes (then refreshes) only on success.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Iterator
+from contextlib import contextmanager
+
+from nicegui import ui
+
+from src._core.infrastructure.admin.layout import button_loading
+from src._core.infrastructure.admin.theme import AdminClasses
+
+
+@contextmanager
+def action_dialog(
+    title: str,
+    *,
+    width: str = "480px",
+    subtitle: str | None = None,
+) -> Iterator[tuple[ui.dialog, ui.card]]:
+    """Open a dialog with a title (and optional subtitle); yield (dialog, card).
+
+    The caller fills the body inside the ``with`` and adds its own footer
+    buttons (e.g. Save/Cancel). The dialog is opened on exit.
+    """
+    with (
+        ui.dialog() as dialog,
+        ui.card().style(f"width: {width}; max-width: 95vw") as card,
+    ):
+        ui.label(title).classes("text-h6")
+        if subtitle:
+            ui.label(subtitle).classes(f"text-caption {AdminClasses.MUTED} q-mb-sm")
+        yield dialog, card
+    dialog.open()
+
+
+async def confirm_dialog(
+    title: str,
+    message: str,
+    *,
+    on_confirm: Callable[[], Awaitable[bool]],
+    on_success: Callable[[], Awaitable[None]] | None = None,
+    confirm_label: str = "Confirm",
+    cancel_label: str = "Cancel",
+    danger: bool = False,
+    width: str = "420px",
+) -> None:
+    """Build + open a confirm dialog.
+
+    Contract:
+    - ``on_confirm()`` performs the work and returns ``True`` on success. It owns
+      its own try/except, audit logging and user notifications.
+    - The builder wraps it in ``button_loading`` and, **only when it returns
+      True**, closes the dialog and (if given) awaits ``on_success`` (e.g. a list
+      refresh) AFTER the close. On ``False`` the dialog stays open.
+    """
+    with ui.dialog() as dialog, ui.card().style(f"width: {width}; max-width: 95vw"):
+        ui.label(title).classes("text-h6")
+        if message:
+            classes = "text-caption q-mb-md" + (" text-negative" if danger else "")
+            ui.label(message).classes(classes)
+
+        async def _confirm() -> None:
+            async with button_loading(confirm_btn):
+                ok = await on_confirm()
+            # Close + refresh OUTSIDE the loading context (button not yet torn
+            # down during the await); only on success.
+            if ok:
+                dialog.close()
+                if on_success is not None:
+                    await on_success()
+
+        with ui.row().classes("q-mt-md justify-end q-gutter-sm"):
+            ui.button(cancel_label, on_click=dialog.close).props("flat")
+            confirm_btn = ui.button(confirm_label, on_click=_confirm).props(
+                "color=negative" if danger else "color=primary"
+            )
+    dialog.open()

--- a/src/_core/infrastructure/admin/components/feedback.py
+++ b/src/_core/infrastructure/admin/components/feedback.py
@@ -1,0 +1,44 @@
+"""Feedback builders for the admin design system (#193 follow-up).
+
+``toast_*`` standardize ``ui.notify`` types. ``report_error`` is the ONLY path
+for surfacing a caught exception — it routes through ``AdminErrorHandler`` which
+sanitizes (never leaks ``str(exc)`` to the UI). ``empty_state`` is the single
+empty-list markup, shared with BaseAdminPage.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from nicegui import ui
+
+from src._core.infrastructure.admin.theme import AdminClasses
+
+
+def toast_success(message: str) -> None:
+    ui.notify(message, type="positive")
+
+
+def toast_warning(message: str) -> None:
+    ui.notify(message, type="warning")
+
+
+def toast_error(message: str) -> None:
+    """Show a sanitized error toast. NEVER pass ``str(exc)`` — use report_error."""
+    ui.notify(message, type="negative")
+
+
+async def report_error(exc: Exception, *, context: str) -> None:
+    """Route a caught exception through the sanitizing admin error handler."""
+    from src._core.infrastructure.admin.error_handler import AdminErrorHandler
+
+    await AdminErrorHandler.handle(exc, context=context)
+
+
+@contextmanager
+def empty_state(icon: str = "inbox") -> Iterator[ui.column]:
+    """A centered, muted empty-state column. Caller adds the message label(s)."""
+    with ui.column().classes(f"w-full {AdminClasses.EMPTY_STATE}") as column:
+        ui.icon(icon).classes("text-h2")
+        yield column

--- a/src/_core/infrastructure/admin/components/forms.py
+++ b/src/_core/infrastructure/admin/components/forms.py
@@ -1,0 +1,90 @@
+"""Form-field builders for the admin design system (#193 follow-up).
+
+All builders force ``outlined`` chrome so inputs are consistent everywhere —
+fixing the prior drift where login used ``outlined`` but accounts / setup /
+change_password did not. Leaf builders: return the element for chaining
+``.classes("full-width")`` / ``.on(...)``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from nicegui import ui
+
+
+def text_field(
+    label: str,
+    *,
+    value: str = "",
+    password: bool = False,
+    clearable: bool = False,
+    placeholder: str | None = None,
+    on_change: Callable[..., Any] | None = None,
+) -> ui.input:
+    """An outlined text/password input."""
+    element = ui.input(
+        label,
+        value=value,
+        placeholder=placeholder,
+        password=password,
+        password_toggle_button=password,
+        on_change=on_change,
+    )
+    props = "outlined dense"
+    if clearable:
+        props += " clearable"
+    return element.props(props)
+
+
+def textarea_field(
+    label: str,
+    *,
+    value: str = "",
+    placeholder: str | None = None,
+    autogrow: bool = True,
+) -> ui.textarea:
+    """An outlined (optionally autogrowing) textarea."""
+    element = ui.textarea(label, value=value, placeholder=placeholder)
+    props = "outlined"
+    if autogrow:
+        props += " autogrow"
+    return element.props(props)
+
+
+def number_field(
+    label: str,
+    *,
+    value: float | None = None,
+    min: float | None = None,  # noqa: A002 - mirrors ui.number kwarg name
+    max: float | None = None,  # noqa: A002 - mirrors ui.number kwarg name
+    step: float = 1,
+) -> ui.number:
+    """An outlined numeric input."""
+    return ui.number(label, value=value, min=min, max=max, step=step).props(
+        "outlined dense"
+    )
+
+
+def select_field(
+    label: str,
+    options: Any,
+    *,
+    value: Any = None,
+    multiple: bool = False,
+    use_chips: bool = False,
+    on_change: Callable[..., Any] | None = None,
+) -> ui.select:
+    """An outlined select (single or multiple, optionally chip-rendered)."""
+    element = ui.select(
+        options,
+        label=label,
+        value=value,
+        multiple=multiple,
+        on_change=on_change,
+    )
+    props = "outlined dense"
+    if use_chips:
+        props += " use-chips"
+    return element.props(props)

--- a/src/_core/infrastructure/admin/components/headers.py
+++ b/src/_core/infrastructure/admin/components/headers.py
@@ -1,0 +1,44 @@
+"""Page-header builder for the admin design system (#193 follow-up).
+
+One builder covers every observed header variant: title-only, title+subtitle,
+back-button+title, and title+actions. Pages compose this instead of hand-writing
+``ui.label(...).classes("text-h5 q-mb-md")``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from nicegui import ui
+
+from src._core.infrastructure.admin.theme import AdminClasses
+
+
+def page_header(
+    title: str,
+    *,
+    subtitle: str | None = None,
+    back_to: str | None = None,
+    actions: Callable[[], None] | None = None,
+) -> ui.row:
+    """Render a page header. Returns the header row.
+
+    - ``back_to``: route → renders a leading back button that navigates there.
+    - ``subtitle``: muted sub-label under the title.
+    - ``actions``: slot builder rendered right-aligned (e.g. a "New" button).
+    """
+    with ui.row().classes("items-center justify-between w-full q-mb-md") as header:
+        with ui.row().classes("items-center q-gutter-sm"):
+            if back_to is not None:
+                ui.button(
+                    icon="arrow_back",
+                    on_click=lambda: ui.navigate.to(back_to),
+                ).props("flat round")
+            with ui.column().classes("q-gutter-none"):
+                ui.label(title).classes("text-h5")
+                if subtitle:
+                    ui.label(subtitle).classes(f"text-caption {AdminClasses.MUTED}")
+        if actions is not None:
+            with ui.row().classes("items-center q-gutter-sm"):
+                actions()
+    return header

--- a/src/_core/infrastructure/admin/theme.py
+++ b/src/_core/infrastructure/admin/theme.py
@@ -75,10 +75,11 @@ class AdminVars:
     SHADOW: Final = "--admin-shadow"
     CARD_BORDER: Final = "--admin-card-border"
 
-    # Layout metrics.
+    # Layout metrics + typography.
     GRID_HEIGHT: Final = "--admin-grid-height"
     GRID_HEIGHT_COMPACT: Final = "--admin-grid-height-compact"
     LABEL_COL_WIDTH: Final = "--admin-label-col-width"
+    FONT: Final = "--admin-font"
 
 
 class AdminMetrics:
@@ -125,7 +126,20 @@ _LAYOUT_TOKENS: Final = {
     AdminVars.GRID_HEIGHT: "calc(100vh - 240px)",
     AdminVars.GRID_HEIGHT_COMPACT: "calc(100vh - 360px)",
     AdminVars.LABEL_COL_WIDTH: "160px",
+    # Wanted Sans (open-source) with a graceful system-font fallback — so the UI
+    # still renders cleanly if the CDN font fails to load.
+    AdminVars.FONT: (
+        '"Wanted Sans Variable", -apple-system, BlinkMacSystemFont, '
+        '"Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif'
+    ),
 }
+
+# Wanted Sans webfont (open-sourced by Wanted). Pinned-ish via @latest with a
+# system fallback in the font stack; swap to a version tag for reproducibility.
+_FONT_CSS_URL: Final = (
+    "https://cdn.jsdelivr.net/gh/wanteddev/wanted-sans@latest/"
+    "packages/wanted-sans/fonts/webfonts/variable/complete/WantedSansVariable.min.css"
+)
 
 _CONTENT_DARK: Final = {
     AdminVars.BG: "#0b1120",
@@ -241,6 +255,9 @@ _HELPER_CSS: Final = """
 /* === Helper classes + Quasar component overrides (token-driven) === */
 body, .q-page-container {
   background-color: var(--admin-bg) !important;
+}
+body {
+  font-family: var(--admin-font) !important;
 }
 /* Chrome: dark header + sidebar, light text. */
 .admin-header {
@@ -397,5 +414,6 @@ def install_admin_theme_css() -> None:
 
     from src._core.config import settings
 
+    ui.add_head_html(f'<link rel="stylesheet" href="{_FONT_CSS_URL}">', shared=True)
     ui.add_css(build_admin_css(settings.admin_theme_palette), shared=True)
     _theme_css_installed = True

--- a/src/ai_usage/interface/admin/pages/ai_usage_page.py
+++ b/src/ai_usage/interface/admin/pages/ai_usage_page.py
@@ -2,14 +2,11 @@ from __future__ import annotations
 
 from nicegui import ui
 
+from src._core.infrastructure.admin import components as c
 from src._core.infrastructure.admin.auth import require_auth
 from src._core.infrastructure.admin.base_admin_page import BaseAdminPage
-from src._core.infrastructure.admin.error_handler import (
-    AdminErrorHandler,
-    admin_error_boundary,
-)
+from src._core.infrastructure.admin.error_handler import admin_error_boundary
 from src._core.infrastructure.admin.layout import admin_layout
-from src._core.infrastructure.admin.theme import AdminClasses
 from src.ai_usage.interface.admin.configs.ai_usage_admin_config import (
     ai_usage_admin_page,
 )
@@ -35,40 +32,38 @@ async def ai_usage_summary_page() -> None:
     if session is None:
         return
     admin_layout(page_configs, current_domain="ai_usage", session=session)
-    ui.label("AI Usage Summary").classes("text-h5 q-mb-md")
+    c.page_header("AI Usage Summary")
 
     try:
         service = ai_usage_admin_page._get_service()
         summary, by_org = await service.get_usage_summary()
     except Exception as exc:  # noqa: BLE001 - delegated to AdminErrorHandler
-        await AdminErrorHandler.handle(exc, context="ai_usage_summary")
+        await c.report_error(exc, context="ai_usage_summary")
         return
 
     with ui.row().classes("q-gutter-md q-mb-md"):
-        _summary_tile("Calls", summary.call_count)
-        _summary_tile("Requests", summary.request_count)
-        _summary_tile("Tokens", summary.total_tokens)
-        _summary_tile("Input", summary.input_tokens)
-        _summary_tile("Output", summary.output_tokens)
+        c.stat_card("Calls", summary.call_count)
+        c.stat_card("Requests", summary.request_count)
+        c.stat_card("Tokens", summary.total_tokens)
+        c.stat_card("Input", summary.input_tokens)
+        c.stat_card("Output", summary.output_tokens)
 
     rows = [item.model_dump() for item in by_org]
-    ui.aggrid(
-        {
-            "columnDefs": [
-                {"headerName": "Org", "field": "org_id"},
-                {"headerName": "Calls", "field": "call_count"},
-                {"headerName": "Requests", "field": "request_count"},
-                {"headerName": "Tokens", "field": "total_tokens"},
-                {"headerName": "Input", "field": "input_tokens"},
-                {"headerName": "Output", "field": "output_tokens"},
-                {"headerName": "Cache Read", "field": "cache_read_tokens"},
-                {"headerName": "Cache Write", "field": "cache_write_tokens"},
-                {"headerName": "Reasoning", "field": "reasoning_tokens"},
-            ],
-            "rowData": rows,
-            "defaultColDef": {"resizable": True, "sortable": True},
-        }
-    ).classes(f"w-full {AdminClasses.GRID_COMPACT}")
+    c.data_grid(
+        [
+            {"headerName": "Org", "field": "org_id"},
+            {"headerName": "Calls", "field": "call_count"},
+            {"headerName": "Requests", "field": "request_count"},
+            {"headerName": "Tokens", "field": "total_tokens"},
+            {"headerName": "Input", "field": "input_tokens"},
+            {"headerName": "Output", "field": "output_tokens"},
+            {"headerName": "Cache Read", "field": "cache_read_tokens"},
+            {"headerName": "Cache Write", "field": "cache_write_tokens"},
+            {"headerName": "Reasoning", "field": "reasoning_tokens"},
+        ],
+        rows,
+        compact=True,
+    )
 
 
 @ui.page("/admin/ai_usage/{record_id}")
@@ -79,9 +74,3 @@ async def ai_usage_detail_page(record_id: int) -> None:
         return
     admin_layout(page_configs, current_domain="ai_usage", session=session)
     await ai_usage_admin_page.render_detail(record_id=record_id)
-
-
-def _summary_tile(label: str, value: int) -> None:
-    with ui.card().classes("q-pa-md"):
-        ui.label(label).classes("text-caption")
-        ui.label(str(value)).classes("text-h6")

--- a/tests/unit/_core/infrastructure/admin/test_components.py
+++ b/tests/unit/_core/infrastructure/admin/test_components.py
@@ -1,0 +1,119 @@
+"""Smoke + contract tests for the admin design-system components (#193 follow-up).
+
+Gated on the ``admin`` extra via ``importorskip`` (matches the other admin
+render tests). NiceGUI auto-creates an index client, so builders can be
+instantiated here; we assert on element type, ``_classes`` and ``_props``
+membership — never on rendered HTML.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("nicegui")
+
+from nicegui import ui  # noqa: E402
+
+from src._core.infrastructure.admin import components as c  # noqa: E402
+from src._core.infrastructure.admin.theme import (  # noqa: E402
+    AdminClasses,
+    AdminMetrics,
+)
+
+
+@pytest.fixture(autouse=True)
+def _ui_slot():
+    """Provide a NiceGUI slot so builders can create elements regardless of
+    suite ordering (other tests can leave the global slot stack empty)."""
+    from nicegui.client import Client
+    from nicegui.page import page as Page
+
+    with Client(Page("/_components_test")):
+        yield
+
+
+# ── Forms: outlined enforced everywhere ──
+
+
+def test_text_field_is_outlined():
+    el = c.text_field("Username")
+    assert isinstance(el, ui.input)
+    assert el._props.get("outlined") is True
+    assert el._props.get("dense") is True
+
+
+def test_password_text_field_uses_password_type():
+    assert c.text_field("Password", password=True)._props.get("type") == "password"
+    assert c.text_field("User")._props.get("type") == "text"
+
+
+def test_all_form_fields_are_outlined():
+    assert c.textarea_field("Q")._props.get("outlined") is True
+    assert c.number_field("n")._props.get("outlined") is True
+    assert c.select_field("S", {"a": "a"})._props.get("outlined") is True
+
+
+def test_clearable_and_chips_flags():
+    assert c.text_field("x", clearable=True)._props.get("clearable") is True
+    assert (
+        c.select_field("S", {"a": "a"}, use_chips=True)._props.get("use-chips") is True
+    )
+
+
+# ── Data grid: theme class + shared options ──
+
+
+def test_data_grid_carries_theme_and_defaults():
+    grid = c.data_grid([{"field": "id"}], [{"id": 1}])
+    assert isinstance(grid, ui.aggrid)
+    assert AdminClasses.GRID in grid._classes
+    options = grid._props["options"]
+    assert options["rowHeight"] == AdminMetrics.GRID_ROW_HEIGHT
+    assert options["defaultColDef"]["sortable"] is True
+    assert options["defaultColDef"]["filter"] is True
+
+
+def test_data_grid_compact_uses_compact_class():
+    grid = c.data_grid([], [], compact=True)
+    assert AdminClasses.GRID_COMPACT in grid._classes
+
+
+def test_data_grid_merges_default_col_def():
+    grid = c.data_grid([], [], default_col_def={"sortable": False, "flex": 1})
+    default = grid._props["options"]["defaultColDef"]
+    assert default["sortable"] is False  # override wins
+    assert default["flex"] == 1
+    assert default["resizable"] is True  # shared base preserved
+
+
+# ── Leaf builders return the right element type ──
+
+
+def test_leaf_builders_return_elements():
+    assert isinstance(c.page_header("T", subtitle="s", back_to="/admin/"), ui.row)
+    assert isinstance(c.stat_card("Calls", 42, icon="bolt"), ui.card)
+    assert isinstance(c.field_row("Email", "a@b.com"), ui.row)
+    assert isinstance(
+        c.pagination(
+            current=1, total_pages=3, on_prev=lambda: None, on_next=lambda: None
+        ),
+        ui.row,
+    )
+
+
+# ── Context-manager builders nest children ──
+
+
+def test_context_manager_builders():
+    with c.card() as card_el:
+        assert isinstance(card_el, ui.card)
+    with c.section("Title") as col:
+        assert isinstance(col, ui.column)
+    with c.empty_state() as col:
+        assert isinstance(col, ui.column)
+
+
+# Note: confirm_dialog's click→close→refresh ordering (close + on_success only on
+# success, stay-open on failure) is exercised manually in the accounts migration;
+# it can't be clicked in a headless test, and building UI inside an async task
+# trips NiceGUI's slot-stack guard.

--- a/tests/unit/_core/infrastructure/admin/test_no_hardcoded_styles.py
+++ b/tests/unit/_core/infrastructure/admin/test_no_hardcoded_styles.py
@@ -53,9 +53,15 @@ def _find_admin_page_files() -> list[pathlib.Path]:
     ]
 
 
+_COMPONENTS_DIR = _SRC_ROOT / "_core" / "infrastructure" / "admin" / "components"
+
+
 def _guarded_files() -> list[pathlib.Path]:
     files = _find_admin_page_files()
     files.extend(p for p in _EXTRA_GUARDED if p.exists())
+    # The design-system component library is the single place tokens become
+    # elements — guard it too (glob so new submodules are covered automatically).
+    files.extend(p for p in _COMPONENTS_DIR.rglob("*.py") if "__init__" not in p.name)
     return files
 
 

--- a/tests/unit/_core/infrastructure/admin/test_route_coverage.py
+++ b/tests/unit/_core/infrastructure/admin/test_route_coverage.py
@@ -60,16 +60,41 @@ def _extract_ui_page_route(decorator: ast.expr) -> str | None:
     return None
 
 
+def _is_auth_gate_call(value: ast.expr | None) -> bool:
+    """True if ``value`` is a (possibly awaited) call to an auth-gate function."""
+    if isinstance(value, ast.Await):
+        value = value.value
+    if not isinstance(value, ast.Call):
+        return False
+    func = value.func
+    if isinstance(func, ast.Name) and func.id in _AUTH_GATE_NAMES:
+        return True
+    return isinstance(func, ast.Attribute) and func.attr in _AUTH_GATE_NAMES
+
+
 def _body_has_auth_gate(func_node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
-    """True if the function body contains a call to any auth gate function."""
-    for node in ast.walk(func_node):
-        if not isinstance(node, ast.Call):
-            continue
-        func = node.func
-        if isinstance(func, ast.Name) and func.id in _AUTH_GATE_NAMES:
-            return True
-        if isinstance(func, ast.Attribute) and func.attr in _AUTH_GATE_NAMES:
-            return True
+    """True if the auth gate is the FIRST real statement (after any docstring).
+
+    Stronger than "exists somewhere": project-dna requires ``require_auth*`` to
+    be the first statement of every gated /admin route, so nothing renders
+    before the gate. Accepts ``session = await require_auth(...)`` (Assign) or a
+    bare ``await require_auth(...)`` (Expr)."""
+    body = list(func_node.body)
+    # Skip a leading docstring.
+    if (
+        body
+        and isinstance(body[0], ast.Expr)
+        and isinstance(body[0].value, ast.Constant)
+        and isinstance(body[0].value.value, str)
+    ):
+        body = body[1:]
+    if not body:
+        return False
+    first = body[0]
+    if isinstance(first, (ast.Assign, ast.AnnAssign)):
+        return _is_auth_gate_call(first.value)
+    if isinstance(first, ast.Expr):
+        return _is_auth_gate_call(first.value)
     return False
 
 


### PR DESCRIPTION
## Related Issue
- Relates to #193 (follow-up initiative, stacked on #220)

> **Stacked on #220** (`feat/193-admin-ui-theme`). Review/merge #220 first; this PR's base is that branch.

## Change Summary
Turns the #220 token foundation into a full **admin design system** so future admin pages are built by composing consistent, reusable builders.

- **Component library** `src/_core/infrastructure/admin/components/` (18 builders): `page_header`, `card`/`section`, `stat_card`, `field_row`, form fields (outlined-enforced), `action_dialog` + `confirm_dialog`, `data_grid`, `pagination`, `empty_state`, toasts + `report_error`. The single place tokens become elements; never imports `base_admin_page` (no cycle).
- **`confirm_dialog` contract**: `on_confirm()` returns `success`; the builder closes + refreshes only on success, stays open on failure.
- **One implementation per shape**: `BaseAdminPage` render hooks delegate to the builders; all pages (accounts/audit_log/dashboard/ai_usage/login/setup/change_password) migrated.
- **Wanted Sans** webfont loaded app-wide via an `--admin-font` token (graceful system fallback).
- **Guard hardening**: `test_route_coverage` now requires `require_auth*` as the *first* statement; `test_no_hardcoded_styles` globs `components/`.
- **Conventions + skill**: new `docs/ai/shared/admin-design-system.md`; `/add-admin-page` (Claude + Codex wrappers) aligned to compose builders; stale page template fixed (`@admin_error_boundary` + auth-first).
- **Sync**: harness-asset-matrix, project-dna §11, `.claude/rules` settings docs updated.

## Type of Change
- [x] feat: New feature
- [x] refactor: Code restructuring
- [x] docs: Documentation

## Checklist
- [x] Architecture rules followed
- [x] Tests pass (`make check-core`: 1128 passed)
- [x] Linting passes (`ruff check src/`)

## How to Test
`uv sync --extra admin && make quickstart`. Verify accounts remove/edit dialogs (close + refresh on success; stay open + toast on self/last-admin guard), audit-log detail dialog, and that all pages render unchanged-or-better.

## Review provenance
Codex (gpt-5.5, xhigh) cross-reviewed the plan (GO-WITH-CHANGES): the `confirm_dialog` boundary, `data_grid` click events, BaseAdminPage delegation semantics, auth-guard strength, governed-docs sync, stale skill template, button over-engineering, and AST-guard glob were all folded in before implementation.

Self-structured review evidence: F (file paths re-verified) · G (all drift closed Fixed/Deferred) · H (canonical diffed) · I (governor-paths consumers checked) · Language policy (Tier 1 English, 0 violations).

## Governor Footer
- trigger: yes
- reviewer: codex-cli, self-structured
- rounds: 2
- r-points-fixed: 8
- r-points-deferred: 0
- r-points-rejected: 0
- touched-adr-consequences: none
- pr-scope-notes: design-system tooling + docs; project-status.md row deferred to merge
- final-verdict: merge-ready
- links: https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/220
