### PR TITLE
fix(examples): blog copy-flow — relative intra-imports + src.author cross-imports

### DIFF
--- a/examples/blog/README.md
+++ b/examples/blog/README.md
@@ -33,6 +33,25 @@ The domains aren't fully independently deployable — `post` needs
 `author`'s domain types — but the infrastructure boundary stays clean
 and the consumer can be tested against a mock implementing the protocol.
 
+## Import Layout (copy-flow)
+
+Each domain uses **package-relative imports** for its own modules, so the
+package works from any parent — `examples/blog/` in this repo, `src/` after
+the copy.
+
+The two cross-domain references (`post` → `author`) are **absolute
+`src.author.*` imports** — the same pattern `src/auth` uses for `src/user`.
+They resolve only in the copied layout (`cp -r examples/blog/author/
+src/author/`); while the example sits under `examples/`, editors show them as
+unresolved. This is deliberate: pulling the author classes in through an
+`examples.blog.author.*` path after the copy would map a second `AuthorModel`
+onto the same `author` table and crash the boot
+(`Table 'author' is already defined`).
+
+`tests/unit/blog/conftest.py` builds the copied layout in a temp directory
+(extending `src.__path__`) so the unit tests import the exact modules the
+copied app runs.
+
 ## Endpoints
 
 ### Author
@@ -73,7 +92,8 @@ curl -X POST http://localhost:8001/v1/post \
   -H "Content-Type: application/json" \
   -d '{"author_id": 1, "title": "Hello World", "body": "First post!"}'
 
-# 5. Get the post — response includes author_display_name
+# 5. Get the post — response data includes "authorDisplayName": "Alice"
+#    (API responses use camelCase keys)
 curl http://localhost:8001/v1/post/1
 
 # 6. Run tests

--- a/examples/blog/author/domain/protocols/author_repository_protocol.py
+++ b/examples/blog/author/domain/protocols/author_repository_protocol.py
@@ -1,7 +1,8 @@
 from typing import Protocol
 
-from examples.blog.author.domain.dtos.author_dto import AuthorDTO
 from src._core.domain.protocols.repository_protocol import BaseRepositoryProtocol
+
+from ..dtos.author_dto import AuthorDTO
 
 
 class AuthorRepositoryProtocol(BaseRepositoryProtocol[AuthorDTO], Protocol):

--- a/examples/blog/author/domain/services/author_service.py
+++ b/examples/blog/author/domain/services/author_service.py
@@ -1,12 +1,13 @@
-from examples.blog.author.domain.dtos.author_dto import AuthorDTO
-from examples.blog.author.domain.protocols.author_repository_protocol import (
-    AuthorRepositoryProtocol,
-)
-from examples.blog.author.interface.server.schemas.author_schema import (
+from src._core.domain.services.base_service import BaseService
+
+from ...interface.server.schemas.author_schema import (
     CreateAuthorRequest,
     UpdateAuthorRequest,
 )
-from src._core.domain.services.base_service import BaseService
+from ..dtos.author_dto import AuthorDTO
+from ..protocols.author_repository_protocol import (
+    AuthorRepositoryProtocol,
+)
 
 
 class AuthorService(BaseService[CreateAuthorRequest, UpdateAuthorRequest, AuthorDTO]):

--- a/examples/blog/author/infrastructure/di/author_container.py
+++ b/examples/blog/author/infrastructure/di/author_container.py
@@ -1,7 +1,7 @@
 from dependency_injector import containers, providers
 
-from examples.blog.author.domain.services.author_service import AuthorService
-from examples.blog.author.infrastructure.repositories.author_repository import (
+from ...domain.services.author_service import AuthorService
+from ..repositories.author_repository import (
     AuthorRepository,
 )
 

--- a/examples/blog/author/infrastructure/repositories/author_repository.py
+++ b/examples/blog/author/infrastructure/repositories/author_repository.py
@@ -1,7 +1,8 @@
-from examples.blog.author.domain.dtos.author_dto import AuthorDTO
-from examples.blog.author.infrastructure.database.models.author_model import AuthorModel
 from src._core.infrastructure.persistence.rdb.base_repository import BaseRepository
 from src._core.infrastructure.persistence.rdb.database import Database
+
+from ...domain.dtos.author_dto import AuthorDTO
+from ..database.models.author_model import AuthorModel
 
 
 class AuthorRepository(BaseRepository[AuthorDTO]):

--- a/examples/blog/author/interface/server/bootstrap/author_bootstrap.py
+++ b/examples/blog/author/interface/server/bootstrap/author_bootstrap.py
@@ -2,12 +2,15 @@
 
 from fastapi import FastAPI
 
-from examples.blog.author.infrastructure.di.author_container import AuthorContainer
-from examples.blog.author.interface.server.routers import author_router
+from ....infrastructure.di.author_container import AuthorContainer
+from ..routers import author_router
 
 
 def create_author_container(author_container: AuthorContainer) -> None:
-    author_container.wire(packages=["examples.blog.author.interface.server.routers"])
+    # Wire the imported module object (not a package path string) so the
+    # Provide markers resolve no matter where the domain package lives
+    # (examples/ before the copy, src/ after).
+    author_container.wire(modules=[author_router])
 
 
 def setup_author_routes(app: FastAPI) -> None:

--- a/examples/blog/author/interface/server/routers/author_router.py
+++ b/examples/blog/author/interface/server/routers/author_router.py
@@ -1,14 +1,15 @@
 from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends, Query
 
-from examples.blog.author.domain.services.author_service import AuthorService
-from examples.blog.author.infrastructure.di.author_container import AuthorContainer
-from examples.blog.author.interface.server.schemas.author_schema import (
+from src._core.application.dtos.base_response import SuccessResponse
+
+from ....domain.services.author_service import AuthorService
+from ....infrastructure.di.author_container import AuthorContainer
+from ..schemas.author_schema import (
     AuthorResponse,
     CreateAuthorRequest,
     UpdateAuthorRequest,
 )
-from src._core.application.dtos.base_response import SuccessResponse
 
 router = APIRouter()
 

--- a/examples/blog/post/domain/protocols/post_repository_protocol.py
+++ b/examples/blog/post/domain/protocols/post_repository_protocol.py
@@ -1,7 +1,8 @@
 from typing import Protocol
 
-from examples.blog.post.domain.dtos.post_dto import PostDTO
 from src._core.domain.protocols.repository_protocol import BaseRepositoryProtocol
+
+from ..dtos.post_dto import PostDTO
 
 
 class PostRepositoryProtocol(BaseRepositoryProtocol[PostDTO], Protocol):

--- a/examples/blog/post/domain/services/post_service.py
+++ b/examples/blog/post/domain/services/post_service.py
@@ -1,16 +1,23 @@
-from examples.blog.author.domain.protocols.author_repository_protocol import (
+# Cross-domain dependency on the author domain. `src.author.*` is the layout
+# this example runs in after `cp -r examples/blog/author src/author` — the same
+# absolute-import pattern the real `src/auth -> src/user` dependency uses. It
+# does not resolve while the file still lives under examples/; the blog unit
+# tests provide a src-layout shadow via tests/unit/blog/conftest.py.
+from src.author.domain.protocols.author_repository_protocol import (
     AuthorRepositoryProtocol,
 )
-from examples.blog.post.domain.dtos.post_dto import PostDTO
-from examples.blog.post.domain.protocols.post_repository_protocol import (
-    PostRepositoryProtocol,
-)
-from examples.blog.post.interface.server.schemas.post_schema import (
+
+from src._core.domain.services.base_service import BaseService
+from src._core.domain.validation import ensure_existing_references
+
+from ...interface.server.schemas.post_schema import (
     CreatePostRequest,
     UpdatePostRequest,
 )
-from src._core.domain.services.base_service import BaseService
-from src._core.domain.validation import ensure_existing_references
+from ..dtos.post_dto import PostDTO
+from ..protocols.post_repository_protocol import (
+    PostRepositoryProtocol,
+)
 
 
 class PostService(BaseService[CreatePostRequest, UpdatePostRequest, PostDTO]):

--- a/examples/blog/post/infrastructure/di/post_container.py
+++ b/examples/blog/post/infrastructure/di/post_container.py
@@ -1,10 +1,16 @@
 from dependency_injector import containers, providers
 
-from examples.blog.author.infrastructure.repositories.author_repository import (
+# Cross-domain wiring import. After both domains are copied
+# (`cp -r examples/blog/author src/author`), the concrete AuthorRepository is
+# the class auto-discovery already registered under `src.author` — importing it
+# from anywhere else would map a second AuthorModel onto the same `author`
+# table and crash the boot. Unresolvable while this file lives under examples/.
+from src.author.infrastructure.repositories.author_repository import (
     AuthorRepository,
 )
-from examples.blog.post.domain.services.post_service import PostService
-from examples.blog.post.infrastructure.repositories.post_repository import (
+
+from ...domain.services.post_service import PostService
+from ..repositories.post_repository import (
     PostRepository,
 )
 

--- a/examples/blog/post/infrastructure/repositories/post_repository.py
+++ b/examples/blog/post/infrastructure/repositories/post_repository.py
@@ -1,7 +1,8 @@
-from examples.blog.post.domain.dtos.post_dto import PostDTO
-from examples.blog.post.infrastructure.database.models.post_model import PostModel
 from src._core.infrastructure.persistence.rdb.base_repository import BaseRepository
 from src._core.infrastructure.persistence.rdb.database import Database
+
+from ...domain.dtos.post_dto import PostDTO
+from ..database.models.post_model import PostModel
 
 
 class PostRepository(BaseRepository[PostDTO]):

--- a/examples/blog/post/interface/server/bootstrap/post_bootstrap.py
+++ b/examples/blog/post/interface/server/bootstrap/post_bootstrap.py
@@ -2,12 +2,15 @@
 
 from fastapi import FastAPI
 
-from examples.blog.post.infrastructure.di.post_container import PostContainer
-from examples.blog.post.interface.server.routers import post_router
+from ....infrastructure.di.post_container import PostContainer
+from ..routers import post_router
 
 
 def create_post_container(post_container: PostContainer) -> None:
-    post_container.wire(packages=["examples.blog.post.interface.server.routers"])
+    # Wire the imported module object (not a package path string) so the
+    # Provide markers resolve no matter where the domain package lives
+    # (examples/ before the copy, src/ after).
+    post_container.wire(modules=[post_router])
 
 
 def setup_post_routes(app: FastAPI) -> None:

--- a/examples/blog/post/interface/server/routers/post_router.py
+++ b/examples/blog/post/interface/server/routers/post_router.py
@@ -1,14 +1,15 @@
 from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends, Query
 
-from examples.blog.post.domain.services.post_service import PostService
-from examples.blog.post.infrastructure.di.post_container import PostContainer
-from examples.blog.post.interface.server.schemas.post_schema import (
+from src._core.application.dtos.base_response import SuccessResponse
+
+from ....domain.services.post_service import PostService
+from ....infrastructure.di.post_container import PostContainer
+from ..schemas.post_schema import (
     CreatePostRequest,
     PostResponse,
     UpdatePostRequest,
 )
-from src._core.application.dtos.base_response import SuccessResponse
 
 router = APIRouter()
 

--- a/tests/unit/blog/conftest.py
+++ b/tests/unit/blog/conftest.py
@@ -1,0 +1,40 @@
+"""Provide the post-copy ``src.author`` / ``src.post`` layout for blog tests.
+
+The blog example teaches the real cross-domain pattern (``src/auth -> src/user``):
+``post`` imports ``author`` via absolute ``src.author.*`` paths, which only
+resolve after the documented activation step (``cp -r examples/blog/author
+src/author``, same for ``post``). Unit tests import the service modules at
+pytest COLLECTION time — before any fixture runs — so this conftest builds the
+copied layout at module import time: it copies both example domains into a
+temp directory and extends ``src.__path__`` with it, making ``src.author`` /
+``src.post`` importable while every ``src._core.*`` module keeps resolving
+from the repo (identical class objects, no dual registration).
+
+The temp directory is removed at interpreter exit; no teardown is needed —
+nothing outside ``tests/unit/blog`` imports these packages, and
+``discover_domains()`` scans the real ``src/`` directory on disk, so the
+shadow never leaks into e2e app boots in the same session.
+"""
+
+import atexit
+import shutil
+import tempfile
+from pathlib import Path
+
+import src
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_BLOG_EXAMPLE = _REPO_ROOT / "examples" / "blog"
+
+_shadow_root = Path(tempfile.mkdtemp(prefix="blog_src_shadow_"))
+atexit.register(shutil.rmtree, _shadow_root, ignore_errors=True)
+
+for _domain in ("author", "post"):
+    shutil.copytree(
+        _BLOG_EXAMPLE / _domain,
+        _shadow_root / _domain,
+        ignore=shutil.ignore_patterns("__pycache__"),
+    )
+
+if str(_shadow_root) not in src.__path__:
+    src.__path__.append(str(_shadow_root))

--- a/tests/unit/blog/domain/test_post_service.py
+++ b/tests/unit/blog/domain/test_post_service.py
@@ -2,16 +2,16 @@ from datetime import UTC, datetime
 from unittest.mock import AsyncMock
 
 import pytest
-
-from examples.blog.author.domain.dtos.author_dto import AuthorDTO
-from examples.blog.author.domain.protocols.author_repository_protocol import (
+from src.author.domain.dtos.author_dto import AuthorDTO
+from src.author.domain.protocols.author_repository_protocol import (
     AuthorRepositoryProtocol,
 )
-from examples.blog.post.domain.protocols.post_repository_protocol import (
+from src.post.domain.protocols.post_repository_protocol import (
     PostRepositoryProtocol,
 )
-from examples.blog.post.domain.services.post_service import PostService
-from examples.blog.post.interface.server.schemas.post_schema import CreatePostRequest
+from src.post.domain.services.post_service import PostService
+from src.post.interface.server.schemas.post_schema import CreatePostRequest
+
 from src._core.domain.validation import ValidationFailed
 
 


### PR DESCRIPTION
## Related Issue
- Closes #261
- Refs #260 (unblocks the exception-free CI guard — follow-up PR)

## Change Summary
- Convert every intra-domain import in `examples/blog/{author,post}` to package-relative and switch both bootstraps to `wire(modules=[<router module>])` — the PR #262 pattern already used by the other examples.
- The two cross-domain references (`post_service` -> author protocol, `post_container` -> `AuthorRepository`) become runtime-absolute `src.author.*` imports, mirroring the real `src/auth -> src/user` precedent. They are commented as unresolvable until the documented copy step.
- `tests/unit/blog/conftest.py` builds the post-copy layout at collection time (temp copy of both domains + `src.__path__` extension), and the test imports switch to `src.author.*` / `src.post.*` — the unit tests now exercise the exact modules the copied app runs.
- Blog README: new "Import Layout (copy-flow)" section + fixes the response-key note to the actual camelCase `authorDisplayName`.

## Type of Change
- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code restructuring
- [ ] docs: Documentation
- [ ] chore: Build/tooling
- [ ] test: Tests
- [ ] ci: CI/CD
- [ ] perf: Performance
- [ ] style: Code style

## Checklist
- [x] Architecture rules followed (no Domain -> Infrastructure imports)
- [x] Tests pass
- [x] Linting passes (`ruff check`)

## How to Test
```bash
# the previously-crashing activation flow (Table 'author' is already defined):
cp -r examples/blog/author/ src/author/
cp -r examples/blog/post/  src/post/
rm -f quickstart.db && make quickstart

curl -X POST http://localhost:8001/v1/author -H 'Content-Type: application/json' -d '{"display_name": "Alice"}'
curl -X POST http://localhost:8001/v1/post   -H 'Content-Type: application/json' -d '{"author_id": 1, "title": "Hello World", "body": "First post!"}'
curl http://localhost:8001/v1/post/1   # data.authorDisplayName == "Alice"
```
- `uv run pytest tests/unit/blog -v` -> 6 passed
- `uv run pytest tests/ -v` -> 1230 passed (10 errors are the pre-existing dynamodb-local docker requirement)
- Verified end-to-end on this branch: boot OK, all three curls return 200 with `authorDisplayName: "Alice"`
