### PR TITLE
fix(security): gate docs reads + reject wildcard CORS in strict envs

### DIFF
--- a/docs/ai/shared/project-dna.md
+++ b/docs/ai/shared/project-dna.md
@@ -587,7 +587,7 @@ class {Name}Container(containers.DeclarativeContainer):
 | dependency-injector | Active | DeclarativeContainer, @inject + Provide |
 | Object Storage (aioboto3) | Active | S3/MinIO switchable via STORAGE_TYPE, ObjectStorage + ObjectStorageClient (via `aws` extra) |
 | AWS DynamoDB (aioboto3) | Active | BaseDynamoRepository + DynamoDBClient (optional infra, via `aws` extra) |
-| NiceGUI (BaseAdminPage) | Active | Admin dashboard (AG Grid, auto-discovery, Template Method rendering) -- gated via `admin` extra (#104) and DB-backed admin auth (#154) |
+| NiceGUI (BaseAdminPage) | Active | Admin dashboard (AG Grid, auto-discovery, Template Method rendering) -- gated via `admin` extra (#104); admin login + page-level permissions backed by the `admin_identity` realm (#218 / ADR 049, supersedes the #154/#194 single-table model). See §17. |
 | alembic (migrations) | Active | DB migrations |
 | Password hashing (bcrypt) | Active | hash_password(), verify_password() in src._core.common.security |
 | AWS S3 Vectors (aioboto3) | Active | BaseS3VectorStore + S3VectorClient (optional infra, via `aws` extra) |

--- a/docs/ai/shared/security-checklist.md
+++ b/docs/ai/shared/security-checklist.md
@@ -65,14 +65,18 @@ Check router files and configuration files:
   - Grep: No `ui.notify(str(exc))` / `ui.notify(f"...{exc}...")` in `interface/admin/pages/` or
     `src/_apps/admin/pages/`; errors route through `AdminErrorHandler` (IC-195-1). The AST test
     `test_route_coverage.py::test_admin_pages_do_not_leak_raw_exception_to_ui` enforces this.
-- [ ] [Always][HIGH] Admin authentication delegates credential checks to the auth domain
-  - Grep: Verify `AdminAuthProvider` calls `AuthUseCase.admin_login()` and password verification stays in `AuthService.verify_credentials()`
+- [ ] [Always][HIGH] Admin authentication delegates credential checks to the `admin_identity` realm (#218 / ADR 049)
+  - Grep: Verify `AdminAuthProvider` calls `AdminAuthUseCase.admin_login()` and password verification stays in the `admin_identity` `AdminAuthService.verify_credentials()` (NOT the customer `AuthService` — admin and customer realms are separate since #218)
 - [ ] [Always][HIGH] Sensitive fields masked in admin grid
   - Grep: Fields containing `password`, `secret`, `token`, `key` in ColumnConfig use `masked=True`
 - [ ] [Always][MEDIUM] Admin bootstrap credentials are seed-only
   - Grep: `ADMIN_BOOTSTRAP_*` settings may create or promote the first admin user, but `ADMIN_ID` / `ADMIN_PASSWORD` must not be used as the login authority
 - [ ] [Always][MEDIUM] Admin session storage secret is non-default
   - Grep: `admin_storage_secret` loaded from environment settings (not hardcoded string)
+- [ ] [When applicable][MEDIUM] Admin session cookie is hardened in strict environments
+  - Detection condition: NiceGUI admin active (project-dna.md §8 "NiceGUI (BaseAdminPage)") AND `ENV` in {stg, prod}
+  - Grep: `ui.run_with(` in `src/_apps/admin/bootstrap.py` -> verify the Starlette session cookie is not left at framework defaults (`https_only=False`, `same_site="lax"`). Strict envs should serve the cookie with `https_only=True` and consider `same_site="strict"`.
+  - Reason: admin auth state lives in the `app.storage.user` session cookie; a non-`Secure` cookie can leak over plaintext transport and a lax `SameSite` widens cross-origin/CSRF exposure of the admin session
 - [ ] [Always][LOW] Admin pages do not directly import domain Services
   - Grep: No `from src.*.domain.services` in `interface/admin/pages/` files
 

--- a/src/_core/config.py
+++ b/src/_core/config.py
@@ -738,6 +738,19 @@ class Settings(BaseSettings):
                 f"'{self.env}' until tenant-aware API authentication exists"
             )
 
+        # CORS trust boundary: a wildcard origin combined with
+        # ``allow_credentials=True`` (see src/_apps/server/bootstrap.py) lets
+        # Starlette reflect ANY Origin with Access-Control-Allow-Credentials,
+        # so a malicious site could read credentialed responses (notably the
+        # cookie-backed NiceGUI admin session). Force an explicit allowlist in
+        # strict environments; dev/local/quickstart keep the convenient "*".
+        if env in STRICT_ENVS and "*" in self.allow_origins:
+            errors.append(
+                "[allow_origins] ALLOW_ORIGINS must not contain '*' in "
+                f"'{self.env}' (wildcard origin with allow_credentials=True is "
+                "unsafe). Set an explicit origin allowlist."
+            )
+
         if errors:
             bullet_list = "\n  - ".join(errors)
             raise ValueError(

--- a/src/docs/interface/server/routers/docs_router.py
+++ b/src/docs/interface/server/routers/docs_router.py
@@ -24,8 +24,9 @@ router = APIRouter()
 # #197 Phase 1+2 — protect write ops + the LLM-invoking query.
 # RAG indirect injection's supply surface is `POST /docs/documents`, so it
 # must require authentication even though the model is invoked elsewhere.
-# GET endpoints intentionally left public; if PO wants full-gating, add
-# `dependencies=[Depends(get_current_user)]` to them as a one-line follow-up.
+# GET endpoints are also authenticated: `DocumentResponse` returns the full
+# raw `content`, so leaving reads public would let any unauthenticated caller
+# enumerate and exfiltrate every stored document (Broken Access Control).
 
 
 # ==========================================================================================
@@ -62,6 +63,7 @@ async def create_document(
     "/docs/documents",
     summary="List docs documents",
     response_model=SuccessResponse[list[DocumentResponse]],
+    dependencies=[Depends(get_current_user)],
 )
 @inject
 async def list_documents(
@@ -83,6 +85,7 @@ async def list_documents(
     summary="Get docs document by ID",
     response_model=SuccessResponse[DocumentResponse],
     response_model_exclude={"pagination"},
+    dependencies=[Depends(get_current_user)],
 )
 @inject
 async def get_document(

--- a/tests/e2e/docs/test_docs_router.py
+++ b/tests/e2e/docs/test_docs_router.py
@@ -42,8 +42,10 @@ async def _create_document(client: AsyncClient, title: str, content: str) -> dic
 
 @pytest.mark.asyncio
 async def test_docs_protected_routes_return_401_without_bearer():
-    """POST /docs/documents, DELETE /docs/documents/{id}, POST /docs/query
-    all require a Bearer header. GET endpoints stay public (intentional).
+    """Every /docs route requires a Bearer header. The GET reads are gated too
+    because ``DocumentResponse`` returns the full raw ``content`` — public reads
+    would let any unauthenticated caller enumerate and exfiltrate stored
+    documents (Broken Access Control).
     """
     reset_current_user_override(app)
     try:
@@ -57,10 +59,12 @@ async def test_docs_protected_routes_return_401_without_bearer():
                 "/v1/docs/query",
                 json={"question": "x", "topK": 1},
             )
+            list_docs = await client.get("/v1/docs/documents?pageSize=10")
+            get_doc = await client.get("/v1/docs/documents/1")
     finally:
         override_current_user(app, make_user_dto())
 
-    for resp in (create, delete, query):
+    for resp in (create, delete, query, list_docs, get_doc):
         assert resp.status_code == 401, resp.text
         assert resp.json()["errorCode"] == "UNAUTHORIZED"
 

--- a/tests/unit/_core/test_config.py
+++ b/tests/unit/_core/test_config.py
@@ -31,6 +31,9 @@ def _make_safe_env(env_name: str = "prod") -> dict[str, str]:
         "AWS_SQS_ACCESS_KEY": "test-key",
         "AWS_SQS_SECRET_KEY": "test-secret",
         "AWS_SQS_URL": "https://sqs.ap-northeast-2.amazonaws.com/123/test",
+        # Strict envs reject the wildcard origin default, so a safe value is
+        # part of the baseline "safe" environment.
+        "ALLOW_ORIGINS": '["https://app.example.com"]',
     }
 
 
@@ -95,7 +98,8 @@ class TestStrictEnvRejectsUnsafeDefaults:
                 _create_settings()
             error_message = str(exc_info.value)
             # +1 vs pre-ADR-049: ADMIN_JWT_SECRET_KEY must be explicitly set in strict envs
-            assert "6 error(s)" in error_message
+            # +1 for the wildcard ALLOW_ORIGINS default rejected in strict envs
+            assert "7 error(s)" in error_message
 
     def test_admin_bootstrap_requires_password_when_enabled(self):
         env = {"ENV": "local", "ADMIN_BOOTSTRAP_ENABLED": "true", **_REQUIRED_VARS}
@@ -144,6 +148,25 @@ class TestStrictEnvRejectsUnsafeDefaults:
         with patch.dict(os.environ, safe_env, clear=True):
             with pytest.raises(ValidationError, match="AI_USAGE_PUBLIC_API_ENABLED"):
                 _create_settings()
+
+    @pytest.mark.parametrize("env_name", ["prod", "stg"])
+    @pytest.mark.parametrize("origins", ['["*"]', '["https://app.example.com", "*"]'])
+    def test_strict_env_rejects_wildcard_allow_origins(self, env_name, origins):
+        # Wildcard origin + allow_credentials=True (bootstrap) lets Starlette
+        # reflect any Origin with credentials — unsafe for the cookie-backed
+        # admin session. Strict envs must use an explicit allowlist.
+        safe_env = _make_safe_env(env_name)
+        safe_env["ALLOW_ORIGINS"] = origins
+        with patch.dict(os.environ, safe_env, clear=True):
+            with pytest.raises(ValidationError, match="allow_origins"):
+                _create_settings()
+
+    @pytest.mark.parametrize("env_name", ["local", "dev", "quickstart"])
+    def test_non_strict_env_allows_wildcard_allow_origins(self, env_name):
+        env = {"ENV": env_name, **_REQUIRED_VARS, "ALLOW_ORIGINS": '["*"]'}
+        with patch.dict(os.environ, env, clear=True):
+            s = _create_settings()
+            assert s.allow_origins == ["*"]
 
 
 class TestUnknownEnv:


### PR DESCRIPTION
## Summary

Outcome of a full-repo OWASP `/security-review` (cross-reviewed with codex GPT-5.5 xhigh). Two **HIGH** code findings fixed + the `/sync-guidelines` closure for the drift candidates the review surfaced.

### Code fixes
**1. `fix(docs)`: require auth on document read endpoints**
`GET /v1/docs/documents` and `GET /v1/docs/documents/{id}` were public while `DocumentResponse` returns the full raw `content` (≤1M chars) — any unauthenticated caller could enumerate and exfiltrate every stored document. Both GET routes now require `Depends(get_current_user)`, matching the existing write/query gates.

**2. `fix(config)`: reject wildcard CORS origins in strict environments**
`ALLOW_ORIGINS` defaults to `["*"]` and CORS uses `allow_credentials=True`; a `stg`/`prod` deploy that forgot an explicit allowlist would let Starlette reflect any `Origin` with credentials (exploitable against the cookie-backed admin session). A strict-env validator now rejects `"*"` for `stg`/`prod`; `dev`/`local`/`quickstart` keep the wildcard.

### Docs sync (`/sync-guidelines` closure)
**3. `docs(sync)`: close security-review drift candidates**
- `project-dna.md §8` NiceGUI row: stale `#154` "DB-backed admin auth" → `admin_identity` realm (`#218`/ADR 049); §8 now agrees with §17.
- `security-checklist.md §2`: corrected a stale item that cited the customer `AuthUseCase.admin_login()`/`AuthService.verify_credentials()` (admin auth moved to `AdminAuthUseCase` + `admin_identity` `AdminAuthService` in #218).
- `security-checklist.md §2`: added a `[When applicable][MEDIUM]` admin session-cookie hardening item (`https_only`/`SameSite` in stg/prod).

## Tests
- `tests/e2e/docs/test_docs_router.py` — unauthenticated test now asserts `401` on the two GET reads.
- `tests/unit/_core/test_config.py` — `test_strict_env_rejects_wildcard_allow_origins` + `test_non_strict_env_allows_wildcard_allow_origins`; `_make_safe_env` sets a safe `ALLOW_ORIGINS`; all-errors count `6 → 7`.
- `make check` green: **1144 passed, 17 skipped**. Tier-1 language policy: 0 violations.

## Cross-review (codex GPT-5.5 xhigh)
- **Security round 1:** refuted a false-positive HIGH on `/v1/usage` (router unmounted unless `AI_USAGE_PUBLIC_API_ENABLED`, forbidden in strict envs); escalated docs-GET to HIGH. Both verified against live code.
- **Security round 2 (code diff):** `clean`.
- **Sync review (docs diff):** `closed`, Sync Required `false` — symbols match live code, no duplicated Codex-side body, parity intact.

## Still open (reported, not in this PR)
- **MEDIUM** admin session cookie hardening is now *documented* in the checklist; the actual `ui.run_with(...)` cookie-flag change is a follow-up.
- **NOTE** `scripts/demo-rag.sh` posts documents without a Bearer token — already broken by the pre-existing write gate (independent of this change).

## Governor Footer
- trigger: yes
- reviewer: codex-cli
- rounds: 2
- r-points-fixed: 6
- r-points-deferred: 0
- r-points-rejected: 1
- touched-adr-consequences: none
- pr-scope-notes: admin session-cookie hardening is documented in the checklist; the ui.run_with cookie-flag change is a follow-up
- final-verdict: merge-ready
- links: https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/227
