### PR TITLE
fix(admin): cleanup — broken dashboard redirect + dashboard/nav tidy-ups

### DIFF
--- a/src/_apps/admin/dashboard_metrics.py
+++ b/src/_apps/admin/dashboard_metrics.py
@@ -1,9 +1,9 @@
 """Dashboard read facade for the admin landing page.
 
 Isolates **all** data gathering for ``/admin/`` so the page file
-(``pages/dashboard.py``) stays a thin renderer (Codex cross-review: a core
-admin landing page must not embed cross-domain orchestration, dynamic service
-probing, or error isolation inline).
+(``pages/dashboard.py``) stays a thin renderer — a core admin landing page must
+not embed cross-domain orchestration, dynamic service probing, or error
+isolation inline.
 
 Design invariants:
 
@@ -79,9 +79,10 @@ async def _count_for(config: BaseAdminPage) -> DomainCount:
     count: int | None
     try:
         service = config._get_service()
-        # count_datas lives on BaseService but not on AdminCrudServiceProtocol;
-        # probe dynamically here so the shared protocol stays a minimal CRUD
-        # contract (Codex cross-review).
+        # count_datas lives on BaseService but not on AdminCrudServiceProtocol
+        # (that contract is scoped to what BaseAdminPage itself uses); probe it
+        # dynamically here so the shared CRUD protocol stays minimal and is not
+        # coupled to this dashboard-only need.
         count_datas = getattr(service, "count_datas", None)
         if count_datas is None:
             raise AttributeError("service does not implement count_datas")

--- a/src/_core/infrastructure/admin/auth.py
+++ b/src/_core/infrastructure/admin/auth.py
@@ -194,7 +194,7 @@ async def require_auth(*, page_key: str) -> AdminSessionDTO | None:
         return None
 
     if page_key not in session.permissions:
-        ui.navigate.to("/admin/dashboard")
+        ui.navigate.to("/admin/")
         return None
 
     return session
@@ -216,7 +216,7 @@ def get_admin_account_use_case() -> AdminAccountUseCase:
 async def require_auth_allowlisted() -> AdminSessionDTO | None:
     """Auth gate for pages that don't require a specific page permission.
 
-    Used by: /admin/dashboard, /admin/change-password.
+    Used by: /admin/ (dashboard), /admin/change-password.
     Redirects unauthenticated users to login.
     Does NOT check page-level permissions.
     """

--- a/src/_core/infrastructure/admin/components/charts.py
+++ b/src/_core/infrastructure/admin/components/charts.py
@@ -20,7 +20,7 @@ from src._core.config import settings
 from src._core.infrastructure.admin.theme import (
     AdminClasses,
     AdminColors,
-    palette_accent,
+    palette_primary,
 )
 
 
@@ -29,10 +29,10 @@ def bar_chart(categories: Sequence[str], values: Sequence[float]) -> ui.echart:
 
     The container height comes from :data:`AdminClasses.CHART` (theme CSS), not
     an inline style, so it stays in the design-system token surface. The bar
-    fill tracks the active ``ADMIN_THEME_PALETTE`` accent so the chart matches
-    the rest of the shell under any preset.
+    fill tracks the active ``ADMIN_THEME_PALETTE`` primary color so the chart
+    matches the rest of the shell under any preset.
     """
-    bar_color = palette_accent(settings.admin_theme_palette)
+    bar_color = palette_primary(settings.admin_theme_palette)
     return ui.echart(
         {
             "textStyle": {"color": AdminColors.CHART_AXIS},

--- a/src/_core/infrastructure/admin/layout.py
+++ b/src/_core/infrastructure/admin/layout.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
@@ -73,11 +73,14 @@ def admin_layout(
     # rather than hiding it, so navigation stays reachable while reclaiming
     # content width. On narrow viewports Quasar overlays the drawer and ``mini``
     # has no effect, so there we fall back to a plain show/hide toggle — without
-    # this, the menu button would do nothing on mobile (Codex cross-review).
-    # ``collapse_icon`` is the in-drawer chevron whose direction flips on toggle.
-    nav_state: dict[str, object] = {"mini": False, "collapse_icon": None}
+    # this, the menu button would do nothing on mobile.
+    nav_mini = False
+    # The in-drawer chevron, assigned once the collapse control renders below;
+    # its direction flips on each toggle.
+    collapse_icon: ui.icon | None = None
 
     async def _toggle_nav() -> None:
+        nonlocal nav_mini
         # run_javascript may raise TimeoutError (NiceGUI 3.9+) if the client is
         # slow/disconnected; fall back to the desktop mini toggle rather than
         # letting the event handler raise.
@@ -88,12 +91,12 @@ def admin_layout(
         if isinstance(width, (int, float)) and width < 1024:
             drawer.toggle()
             return
-        mini = not nav_state["mini"]
-        nav_state["mini"] = mini
-        drawer.props(add="mini") if mini else drawer.props(remove="mini")
-        icon = nav_state["collapse_icon"]
-        if isinstance(icon, ui.icon):
-            icon.props(f"name={'chevron_right' if mini else 'chevron_left'}")
+        nav_mini = not nav_mini
+        drawer.props(add="mini") if nav_mini else drawer.props(remove="mini")
+        if collapse_icon is not None:
+            collapse_icon.props(
+                f"name={'chevron_right' if nav_mini else 'chevron_left'}"
+            )
 
     with ui.header(elevated=True).classes(
         f"items-center justify-between {AdminClasses.HEADER}"
@@ -128,7 +131,7 @@ def admin_layout(
         # Collapse control at the TOP of the drawer (above the nav), set off by a
         # separator: prominent enough to notice, and the directional chevron +
         # divider keep it from reading as just another nav icon in the mini rail.
-        _render_collapse_control(on_click=_toggle_nav, icon_holder=nav_state)
+        collapse_icon = _render_collapse_control(on_click=_toggle_nav)
         ui.separator().classes("q-my-xs")
 
         _nav_item(
@@ -173,24 +176,23 @@ def _nav_section(title: str) -> None:
     ui.label(title).classes(f"{AdminClasses.NAV_SECTION} q-mt-md q-mb-xs q-ml-md")
 
 
-def _render_collapse_control(*, on_click, icon_holder: dict) -> None:
+def _render_collapse_control(*, on_click: Callable[[], Awaitable[None]]) -> ui.icon:
     """Render the 'Collapse' control (top of the drawer) that toggles the mini rail.
 
     Attached to the drawer (not the header) so the affordance sits on the panel
     it controls — far more discoverable than the detached header hamburger, and
     placed at the top (above a separator) so it is noticeable without being
     mistaken for a nav item. Built as a ``ui.item`` so Quasar hides the text
-    label in the mini rail, leaving just the chevron (whose direction flips on
-    toggle). The stored icon handle lets :func:`admin_layout`'s toggle flip it.
+    label in the mini rail, leaving just the chevron. Returns the chevron handle
+    so :func:`admin_layout`'s toggle can flip its direction.
     """
     item = ui.item(on_click=on_click).props('aria-label="Collapse sidebar"')
     with item:
         with ui.item_section().props("avatar"):
-            icon_holder["collapse_icon"] = ui.icon("chevron_left").classes(
-                AdminClasses.MUTED
-            )
+            icon = ui.icon("chevron_left").classes(AdminClasses.MUTED)
         with ui.item_section():
             ui.label("Collapse").classes(AdminClasses.MUTED)
+    return icon
 
 
 def _nav_item(*, label: str, icon: str, target: str, active: bool) -> None:
@@ -260,10 +262,6 @@ def _stored_dark_preference() -> bool | None:
 
 def _app_username() -> str | None:
     return app.storage.user.get("username")  # type: ignore[return-value]
-
-
-# Keep the old name as an alias so existing callers still work.
-app_username = _app_username
 
 
 async def _handle_logout() -> None:

--- a/src/_core/infrastructure/admin/theme.py
+++ b/src/_core/infrastructure/admin/theme.py
@@ -4,7 +4,7 @@ Single source of truth for admin colors, **style tokens** (radius, shadow,
 border treatment), layout metrics, and the helper CSS classes + Quasar
 component overrides that every admin page inherits.
 
-Design (see plan #193 / Codex cross-review):
+Design (see plan #193):
 
 * The look is driven by CSS custom properties: ``--q-*`` (Quasar brand) and
   ``--admin-*`` (semantic + style) variables. The shell **chrome** (header +
@@ -406,12 +406,12 @@ body {
 """
 
 
-def palette_accent(palette: str = DEFAULT_PALETTE) -> str:
-    """Return the selected preset's primary/accent color.
+def palette_primary(palette: str = DEFAULT_PALETTE) -> str:
+    """Return the selected preset's primary brand color (``--q-primary``).
 
     Used by chart builders whose canvas lives outside the CSS-var cascade, so a
     palette-driven element (e.g. a bar fill) still tracks ``ADMIN_THEME_PALETTE``
-    instead of hardcoding the default-preset accent. Unknown names fall back to
+    instead of hardcoding the default-preset color. Unknown names fall back to
     :data:`DEFAULT_PALETTE`.
     """
     name = palette if palette in _PALETTES else DEFAULT_PALETTE

--- a/tests/unit/_core/infrastructure/admin/test_auth.py
+++ b/tests/unit/_core/infrastructure/admin/test_auth.py
@@ -251,7 +251,9 @@ async def test_require_auth_redirects_to_dashboard_for_page_not_in_permissions(
 
     result = await admin_auth.require_auth(page_key=_TEST_PAGE_KEY)
     assert result is None
-    assert fake_navigate.target == "/admin/dashboard"
+    # Redirect lands on the dashboard landing, whose route is "/admin/"
+    # (there is no "/admin/dashboard" route).
+    assert fake_navigate.target == "/admin/"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/_core/infrastructure/admin/test_theme.py
+++ b/tests/unit/_core/infrastructure/admin/test_theme.py
@@ -16,7 +16,7 @@ from src._core.infrastructure.admin.theme import (
     AdminMetrics,
     AdminVars,
     build_admin_css,
-    palette_accent,
+    palette_primary,
 )
 
 
@@ -40,17 +40,17 @@ def test_css_var_names_are_custom_properties():
     assert all(isinstance(v, str) and v.startswith("--") for v in values)
 
 
-def test_palette_accent_tracks_selected_preset():
+def test_palette_primary_tracks_selected_preset():
     """Chart fill resolves per-preset (so charts match ADMIN_THEME_PALETTE)."""
     # supabase is the most divergent preset (green, not indigo).
-    assert palette_accent("supabase") == "#3ecf8e"
-    assert palette_accent("default") == AdminColors.PRIMARY
+    assert palette_primary("supabase") == "#3ecf8e"
+    assert palette_primary("default") == AdminColors.PRIMARY
     # Every preset resolves to a hex color.
-    assert all(palette_accent(p).startswith("#") for p in PALETTES)
+    assert all(palette_primary(p).startswith("#") for p in PALETTES)
 
 
-def test_palette_accent_unknown_falls_back_to_default():
-    assert palette_accent("does-not-exist") == palette_accent(DEFAULT_PALETTE)
+def test_palette_primary_unknown_falls_back_to_default():
+    assert palette_primary("does-not-exist") == palette_primary(DEFAULT_PALETTE)
 
 
 def test_helper_class_names_are_admin_prefixed():


### PR DESCRIPTION
## Related Issue
- Closes #229

## Change Summary
Admin code cleanup surfaced by a Codex cross-review of the v0.7.0 dashboard code. One real bug fix + internal tidy-ups (no user-facing change beyond the redirect):

- **fix**: `require_auth` redirected page-denied operators to `/admin/dashboard`, a non-existent route (dashboard is `@ui.page("/admin/")`) → blank/404. Now redirects to `/admin/`; stale docstring fixed. (The existing test asserted the broken target — updated.)
- **refactor**: rename `theme.palette_accent` → `palette_primary` (returns `--q-primary`, not the accent); simplify the drawer mini-rail nav state (`nonlocal` bool + returned `collapse_icon` handle, dropping `dict[str, object]` + `isinstance`); remove the dead `app_username` alias; strip dev-process comments from shipped source + reword the `count_datas` comment to state the design reason on its merits.

`count_datas` quarantine **kept** (decided on merits: `AdminCrudServiceProtocol` is scoped to what `BaseAdminPage` uses; count is a dashboard-only need — not added to the shared CRUD contract).

## Type of Change
- [x] fix: Bug fix
- [x] refactor: Code restructuring

## Checklist
- [x] Architecture rules followed
- [x] Tests pass (`make check-core`: 1144 passed)
- [x] Linting passes (`ruff check src/`) + pyright clean

## How to Test
- `uv run pytest tests/unit/_core/infrastructure/admin/ -q` → 126 pass (redirect target + palette rename covered).
- Manually: log in as an operator lacking a page permission → you land on `/admin/` (dashboard), not a blank page.

## Independent Review (ADR 048) — cross-tool (codex-cli)
Codex GPT-5.5 (xhigh) reviewed the diff → **merge-ready, no findings**. Confirmed the `nonlocal nav_mini` + free-variable `collapse_icon` closure is correct Python and no behavior changed beyond the redirect fix.

---

## Governor Footer
- trigger: no
- reviewer: codex-cli
- rounds: 1
- r-points-fixed: 0
- r-points-deferred: 0
- r-points-rejected: 0
- touched-adr-consequences: none
- pr-scope-notes: src-only admin cleanup; no Tier A / .claude/rules / ADR change
- final-verdict: merge-ready
- links: https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/230
