### PR TITLE
chore(release): 0.8.0

### DIFF
--- a/.claude/rules/project-status.md
+++ b/.claude/rules/project-status.md
@@ -1,9 +1,9 @@
 # Project Status
 
-> Last synced: 2026-06-17 — single Toss admin theme (#235) + AG Grid render fix (#234) merged to `main`; contributor examples `blog/` (#237) + `webhook_receiver/` (#240) landed. Unreleased: latest tag is v0.7.2, `main` is ahead (release pending).
+> Last synced: 2026-06-17 — **v0.8.0 released**: single Toss admin theme (#235; breaking — `ADMIN_THEME_PALETTE` removed) + AG Grid render fix (#234), `blog/` (#237) + `webhook_receiver/` (#240) examples, and T0 trust-signal fixes (#241/#242/#243).
 
 ## Current Version Context
-- Latest release: v0.7.2 (2026-06-04)
+- Latest release: v0.8.0 (2026-06-17)
 - Active domains: auth (customer JWT access/refresh token API, #4), user (reference domain — pure customer identity after #218; admin fields removed), admin_identity (admin/operator identity + separate JWT realm, #218/ADR 049), classification (prototype), docs (RAG consumer example, #80), ai_usage (usage ledger, #75)
 - Contributor examples: `examples/todo/` (minimal CRUD, mirrors `src/user/` layout), `examples/blog/` (Protocol-based cross-domain DIP, #237), `examples/webhook_receiver/` (background worker task, #240) — see [`examples/README.md`](../../examples/README.md)
 - Infrastructure: RDB (PostgreSQL/MySQL/SQLite), DynamoDB, Storage (S3/MinIO), S3 Vectors, InMemory Vectors (quickstart), Embedding (PydanticAI + StubEmbedder fallback), LLM (PydanticAI Agent + TestModel stub fallback via `build_stub_llm_model`), RagPipeline (+ StubAnswerAgent), Broker (SQS/RabbitMQ/InMemory), Structured logging (structlog + asgi-correlation-id), JWT auth (HS256 v1). All non-DB infras optional via `providers.Selector` + lazy factories (ADR 042). `nicegui` in `admin` extra, `boto3`/`aioboto3` in `aws` extra (#104). Admin identity is a separate bounded context with its own credential store + JWT realm (distinct secret/issuer/audience); NiceGUI admin login + page-level permissions backed by `admin_identity` (#218/ADR 049, supersedes the #154/#194 single-table model).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-06-17
+
+This release simplifies admin theming down to a single Toss-style theme — a
+breaking change that removes the multi-preset machinery — lands two new
+contributor examples, and clears a batch of trust-signal fixes around the
+worker/broker docs and fork-PR CI.
+
+> Spans every change merged since v0.7.2 (2026-06-04).
+
+### Added
+
+- **`blog` example** (`examples/blog/`) — two domains wired through Protocol-based cross-domain DIP, the canonical pattern for one domain depending on another ([#237](https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/237))
+- **`webhook_receiver` example** (`examples/webhook_receiver/`) — a fast HTTP accept that enqueues a background Taskiq task to process the payload asynchronously, then a status-polling read ([#240](https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/240))
+
+### Changed
+
+- **BREAKING — single Toss-style admin theme.** The multi-preset theming system is removed: the `ADMIN_THEME_PALETTE` setting/env var, the `_PALETTES` registry, the `palette_primary` helper, and the `default`/`linear`/`shadcn`/`supabase` presets are gone. The admin look is now two token dicts (`_ROOT_TOKENS` / `_DARK_TOKENS`) in `src/_core/infrastructure/admin/theme.py` — rebrand by editing those dicts. Ships the Toss Design System grey palette + blue/green/red semantics, a light-mode chrome flip, 20px/pill rounding, a dark-mode elevation ladder, a per-mode login backdrop + dark-mode toggle, and global micro-interactions ([#235](https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/235))
+- `make worker` and `make dev` now pass `--env local` — both previously invoked their launchers without the required `--env` and exited immediately ([#243](https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/243))
+- `run_server_local.py` honors a `PORT` env override (default `8001`), so a second instance can run alongside the primary dev server ([#235](https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/235))
+- The `Governor Footer Lint` CI comment steps are now best-effort (`continue-on-error`), so a fork PR's read-only `GITHUB_TOKEN` can no longer turn an otherwise-passing check red ([#243](https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/243))
+
+### Fixed
+
+- **AG Grid empty admin list rendered blank** — a stuck `ag-delay-render` on the grid root left rows permanently `visibility:hidden` in the NiceGUI embed (data present but invisible); `_HELPER_CSS` now forces `.admin-grid` cells visible ([#234](https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/234))
+- **InMemory broker documented as a standalone-worker default** — `commands.md` and `canonical-demo.md` told readers to run a standalone worker on `BROKER_TYPE=inmemory`, which crash-loops (`InMemoryBroker.listen()` raises). The docs now explain InMemory runs tasks inline in the producer and point to the RabbitMQ/SQS recipe, and a new fast-fail guard (`src/_apps/worker/guards.py`) exits `run_worker_local.py` with an actionable message instead of crash-looping ([#241](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/241), [#243](https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/243))
+- `TaskiqManager.send_task` now logs `SendTaskError` via structlog before re-raising ([#243](https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/243))
+- Examples catalog refreshed (`todo` / `blog` marked landed) and the now-vestigial `examples/**/tests/**` ruff ignore removed ([#242](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/242))
+
+### Docs
+
+- Worker-environment args and InMemory broker limits clarified across the example READMEs and the external-broker recipe ([#96](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/96))
+
+### Upgrading
+
+No database migration. One breaking change to act on when upgrading a derived codebase:
+
+- **`ADMIN_THEME_PALETTE` is removed.** Drop the variable if you set it — the admin now ships a single Toss-style theme. To rebrand, edit the `_ROOT_TOKENS` / `_DARK_TOKENS` dicts in `src/_core/infrastructure/admin/theme.py`; `ADMIN_BRAND_NAME` and `ADMIN_DARK_MODE_DEFAULT` still apply.
+
 ## [0.7.2] - 2026-06-04
 
 An admin code-cleanup patch on top of 0.7.1.
@@ -277,7 +315,8 @@ Quality Gate review contract, `/plan-feature` Approach Options stage,
 - ADR documentation (001-013)
 - CONTRIBUTING guide and issue templates
 
-[Unreleased]: https://github.com/Mr-DooSun/fastapi-agent-blueprint/compare/v0.7.2...HEAD
+[Unreleased]: https://github.com/Mr-DooSun/fastapi-agent-blueprint/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/Mr-DooSun/fastapi-agent-blueprint/compare/v0.7.2...v0.8.0
 [0.7.2]: https://github.com/Mr-DooSun/fastapi-agent-blueprint/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/Mr-DooSun/fastapi-agent-blueprint/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/Mr-DooSun/fastapi-agent-blueprint/compare/v0.6.0...v0.7.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fastapi-agent-blueprint"
-version = "0.7.2"
+version = "0.8.0"
 description = "FastAPI backend blueprint for AI agent apps: DDD domains, SQLAlchemy, Taskiq, RAG infra, and Claude/Codex collaboration harness"
 readme = "README.md"
 requires-python = ">=3.12.9"


### PR DESCRIPTION
## Change Summary

Release **0.8.0**. All code is already on `main`; this PR is the version + CHANGELOG + project-status paperwork.

Highlights (full notes in [`CHANGELOG.md`](CHANGELOG.md)):
- **BREAKING** — single Toss-style admin theme; the `ADMIN_THEME_PALETTE` setting/env and the multi-preset machinery are removed ([#235](https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/235))
- New contributor examples: `blog` ([#237](https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/237)) and `webhook_receiver` ([#240](https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/240))
- Trust-signal fixes: InMemory-worker docs + fast-fail guard ([#241](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/241) / [#243](https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/243)), AG Grid empty-list render ([#234](https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/234)), fork-PR governor lint, examples catalog ([#242](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/242))

## Type of Change
- [x] chore: Build/tooling

## Checklist
- [x] Tests pass (`make check` — 1149 passed, 17 skipped)
- [x] CHANGELOG verified against `git log v0.7.2..HEAD`

## How to Test
- `make check` stays green.
- After merge: tag `v0.8.0` and cut the GitHub release.

## Governor Footer
- trigger: yes
- reviewer: self-structured
- rounds: 1
- r-points-fixed: 0
- r-points-deferred: 0
- r-points-rejected: 0
- touched-adr-consequences: none
- pr-scope-notes: release paperwork only; all code already merged (#234/#235/#237/#240/#241/#242/#243); ships v0.8.0
- final-verdict: merge-ready
- links: https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/244
