### PR TITLE
fix(examples): make examples runnable via cp-to-src (relative imports + wire(modules))

### DIFF
--- a/examples/simple_chatbot/domain/protocols/chatbot_protocol.py
+++ b/examples/simple_chatbot/domain/protocols/chatbot_protocol.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Protocol, runtime_checkable
 
-from examples.simple_chatbot.domain.dtos.chatbot_dto import ChatReply
+from ..dtos.chatbot_dto import ChatReply
 
 
 @runtime_checkable

--- a/examples/simple_chatbot/domain/protocols/chatbot_repository_protocol.py
+++ b/examples/simple_chatbot/domain/protocols/chatbot_repository_protocol.py
@@ -1,7 +1,8 @@
 from typing import Protocol
 
-from examples.simple_chatbot.domain.dtos.chatbot_dto import ChatMessageDTO
 from src._core.domain.protocols.repository_protocol import BaseRepositoryProtocol
+
+from ..dtos.chatbot_dto import ChatMessageDTO
 
 
 class ChatbotRepositoryProtocol(BaseRepositoryProtocol[ChatMessageDTO], Protocol):

--- a/examples/simple_chatbot/domain/services/chatbot_service.py
+++ b/examples/simple_chatbot/domain/services/chatbot_service.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from examples.simple_chatbot.domain.dtos.chatbot_dto import (
+from ..dtos.chatbot_dto import (
     ChatMessageDTO,
     CreateChatMessageDTO,
 )
-from examples.simple_chatbot.domain.protocols.chatbot_protocol import ChatbotProtocol
-from examples.simple_chatbot.domain.protocols.chatbot_repository_protocol import (
+from ..protocols.chatbot_protocol import ChatbotProtocol
+from ..protocols.chatbot_repository_protocol import (
     ChatbotRepositoryProtocol,
 )
 

--- a/examples/simple_chatbot/infrastructure/chatbot/pydantic_ai_chatbot.py
+++ b/examples/simple_chatbot/infrastructure/chatbot/pydantic_ai_chatbot.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Final, LiteralString
 
-from examples.simple_chatbot.domain.dtos.chatbot_dto import ChatReply
+from ...domain.dtos.chatbot_dto import ChatReply
 
 _INSTRUCTIONS: Final[LiteralString] = "You are a helpful assistant."
 

--- a/examples/simple_chatbot/infrastructure/chatbot/stub_chatbot.py
+++ b/examples/simple_chatbot/infrastructure/chatbot/stub_chatbot.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import structlog
 
-from examples.simple_chatbot.domain.dtos.chatbot_dto import ChatReply
+from ...domain.dtos.chatbot_dto import ChatReply
 
 logger = structlog.stdlib.get_logger(__name__)
 

--- a/examples/simple_chatbot/infrastructure/di/simple_chatbot_container.py
+++ b/examples/simple_chatbot/infrastructure/di/simple_chatbot_container.py
@@ -1,14 +1,15 @@
 from dependency_injector import containers, providers
 
-from examples.simple_chatbot.domain.services.chatbot_service import ChatService
-from examples.simple_chatbot.infrastructure.chatbot.pydantic_ai_chatbot import (
+from src._core.config import settings
+
+from ...domain.services.chatbot_service import ChatService
+from ..chatbot.pydantic_ai_chatbot import (
     PydanticAIChatbot,
 )
-from examples.simple_chatbot.infrastructure.chatbot.stub_chatbot import StubChatbot
-from examples.simple_chatbot.infrastructure.repositories.chatbot_repository import (
+from ..chatbot.stub_chatbot import StubChatbot
+from ..repositories.chatbot_repository import (
     ChatbotRepository,
 )
-from src._core.config import settings
 
 
 def _chatbot_selector() -> str:

--- a/examples/simple_chatbot/infrastructure/repositories/chatbot_repository.py
+++ b/examples/simple_chatbot/infrastructure/repositories/chatbot_repository.py
@@ -1,12 +1,13 @@
-from examples.simple_chatbot.domain.dtos.chatbot_dto import ChatMessageDTO
-from examples.simple_chatbot.domain.protocols.chatbot_repository_protocol import (
-    ChatbotRepositoryProtocol,
-)
-from examples.simple_chatbot.infrastructure.database.models.chatbot_model import (
-    ChatMessageModel,
-)
 from src._core.infrastructure.persistence.rdb.base_repository import BaseRepository
 from src._core.infrastructure.persistence.rdb.database import Database
+
+from ...domain.dtos.chatbot_dto import ChatMessageDTO
+from ...domain.protocols.chatbot_repository_protocol import (
+    ChatbotRepositoryProtocol,
+)
+from ..database.models.chatbot_model import (
+    ChatMessageModel,
+)
 
 
 class ChatbotRepository(BaseRepository[ChatMessageDTO], ChatbotRepositoryProtocol):

--- a/examples/simple_chatbot/interface/server/bootstrap/simple_chatbot_bootstrap.py
+++ b/examples/simple_chatbot/interface/server/bootstrap/simple_chatbot_bootstrap.py
@@ -1,18 +1,16 @@
 from fastapi import FastAPI
 
-from examples.simple_chatbot.infrastructure.di.simple_chatbot_container import (
+from ....infrastructure.di.simple_chatbot_container import (
     SimpleChatbotContainer,
 )
-from examples.simple_chatbot.interface.server.routers import chatbot_router
+from ..routers import chatbot_router
 
 
 def create_simple_chatbot_container(
     simple_chatbot_container: SimpleChatbotContainer,
 ) -> None:
     """Wire dependencies into the simple-chatbot router package."""
-    simple_chatbot_container.wire(
-        packages=["examples.simple_chatbot.interface.server.routers"]
-    )
+    simple_chatbot_container.wire(modules=[chatbot_router])
 
 
 def setup_simple_chatbot_routes(app: FastAPI) -> None:

--- a/examples/simple_chatbot/interface/server/routers/chatbot_router.py
+++ b/examples/simple_chatbot/interface/server/routers/chatbot_router.py
@@ -3,16 +3,17 @@ from typing import Annotated
 from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends, Path
 
-from examples.simple_chatbot.domain.services.chatbot_service import ChatService
-from examples.simple_chatbot.infrastructure.di.simple_chatbot_container import (
+from src._core.application.dtos.base_response import SuccessResponse
+
+from ....domain.services.chatbot_service import ChatService
+from ....infrastructure.di.simple_chatbot_container import (
     SimpleChatbotContainer,
 )
-from examples.simple_chatbot.interface.server.schemas.chatbot_schema import (
+from ..schemas.chatbot_schema import (
     ChatHistoryResponse,
     ChatRequest,
     ChatResponse,
 )
-from src._core.application.dtos.base_response import SuccessResponse
 
 router = APIRouter()
 

--- a/examples/todo/domain/protocols/todo_repository_protocol.py
+++ b/examples/todo/domain/protocols/todo_repository_protocol.py
@@ -1,7 +1,8 @@
 from typing import Protocol
 
-from examples.todo.domain.dtos.todo_dto import TodoDTO
 from src._core.domain.protocols.repository_protocol import BaseRepositoryProtocol
+
+from ..dtos.todo_dto import TodoDTO
 
 
 class TodoRepositoryProtocol(BaseRepositoryProtocol[TodoDTO], Protocol):

--- a/examples/todo/domain/services/todo_service.py
+++ b/examples/todo/domain/services/todo_service.py
@@ -1,12 +1,13 @@
-from examples.todo.domain.dtos.todo_dto import TodoDTO
-from examples.todo.domain.protocols.todo_repository_protocol import (
-    TodoRepositoryProtocol,
-)
-from examples.todo.interface.server.schemas.todo_schema import (
+from src._core.domain.services.base_service import BaseService
+
+from ...interface.server.schemas.todo_schema import (
     CreateTodoRequest,
     UpdateTodoRequest,
 )
-from src._core.domain.services.base_service import BaseService
+from ..dtos.todo_dto import TodoDTO
+from ..protocols.todo_repository_protocol import (
+    TodoRepositoryProtocol,
+)
 
 
 class TodoService(BaseService[CreateTodoRequest, UpdateTodoRequest, TodoDTO]):

--- a/examples/todo/infrastructure/di/todo_container.py
+++ b/examples/todo/infrastructure/di/todo_container.py
@@ -1,7 +1,7 @@
 from dependency_injector import containers, providers
 
-from examples.todo.domain.services.todo_service import TodoService
-from examples.todo.infrastructure.repositories.todo_repository import TodoRepository
+from ...domain.services.todo_service import TodoService
+from ..repositories.todo_repository import TodoRepository
 
 
 class TodoContainer(containers.DeclarativeContainer):

--- a/examples/todo/infrastructure/repositories/todo_repository.py
+++ b/examples/todo/infrastructure/repositories/todo_repository.py
@@ -1,7 +1,8 @@
-from examples.todo.domain.dtos.todo_dto import TodoDTO
-from examples.todo.infrastructure.database.models.todo_model import TodoModel
 from src._core.infrastructure.persistence.rdb.base_repository import BaseRepository
 from src._core.infrastructure.persistence.rdb.database import Database
+
+from ...domain.dtos.todo_dto import TodoDTO
+from ..database.models.todo_model import TodoModel
 
 
 class TodoRepository(BaseRepository[TodoDTO]):

--- a/examples/todo/interface/server/bootstrap/todo_bootstrap.py
+++ b/examples/todo/interface/server/bootstrap/todo_bootstrap.py
@@ -2,12 +2,12 @@
 
 from fastapi import FastAPI
 
-from examples.todo.infrastructure.di.todo_container import TodoContainer
-from examples.todo.interface.server.routers import todo_router
+from ....infrastructure.di.todo_container import TodoContainer
+from ..routers import todo_router
 
 
 def create_todo_container(todo_container: TodoContainer) -> None:
-    todo_container.wire(packages=["examples.todo.interface.server.routers"])
+    todo_container.wire(modules=[todo_router])
 
 
 def setup_todo_routes(app: FastAPI) -> None:

--- a/examples/todo/interface/server/routers/todo_router.py
+++ b/examples/todo/interface/server/routers/todo_router.py
@@ -1,14 +1,15 @@
 from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends, Query
 
-from examples.todo.domain.services.todo_service import TodoService
-from examples.todo.infrastructure.di.todo_container import TodoContainer
-from examples.todo.interface.server.schemas.todo_schema import (
+from src._core.application.dtos.base_response import SuccessResponse
+
+from ....domain.services.todo_service import TodoService
+from ....infrastructure.di.todo_container import TodoContainer
+from ..schemas.todo_schema import (
     CreateTodoRequest,
     TodoResponse,
     UpdateTodoRequest,
 )
-from src._core.application.dtos.base_response import SuccessResponse
 
 router = APIRouter()
 

--- a/examples/url_shortener/interface/server/bootstrap/url_shortener_bootstrap.py
+++ b/examples/url_shortener/interface/server/bootstrap/url_shortener_bootstrap.py
@@ -9,9 +9,7 @@ from ..routers import link_router
 def create_url_shortener_container(
     url_shortener_container: UrlShortenerContainer,
 ) -> None:
-    url_shortener_container.wire(
-        packages=["src.url_shortener.interface.server.routers"]
-    )
+    url_shortener_container.wire(modules=[link_router])
 
 
 def setup_url_shortener_routes(app: FastAPI) -> None:

--- a/examples/webhook_receiver/domain/protocols/webhook_event_repository_protocol.py
+++ b/examples/webhook_receiver/domain/protocols/webhook_event_repository_protocol.py
@@ -1,7 +1,8 @@
 from typing import Protocol
 
-from examples.webhook_receiver.domain.dtos.webhook_event_dto import WebhookEventDTO
 from src._core.domain.protocols.repository_protocol import BaseRepositoryProtocol
+
+from ..dtos.webhook_event_dto import WebhookEventDTO
 
 
 class WebhookEventRepositoryProtocol(BaseRepositoryProtocol[WebhookEventDTO], Protocol):

--- a/examples/webhook_receiver/domain/services/webhook_event_service.py
+++ b/examples/webhook_receiver/domain/services/webhook_event_service.py
@@ -1,12 +1,13 @@
-from examples.webhook_receiver.domain.dtos.webhook_event_dto import WebhookEventDTO
-from examples.webhook_receiver.domain.protocols.webhook_event_repository_protocol import (
-    WebhookEventRepositoryProtocol,
-)
-from examples.webhook_receiver.interface.server.schemas.webhook_event_schema import (
+from src._core.domain.services.base_service import BaseService
+
+from ...interface.server.schemas.webhook_event_schema import (
     CreateWebhookRequest,
     UpdateWebhookEventRequest,
 )
-from src._core.domain.services.base_service import BaseService
+from ..dtos.webhook_event_dto import WebhookEventDTO
+from ..protocols.webhook_event_repository_protocol import (
+    WebhookEventRepositoryProtocol,
+)
 
 
 class WebhookEventService(

--- a/examples/webhook_receiver/infrastructure/di/webhook_receiver_container.py
+++ b/examples/webhook_receiver/infrastructure/di/webhook_receiver_container.py
@@ -1,9 +1,9 @@
 from dependency_injector import containers, providers
 
-from examples.webhook_receiver.domain.services.webhook_event_service import (
+from ...domain.services.webhook_event_service import (
     WebhookEventService,
 )
-from examples.webhook_receiver.infrastructure.repositories.webhook_event_repository import (
+from ..repositories.webhook_event_repository import (
     WebhookEventRepository,
 )
 

--- a/examples/webhook_receiver/infrastructure/repositories/webhook_event_repository.py
+++ b/examples/webhook_receiver/infrastructure/repositories/webhook_event_repository.py
@@ -1,9 +1,10 @@
-from examples.webhook_receiver.domain.dtos.webhook_event_dto import WebhookEventDTO
-from examples.webhook_receiver.infrastructure.database.models.webhook_event_model import (
-    WebhookEventModel,
-)
 from src._core.infrastructure.persistence.rdb.base_repository import BaseRepository
 from src._core.infrastructure.persistence.rdb.database import Database
+
+from ...domain.dtos.webhook_event_dto import WebhookEventDTO
+from ..database.models.webhook_event_model import (
+    WebhookEventModel,
+)
 
 
 class WebhookEventRepository(BaseRepository[WebhookEventDTO]):

--- a/examples/webhook_receiver/interface/server/bootstrap/webhook_receiver_bootstrap.py
+++ b/examples/webhook_receiver/interface/server/bootstrap/webhook_receiver_bootstrap.py
@@ -1,17 +1,20 @@
 from fastapi import FastAPI
 
-from examples.webhook_receiver.infrastructure.di.webhook_receiver_container import (
+from ....infrastructure.di.webhook_receiver_container import (
     WebhookReceiverContainer,
 )
-from examples.webhook_receiver.interface.server.routers import webhook_event_router
+from ...worker.tasks import webhook_event_task
+from ..routers import webhook_event_router
 
 
 def create_webhook_receiver_container(
     webhook_receiver_container: WebhookReceiverContainer,
 ) -> None:
-    webhook_receiver_container.wire(
-        packages=["examples.webhook_receiver.interface.server.routers"]
-    )
+    # Wire the router AND the worker task module. Under the quickstart
+    # InMemoryBroker, ``.kiq()`` runs the task inline in THIS (server) process,
+    # so the task's ``Provide[...]`` markers must be wired here too — not only in
+    # the worker bootstrap (which handles the cross-process RabbitMQ/SQS case).
+    webhook_receiver_container.wire(modules=[webhook_event_router, webhook_event_task])
 
 
 def setup_webhook_receiver_routes(app: FastAPI) -> None:

--- a/examples/webhook_receiver/interface/server/routers/webhook_event_router.py
+++ b/examples/webhook_receiver/interface/server/routers/webhook_event_router.py
@@ -1,20 +1,21 @@
 from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends
 
-from examples.webhook_receiver.domain.services.webhook_event_service import (
+from src._core.application.dtos.base_response import SuccessResponse
+
+from ....domain.services.webhook_event_service import (
     WebhookEventService,
 )
-from examples.webhook_receiver.infrastructure.di.webhook_receiver_container import (
+from ....infrastructure.di.webhook_receiver_container import (
     WebhookReceiverContainer,
 )
-from examples.webhook_receiver.interface.server.schemas.webhook_event_schema import (
+from ...worker.tasks.webhook_event_task import (
+    process_webhook_task,
+)
+from ..schemas.webhook_event_schema import (
     CreateWebhookRequest,
     WebhookEventResponse,
 )
-from examples.webhook_receiver.interface.worker.tasks.webhook_event_task import (
-    process_webhook_task,
-)
-from src._core.application.dtos.base_response import SuccessResponse
 
 router = APIRouter()
 

--- a/examples/webhook_receiver/interface/worker/bootstrap/webhook_receiver_bootstrap.py
+++ b/examples/webhook_receiver/interface/worker/bootstrap/webhook_receiver_bootstrap.py
@@ -1,7 +1,7 @@
-from examples.webhook_receiver.infrastructure.di.webhook_receiver_container import (
+from ....infrastructure.di.webhook_receiver_container import (
     WebhookReceiverContainer,
 )
-from examples.webhook_receiver.interface.worker.tasks import webhook_event_task
+from ..tasks import webhook_event_task
 
 
 def create_webhook_receiver_container(

--- a/examples/webhook_receiver/interface/worker/tasks/webhook_event_task.py
+++ b/examples/webhook_receiver/interface/worker/tasks/webhook_event_task.py
@@ -4,20 +4,21 @@ from datetime import UTC, datetime
 import structlog
 from dependency_injector.wiring import Provide, inject
 
-from examples.webhook_receiver.domain.services.webhook_event_service import (
+from src._apps.worker.broker import broker
+
+from ....domain.services.webhook_event_service import (
     WebhookEventService,
 )
-from examples.webhook_receiver.infrastructure.di.webhook_receiver_container import (
+from ....infrastructure.di.webhook_receiver_container import (
     WebhookReceiverContainer,
 )
-from examples.webhook_receiver.interface.server.schemas.webhook_event_schema import (
+from ...server.schemas.webhook_event_schema import (
     UpdateWebhookEventRequest,
 )
-from examples.webhook_receiver.interface.worker.payloads.webhook_event_payload import (
+from ..payloads.webhook_event_payload import (
     WEBHOOK_EVENT_TASK_NAME,
     WebhookEventPayload,
 )
-from src._apps.worker.broker import broker
 
 _logger = structlog.stdlib.get_logger(__name__)
 


### PR DESCRIPTION
Addresses #260 (copied-to-src examples 500 on DI wiring) for the single-domain examples. Blog remainder tracked in #261.

## Problem

`examples/*` are activated by copying into `src/`:

```bash
cp -r examples/<name> src/<name> && make quickstart
```

But the single-domain examples hardcoded `from examples.<name>.*` **absolute imports**
and wired `packages=["examples.<name>.interface.server.routers"]`. After the copy,
auto-discovery instantiates the `src.<name>` container, while the router's
`Provide[<Name>Container.<provider>]` markers still reference the
`examples.<name>` container **class** — a different object — so dependency-injector
never resolves them and every endpoint 500s:

```
AttributeError: 'Provide' object has no attribute 'reply'
```

Reproduced on the real `make quickstart` server (`POST /v1/chat` → 500). Because the
example tests import `examples.<name>.*` directly (never through `cp`), CI stayed
green and this was invisible until you actually copied an example into `src/`.

## Fix

1. **Intra-example imports → package-relative** — so the *same* class object resolves
   whether the package loads as `examples.*` (tests) or `src.*` (runtime). This matches
   `url_shortener`, which already used relative imports and already worked after `cp`.
2. **`wire(packages=["…"])` → `wire(modules=[<router>])`** in every bootstrap — targets
   the actually-loaded module object instead of a hardcoded string path. `url_shortener`'s
   server bootstrap standardized for consistency (it was the last `packages=[...]` holdout).
3. **`webhook_receiver`: server bootstrap now also wires the worker task module.** Under
   the quickstart `InMemoryBroker`, `.kiq()` runs the task **inline in the server process**,
   so the task's `Provide[…]` markers must be wired there too — not only in the worker
   bootstrap (which covers the cross-process RabbitMQ/SQS case). This latent bug was masked
   before, since the router 500'd first.

## Verification — real `make quickstart` server, `cp`-to-`src/`

| Example | Before | After |
|---|---|---|
| `simple_chatbot` — `POST /v1/chat` | 500 `'Provide' … 'reply'` | **200** ✅ |
| `todo` — `POST /v1/todo` + `GET /v1/todos` | 500 | **200** ✅ |
| `url_shortener` — `POST`/`GET /v1/link` | (already worked) | **200** ✅ |
| `webhook_receiver` — `POST /v1/webhook` → inline task → `GET /v1/webhook/1` | 500, then silent task failure | **200, `status: done`** ✅ |

- `pytest tests/unit/{simple_chatbot,todo,url_shortener,webhook_receiver}` → `6 passed, 1 skipped`
- `ruff check` + `ruff format --check` + `pre-commit` hooks → green

## Out of scope — `blog/` (tracked in #261)

The two-domain `blog/` example (cross-domain DIP) is a genuinely different case:
after `cp` it crashes on boot with `Table 'author' is already defined`, because
`post`'s container re-registers `author`'s model via an `examples.blog.author` import.
It can't be fixed by relative imports (the two domains become separate top-level
packages), and the runtime-correct `src.author` import collides with the
`examples.blog.*` test imports. Left untouched here and tracked as #261 with the
options written up.