### PR TITLE
fix(worker): InMemory broker docs + standalone-worker guard, plus T0 trust-signal cleanup (#241, #242)

### DIFF
--- a/.claude/rules/commands.md
+++ b/.claude/rules/commands.md
@@ -123,9 +123,13 @@ pytest tests/integration/ -v -k "dynamo"
 
 ## Broker
 ```bash
-BROKER_TYPE=inmemory python run_worker_local.py --env local   # default
+# A standalone worker requires a cross-process broker (RabbitMQ or SQS).
 BROKER_TYPE=rabbitmq RABBITMQ_URL=amqp://guest:guest@localhost:5672/ python run_worker_local.py --env local
 ```
+
+> `BROKER_TYPE=inmemory` (the dev/quickstart default) executes tasks **inline in the producer
+> process**; `InMemoryBroker.listen()` raises, so it cannot back a standalone
+> `run_worker_local.py`. Use RabbitMQ or SQS to run a separate worker process.
 
 ## Storage
 ```bash

--- a/.claude/rules/project-status.md
+++ b/.claude/rules/project-status.md
@@ -1,11 +1,11 @@
 # Project Status
 
-> Last synced: 2026-06-10 — `toss` admin theme preset (#235) + AG Grid empty-list render fix (#234) on branch `feat/admin-toss-theme` (unreleased)
+> Last synced: 2026-06-17 — single Toss admin theme (#235) + AG Grid render fix (#234) merged to `main`; contributor examples `blog/` (#237) + `webhook_receiver/` (#240) landed. Unreleased: latest tag is v0.7.2, `main` is ahead (release pending).
 
 ## Current Version Context
 - Latest release: v0.7.2 (2026-06-04)
 - Active domains: auth (customer JWT access/refresh token API, #4), user (reference domain — pure customer identity after #218; admin fields removed), admin_identity (admin/operator identity + separate JWT realm, #218/ADR 049), classification (prototype), docs (RAG consumer example, #80), ai_usage (usage ledger, #75)
-- Contributor examples: `examples/todo/` (minimal CRUD, mirrors `src/user/` layout — see [`examples/README.md`](../../examples/README.md))
+- Contributor examples: `examples/todo/` (minimal CRUD, mirrors `src/user/` layout), `examples/blog/` (Protocol-based cross-domain DIP, #237), `examples/webhook_receiver/` (background worker task, #240) — see [`examples/README.md`](../../examples/README.md)
 - Infrastructure: RDB (PostgreSQL/MySQL/SQLite), DynamoDB, Storage (S3/MinIO), S3 Vectors, InMemory Vectors (quickstart), Embedding (PydanticAI + StubEmbedder fallback), LLM (PydanticAI Agent + TestModel stub fallback via `build_stub_llm_model`), RagPipeline (+ StubAnswerAgent), Broker (SQS/RabbitMQ/InMemory), Structured logging (structlog + asgi-correlation-id), JWT auth (HS256 v1). All non-DB infras optional via `providers.Selector` + lazy factories (ADR 042). `nicegui` in `admin` extra, `boto3`/`aioboto3` in `aws` extra (#104). Admin identity is a separate bounded context with its own credential store + JWT realm (distinct secret/issuer/audience); NiceGUI admin login + page-level permissions backed by `admin_identity` (#218/ADR 049, supersedes the #154/#194 single-table model).
 
 ## Recent Major Changes (since v0.6.0)

--- a/.github/workflows/governor-footer-lint.yml
+++ b/.github/workflows/governor-footer-lint.yml
@@ -61,8 +61,13 @@ jobs:
             echo '```'
           } > lint_comment.md
 
+      # Fork PRs receive a read-only GITHUB_TOKEN, so posting/deleting a PR
+      # comment fails with "Resource not accessible by integration". Keep the
+      # comment steps best-effort (continue-on-error) so they never turn an
+      # otherwise-passing check red — the real gate is the "Fail job" step below.
       - name: Update sticky comment on failure
         if: steps.lint.outputs.exit_code != '0'
+        continue-on-error: true
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: governor-footer-lint
@@ -70,6 +75,7 @@ jobs:
 
       - name: Clear sticky comment on pass
         if: steps.lint.outputs.exit_code == '0'
+        continue-on-error: true
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: governor-footer-lint

--- a/.gitignore
+++ b/.gitignore
@@ -179,6 +179,7 @@ quickstart.db
 
 # Claude Code per-user local overrides
 .claude/settings.local.json
+.claude/launch.json
 
 # Per-session governor state (exception-token markers, etc.) — Phase 2 #121
 .claude/state/

--- a/Makefile
+++ b/Makefile
@@ -46,11 +46,11 @@ dev:
 	docker compose -f docker-compose.local.yml up -d postgres && \
 	sleep 2 && \
 	uv run alembic upgrade head && \
-	uv run python run_server_local.py
+	uv run python run_server_local.py --env local
 
-## Start worker locally
+## Start worker locally (cross-process broker required — set BROKER_TYPE=rabbitmq|sqs)
 worker:
-	uv run python run_worker_local.py
+	uv run python run_worker_local.py --env local
 
 ## Start Taskiq scheduler locally — separate process from the worker; enqueues
 ## @broker.task schedule labels. Skip in deployments that prefer external cron.

--- a/docs/canonical-demo.md
+++ b/docs/canonical-demo.md
@@ -90,24 +90,24 @@ Open `http://127.0.0.1:8001/admin` in a browser.
 
 ## Step 5 — Background worker
 
-In a third terminal:
+The quickstart runs on the **InMemory broker** (`BROKER_TYPE=inmemory`), which executes Taskiq
+tasks **synchronously inline inside the API server process** — there is no separate worker to
+start (`InMemoryBroker.listen()` raises, so it cannot back a standalone `make worker`). The
+`docs` domain dispatches a background ingestion task when a document exceeds the inline
+threshold (20,000 characters); in quickstart mode that work runs in-process, so the upload in
+Step 3 already exercised it.
+
+To watch a **standalone worker** pull jobs across process boundaries, switch to a cross-process
+broker. Start RabbitMQ, set `BROKER_TYPE=rabbitmq` + `RABBITMQ_URL` in your env file, then run
+the server and worker in the same environment (the
+[`examples/webhook_receiver/` README](../examples/webhook_receiver/README.md) walks through the
+full recipe):
 
 ```bash
-make worker
-```
-
-Expected: worker connects to the InMemory broker and subscribes to task queues:
-
-```text
-INFO  event="worker_start" broker="inmemory"
-INFO  event="worker_ready" queues=["fastapi-agent-blueprint.user.test", "fastapi-agent-blueprint.docs.ingest"]
-```
-
-The `docs` domain dispatches a background ingestion task when a document is too large for inline processing (threshold: 20,000 characters). Upload a large document while the worker is running and you will see:
-
-```text
-INFO  event="task_received" task_name="fastapi-agent-blueprint.docs.ingest" document_id=1
-INFO  event="task_completed" task_name="fastapi-agent-blueprint.docs.ingest" duration_ms=45
+docker run -d --name rabbitmq -p 5672:5672 -p 15672:15672 rabbitmq:3-management
+# _env/quickstart.env → BROKER_TYPE=rabbitmq, RABBITMQ_URL=amqp://guest:guest@localhost:5672/
+uv run python run_server_local.py --env quickstart   # terminal 1
+uv run python run_worker_local.py --env quickstart    # terminal 2 — the standalone worker
 ```
 
 The `user` domain registers a `user.test` task as a reference example — see [`src/user/interface/worker/tasks/user_test_task.py`](../src/user/interface/worker/tasks/user_test_task.py). Replace it with domain-specific background work (email dispatch, async enrichment, scheduled jobs) following the same Taskiq pattern.

--- a/examples/README.md
+++ b/examples/README.md
@@ -91,9 +91,9 @@ Populated incrementally as contributors land the good-first-issues:
 
 | Example | Pattern it teaches | Status |
 |---|---|---|
-| `todo/` | Minimal CRUD domain (zero infra) | 🟡 tracked issue |
+| `todo/` | Minimal CRUD domain (zero infra) | ✅ [#112](https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/112) |
 | `url-shortener/` | CRUD + Taskiq worker cleanup task | 🟡 tracked issue |
-| `blog/` | Two domains + Protocol-based cross-domain DIP | 🟡 tracked issue |
+| `blog/` | Two domains + Protocol-based cross-domain DIP | ✅ [#237](https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/237) |
 | `webhook_receiver/` | Worker task driven by a broker message | ✅ [#240](https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/240) |
 | `simple-chatbot/` | Minimal PydanticAI Agent — no RAG | 🟡 tracked issue |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,6 @@ max-complexity = 20
 "**/workflows/*.py" = ["B006"]
 "tests/**/*.py" = ["S"]
 "*_test.py" = ["S"]
-"examples/**/tests/**/*.py" = ["S"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/run_worker_local.py
+++ b/run_worker_local.py
@@ -4,8 +4,16 @@ from dotenv import load_dotenv
 from taskiq.cli.worker.args import WorkerArgs
 from taskiq.cli.worker.cmd import run_worker
 
+from src._apps.worker.guards import InMemoryWorkerError, ensure_worker_capable_broker
+
 
 def main():
+    # Imported here (after load_dotenv) so the broker is selected against the
+    # chosen environment's BROKER_TYPE before we guard it.
+    from src._apps.worker.broker import broker
+
+    ensure_worker_capable_broker(broker)
+
     worker_args = WorkerArgs(
         broker="src._apps.worker.app:app",
         modules=["src._apps.worker.app"],
@@ -22,4 +30,7 @@ if __name__ == "__main__":
 
     load_dotenv(dotenv_path=f"_env/{args.env}.env", override=True)
 
-    main()
+    try:
+        main()
+    except InMemoryWorkerError as exc:
+        raise SystemExit(f"\n{exc}\n") from exc

--- a/src/_apps/worker/guards.py
+++ b/src/_apps/worker/guards.py
@@ -1,0 +1,25 @@
+from taskiq import AsyncBroker, InMemoryBroker
+
+
+class InMemoryWorkerError(RuntimeError):
+    """Raised when a standalone worker is launched on the InMemory broker.
+
+    Taskiq's ``InMemoryBroker`` executes tasks inline in the producer process and
+    ``InMemoryBroker.listen()`` raises, so a standalone worker process would
+    crash-loop. The launcher fails fast with an actionable message instead.
+    """
+
+
+def ensure_worker_capable_broker(broker: AsyncBroker) -> None:
+    """Fail fast when ``broker`` cannot back a standalone worker process.
+
+    Only the inline-only :class:`~taskiq.InMemoryBroker` is rejected; any
+    cross-process broker (RabbitMQ, SQS) is accepted.
+    """
+    if isinstance(broker, InMemoryBroker):
+        raise InMemoryWorkerError(
+            "BROKER_TYPE=inmemory cannot run a standalone worker: Taskiq's "
+            "InMemoryBroker runs tasks inline in the producer process and "
+            "InMemoryBroker.listen() raises. Set BROKER_TYPE=rabbitmq or sqs to "
+            "run a standalone worker (see docs/canonical-demo.md Step 5)."
+        )

--- a/src/_core/infrastructure/taskiq/manager.py
+++ b/src/_core/infrastructure/taskiq/manager.py
@@ -1,6 +1,9 @@
 from typing import Any
 
+import structlog
 from taskiq import AsyncBroker, SendTaskError
+
+_logger = structlog.stdlib.get_logger(__name__)
 
 
 class TaskiqManager:
@@ -16,6 +19,6 @@ class TaskiqManager:
         try:
             task = await self._broker.kick(task_name, *(args or []), **(kwargs or {}))
             return task
-        except SendTaskError as e:
-            # TODO: add logging
-            raise e
+        except SendTaskError:
+            _logger.exception("taskiq_send_failed", task_name=task_name)
+            raise

--- a/tests/unit/_apps/worker/test_broker_guard.py
+++ b/tests/unit/_apps/worker/test_broker_guard.py
@@ -1,0 +1,17 @@
+from typing import cast
+
+import pytest
+from taskiq import AsyncBroker, InMemoryBroker
+
+from src._apps.worker.guards import InMemoryWorkerError, ensure_worker_capable_broker
+
+
+def test_inmemory_broker_rejected_for_standalone_worker():
+    with pytest.raises(InMemoryWorkerError, match="BROKER_TYPE"):
+        ensure_worker_capable_broker(InMemoryBroker())
+
+
+def test_listenable_broker_passes_guard():
+    # Any non-InMemory broker is accepted — the guard only blocks the
+    # inline-only InMemoryBroker that cannot back a standalone worker.
+    ensure_worker_capable_broker(cast(AsyncBroker, object()))


### PR DESCRIPTION
## Related Issue
- Fixes #241
- Fixes #242

## Change Summary

T0 "trust-signal" fixes — remove the rough edges a visitor hits when evaluating the blueprint as a base codebase. No feature/architecture changes.

- **#241 — InMemory broker worker docs**: `.claude/rules/commands.md` and `docs/canonical-demo.md` no longer present a standalone worker on the InMemory broker (which crash-loops — `InMemoryBroker.listen()` raises). They now explain InMemory runs tasks inline in the producer and point to the RabbitMQ/SQS recipe (consistent with the `examples/webhook_receiver/` README from #96). Also removed fabricated `worker_start`/`worker_ready` log lines that do not exist in source.
- **`make worker` root cause (beyond docs)**: `make worker` / `make dev` invoked their launchers without the required `--env`, and `run_worker_local.py` would crash-loop on the default InMemory broker. Added `--env local` to both targets (parity with `make scheduler`) and a fast-fail guard (`src/_apps/worker/guards.py`) that exits with an actionable message when a standalone worker is launched on the InMemory broker, plus a unit test.
- **#242 — examples housekeeping**: dropped the now-vestigial `examples/**/tests/**/*.py` ruff ignore (matches 0 files), and flipped the `todo/` + `blog/` catalog rows from 🟡 to ✅ (both have landed: #112, #237).
- **Fork-PR CI friction**: the `Governor Footer Lint` comment steps are now `continue-on-error`, so a fork's read-only `GITHUB_TOKEN` ("Resource not accessible by integration") cannot turn an otherwise-passing check red — the gate stays the final lint step.
- **Misc cleanup**: gitignore `.claude/launch.json` (per-user), resolve the `taskiq/manager.py` `# TODO: add logging` with structlog, and refresh the stale `project-status.md` sync line + examples list.

## Type of Change
- [x] fix: Bug fix
- [x] docs: Documentation
- [x] chore: Build/tooling
- [x] ci: CI/CD

## Checklist
- [x] Architecture rules followed (no Domain -> Infrastructure imports)
- [x] Tests pass (`make check` — 1149 passed, 17 skipped)
- [x] Linting passes (`ruff check src/`)

## How to Test
- `make check` — full lint + format + core suite (1149 passed, 17 skipped).
- `uv run python run_worker_local.py --env quickstart` → exits immediately with the InMemory guard message instead of crash-looping.
- `uv run pytest tests/unit/_apps/worker/test_broker_guard.py` → 2 passed.
- `rg -in "inmemory" docs/ .claude/` → no standalone-worker-on-InMemory guidance remains.

## Independent Review (self-structured evidence)
- **Plan stage** — cross-reviewed by Codex GPT-5.5 (xhigh) on the overall remediation strategy (`reviewer: codex-cli`).
- **Implementation stage** (`self-structured`): verified each change against source — the `worker_start`/`worker_ready` logs were fabricated (removed); `make dev` had the identical missing-`--env` defect (fixed for parity); confirmed the structlog `format_exc_info` warning is pre-existing (reproduces with the `manager.py` change stashed); confirmed `TaskiqManager.send_task` is outside the touched test paths; `make check` green.
- **Deferred** (tracked in the remediation roadmap, not this PR): README repositioning, `make strip-ai-harness` escape hatch, growth/distribution.

## Governor Footer
- trigger: yes
- reviewer: codex-cli, self-structured
- rounds: 2
- r-points-fixed: 5
- r-points-deferred: 3
- r-points-rejected: 0
- touched-adr-consequences: none
- pr-scope-notes: T0 trust-signal fixes only; positioning / strip-harness / growth deferred to roadmap.
- final-verdict: merge-ready
- links: https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/243
