### PR TITLE
fix(core): propagate domain exceptions from Database.session() (404 not-found no longer masked as 500)

### DIFF
--- a/src/_core/infrastructure/persistence/rdb/database.py
+++ b/src/_core/infrastructure/persistence/rdb/database.py
@@ -9,6 +9,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import DeclarativeBase, sessionmaker
 
+from src._core.exceptions.base_exception import BaseCustomException
 from src._core.infrastructure.persistence.rdb.config import DatabaseConfig
 from src._core.infrastructure.persistence.rdb.exceptions import DatabaseException
 
@@ -186,6 +187,15 @@ class Database:
         try:
             session = self.async_session_factory()
             yield session
+        except BaseCustomException:
+            # Domain/infra exceptions raised inside the session block — e.g. a
+            # 404 not-found from a repository, or an already-typed
+            # ``DatabaseException`` — are meant for the API layer. Roll back any
+            # pending writes but let them propagate unchanged instead of masking
+            # them as a generic 500 ``DB_INTERNAL_ERROR`` (#245).
+            if session:
+                await session.rollback()
+            raise
         except IntegrityError:
             if session:
                 await session.rollback()

--- a/tests/e2e/docs/test_docs_router.py
+++ b/tests/e2e/docs/test_docs_router.py
@@ -112,15 +112,12 @@ async def test_delete_document():
 
         fetch_resp = await client.get(f"/v1/docs/documents/{document_id}")
 
-    # NOTE: Ideally this would be 404, but the core ``Database.session``
-    # context manager wraps any in-session exception (including the
-    # 404 ``BaseCustomException`` raised by ``select_data_by_id``) into
-    # a 500 ``DB_INTERNAL_ERROR``. Pre-existing behaviour across all
-    # domains — tracked outside the RAG refactor scope.
-    assert fetch_resp.status_code in (404, 500), fetch_resp.text
-    if fetch_resp.status_code == 500:
-        body = fetch_resp.json()
-        assert "not found" in body["errorDetails"]["original_error"].lower()
+    # Deleted document → 404 not-found. The core ``Database.session`` context
+    # manager now lets a domain ``BaseCustomException`` (the 404 raised by
+    # ``select_data_by_id``) propagate instead of masking it as a 500 (#245).
+    assert fetch_resp.status_code == 404, fetch_resp.text
+    body = fetch_resp.json()
+    assert "not found" in body["message"].lower()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/_core/infrastructure/persistence/rdb/test_database_session.py
+++ b/tests/unit/_core/infrastructure/persistence/rdb/test_database_session.py
@@ -1,0 +1,35 @@
+import pytest
+
+from src._core.exceptions.base_exception import BaseCustomException
+from src._core.infrastructure.persistence.rdb.exceptions import DatabaseException
+
+
+@pytest.mark.asyncio
+async def test_session_propagates_domain_exception(test_db):
+    """Regression for #245.
+
+    A ``BaseCustomException`` raised inside the ``session()`` block — e.g. the
+    404 a repository raises on a missing row — must propagate unchanged. It must
+    NOT be masked as a 500 ``DB_INTERNAL_ERROR`` by the catch-all wrapper.
+    """
+    with pytest.raises(BaseCustomException) as exc_info:
+        async with test_db.session():
+            raise BaseCustomException(
+                status_code=404, message="missing", error_code="NOT_FOUND"
+            )
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.error_code == "NOT_FOUND"
+    # The wrapper must not have re-typed it into a DatabaseException.
+    assert not isinstance(exc_info.value, DatabaseException)
+
+
+@pytest.mark.asyncio
+async def test_session_wraps_unexpected_error(test_db):
+    """A non-domain error inside the block is still wrapped as a 500."""
+    with pytest.raises(DatabaseException) as exc_info:
+        async with test_db.session():
+            raise RuntimeError("boom")
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.error_code == "DB_INTERNAL_ERROR"


### PR DESCRIPTION
## Summary
`Database.session()` re-wrapped *every* exception raised inside an
`async with self.database.session()` block — including a domain
`BaseCustomException` (e.g. the 404 a repository raises on a missing row) — into
`DatabaseException(500, DB_INTERNAL_ERROR)`. So "get by id → missing row"
returned **500** instead of **404** across every domain, and in dev the internal
message leaked into `errorDetails.original_error`.

## Root cause
The session context manager's `except Exception as e:` also caught
`BaseCustomException`. Every repository raises not-found *inside* the session
block (`BaseRepository.select_data_by_id` and domain custom finders alike), so
the 404 was swallowed.

## Fix
- Add `except BaseCustomException: raise` ahead of the catch-all so typed
  domain/infra exceptions (and already-typed `DatabaseException`) propagate
  unchanged; only genuine driver errors become a 500. Pending writes are rolled
  back before re-raising.

## Tests
- Tighten `tests/e2e/docs/test_docs_router.py` from `(404, 500)` to `404`.
- Add `tests/unit/_core/infrastructure/persistence/rdb/test_database_session.py`:
  domain exception propagates (404 preserved, not re-typed) / non-domain error
  still wrapped as 500.
- Core suite green (1149 passed, no regressions).

Closes #245