### PR TITLE
fix(harness): emit verify-first reminder on the model-visible additionalContext channel

### DIFF
--- a/.claude/hooks/verify_first.py
+++ b/.claude/hooks/verify_first.py
@@ -9,6 +9,13 @@ contract:
   byte-equal to the Codex side automatically.
 * Module-level ``sys.exit`` is forbidden (Plan §D3) — shared import
   failure → ``_SHARED_OK = False`` and ``main()`` returns 0 silently.
+
+Delivery channel (#271, ADR 050 D3 drift candidate): the reminder is
+emitted as ``hookSpecificOutput.additionalContext`` JSON on stdout with
+exit 0 — the documented model-visible, non-blocking PostToolUse channel.
+Plain stderr on exit 0 reaches only the user transcript, never the
+model, so the reminder could not influence the agent's next action.
+Mirrors the PR #270 stage-gate emit pattern.
 """
 
 from __future__ import annotations
@@ -98,8 +105,17 @@ def main() -> int:
             # IC-19: always combine resolver result with canonical English
             # fallback so an empty locale lookup never emits a blank line.
             print(
-                _resolve_locale_string("REMINDER_TEXT") or REMINDER_TEXT,
-                file=sys.stderr,
+                json.dumps(
+                    {
+                        "hookSpecificOutput": {
+                            "hookEventName": "PostToolUse",
+                            "additionalContext": (
+                                _resolve_locale_string("REMINDER_TEXT") or REMINDER_TEXT
+                            ),
+                        }
+                    },
+                    ensure_ascii=False,
+                )
             )
     except Exception:  # noqa: BLE001 — fail-open per HC-5.5
         return 0

--- a/docs/ai/shared/harness-asset-matrix.md
+++ b/docs/ai/shared/harness-asset-matrix.md
@@ -596,7 +596,7 @@ Twenty hook scripts (7 Claude shell + 5 Claude Python implementations + 8 Codex 
 - **Current role**: PostToolUse on Edit / Write; runs `ruff format` + `ruff check --fix` on `.py` files.
 - **Why it exists**: Format consistency without manual invocation.
 - **Bucket**: Keep.
-- **Notes**: Phase 3 (#122) verification-first hook (`.claude/hooks/verify-first.sh`) and #268 (ADR 050) stage-gate hook (`.claude/hooks/stage-gate.sh`) live in the *same* `PostToolUse Edit|Write` matcher block as siblings, not separate matchers. SoC: this hook mutates files (ruff); verify-first and stage-gate are advisory only.
+- **Notes**: Phase 3 (#122) verification-first hook (`.claude/hooks/verify-first.sh`) and #268 (ADR 050) stage-gate hook (`.claude/hooks/stage-gate.sh`) live in the *same* `PostToolUse Edit|Write` matcher block as siblings, not separate matchers. SoC: this hook mutates files (ruff); verify-first and stage-gate are advisory only — since #271 verify-first emits model-visible `hookSpecificOutput.additionalContext` JSON on stdout (exit 0), never blocking.
 
 ### `.claude/hooks/stop-sync-reminder.sh`
 
@@ -657,7 +657,7 @@ Twenty hook scripts (7 Claude shell + 5 Claude Python implementations + 8 Codex 
 - **Current role**: Phase 5 (#124) thin shim — the verify-first decision body now lives in `.agents/shared/governor/verify.py`. The shim imports `REMINDER_TEXT`, `is_python_source`, `extract_file_path`, and the marker reader, then exposes `read_latest_token_marker` (READ_ONLY lifecycle wrapper) and `should_remind` for the existing test surface.
 - **Why it exists**: Reminds the user that the Default Coding Flow `verify` step is missing for the changed Python file. Read-only on Phase 2 markers (IC-11 — verify-first reads with `MarkerLifecycle.READ_ONLY`; Phase 4 #123 owns lifecycle).
 - **Bucket**: Overlay.
-- **Notes**: `REMINDER_TEXT` is now a single shared constant — string-equality is intrinsic, not asserted. Phase 5 invariant: no top-level `sys.exit` (R0-A.1). Fail-open on every error path (HC-3.6 / HC-5.5).
+- **Notes**: `REMINDER_TEXT` is now a single shared constant — string-equality is intrinsic, not asserted. Phase 5 invariant: no top-level `sys.exit` (R0-A.1). Fail-open on every error path (HC-3.6 / HC-5.5). Emit channel (#271, ADR 050 D3 drift-candidate remediation): `hookSpecificOutput.additionalContext` JSON on stdout with exit 0 — the model-visible non-blocking PostToolUse channel; plain stderr on exit 0 reached only the user transcript, so the pre-#271 reminder never influenced the agent. Codex side is unaffected by design: its reminder is delivered by the Stop hook's `systemMessage`, which targets the user after the turn has ended.
 
 ### `.claude/hooks/stage-gate.sh`
 

--- a/docs/ai/shared/migration-strategy.md
+++ b/docs/ai/shared/migration-strategy.md
@@ -78,7 +78,7 @@ The shared-policy part is identical across tools; the adapters differ because th
 - After each `implement` step, the Default Flow expects a `verify` step within the same session (or before commit).
 - "Verification" includes: test invocation, `make demo`, `make demo-rag`, `alembic upgrade head` (for migration changes), or an explicit user confirmation.
 
-**Claude adapter**: extend `.claude/hooks/post-tool-format.sh` (or add a new sibling) on `PostToolUse Edit|Write` matchers. After Python file edits, suggest `/test-domain run {domain}`. Output is a stderr reminder, not a block.
+**Claude adapter**: extend `.claude/hooks/post-tool-format.sh` (or add a new sibling) on `PostToolUse Edit|Write` matchers. After Python file edits, suggest `/test-domain run {domain}`. Output is an advisory reminder, not a block — since #271 delivered as model-visible `hookSpecificOutput.additionalContext` JSON on stdout with exit 0 (the original stderr-on-exit-0 emit reached only the user transcript, never the model; recorded as an ADR 050 D3 drift candidate).
 **Codex adapter**: **cannot rely on `PostToolUse Bash`** (Codex review R7). Instead, extend `.codex/hooks/stop-sync-reminder.py` to compute `git status --porcelain` and produce the verification reminder when source files changed without a verify-class command being run. Run a small in-session log file under `.codex/state/` (gitignored) to track verify invocations within a session.
 
 **Acceptance**:

--- a/tests/unit/agents_shared/test_verify_first.py
+++ b/tests/unit/agents_shared/test_verify_first.py
@@ -12,6 +12,9 @@ smokes. Covers (per plan §4.7 + R0.5 + R1.1~R1.3):
 - subsecond ordering (R0.3 — ts_epoch_ns)
 - fail-open on missing state dir / corrupt marker / invalid JSON stdin
 - Phase 2 marker idempotency (read does not mutate file)
+- Claude emit channel (#271): hookSpecificOutput.additionalContext JSON on
+  stdout, nothing on stderr, silent stdout when not reminding, ko locale
+  routed through the envelope (IC-19)
 
 Stop-hook segment merge tests are covered by manual smoke in plan §6 (the
 `changed_files()` git status dependency makes pytest isolation brittle).
@@ -303,14 +306,36 @@ def test_codex_cross_session_does_not_silence(
 # ---------------------------------------------------------------------------
 # 16~18. Subprocess fail-open smoke (HC-3.6)
 # ---------------------------------------------------------------------------
-def _run_claude_verify_first(stdin: str) -> subprocess.CompletedProcess[str]:
+def _run_claude_verify_first(
+    stdin: str, env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(  # noqa: S603
         [sys.executable, str(CLAUDE_PY)],
         input=stdin,
         capture_output=True,
         text=True,
         check=False,
+        env=env,
     )
+
+
+def _isolated_env(tmp_path: Path, locale: str | None = None) -> dict[str, str]:
+    """Subprocess env with deterministic state dir and locale.
+
+    ``HARNESS_STATE_ROOT`` points at ``tmp_path`` so real repo markers
+    cannot silence the reminder; ``AGENT_LOCALE`` is scrubbed (or forced)
+    so the expected text is deterministic.
+    """
+    scrub = {"AGENT_LOCALE", "HARNESS_DEBUG", "HARNESS_LAUNCHER_STRICT"}
+    env = {
+        k: v
+        for k, v in __import__("os").environ.items()
+        if k not in scrub and not k.startswith("HARNESS_PYTHON_")
+    }
+    env["HARNESS_STATE_ROOT"] = str(tmp_path)
+    if locale is not None:
+        env["AGENT_LOCALE"] = locale
+    return env
 
 
 def test_fail_open_empty_stdin() -> None:
@@ -329,6 +354,100 @@ def test_fail_open_missing_state_dir(claude_helper, tmp_path) -> None:
     assert (
         claude_helper.should_remind(payload, state_dir=tmp_path / "nonexistent") is True
     )
+
+
+# ---------------------------------------------------------------------------
+# 18a~18d. Claude emit channel — model-visible additionalContext JSON (#271)
+# ---------------------------------------------------------------------------
+# ADR 050 D3 drift-candidate remediation: plain stderr on exit 0 reaches only
+# the user transcript, never the model. The reminder must be emitted as
+# hookSpecificOutput.additionalContext JSON on stdout (exit 0) — the
+# documented model-visible, non-blocking PostToolUse channel.
+def test_claude_emits_additional_context_json_on_stdout(
+    claude_helper, tmp_path
+) -> None:
+    payload = {"tool_name": "Edit", "tool_input": {"file_path": "src/foo.py"}}
+    result = _run_claude_verify_first(json.dumps(payload), env=_isolated_env(tmp_path))
+    assert result.returncode == 0
+    envelope = json.loads(result.stdout)
+    assert envelope["hookSpecificOutput"]["hookEventName"] == "PostToolUse"
+    assert (
+        envelope["hookSpecificOutput"]["additionalContext"]
+        == claude_helper.REMINDER_TEXT
+    )
+
+
+def test_claude_reminder_not_on_stderr(tmp_path) -> None:
+    """Regression for the invisible-reminder defect — stderr stays empty."""
+    payload = {"tool_name": "Edit", "tool_input": {"file_path": "src/foo.py"}}
+    result = _run_claude_verify_first(json.dumps(payload), env=_isolated_env(tmp_path))
+    assert result.returncode == 0
+    assert result.stderr.strip() == ""
+
+
+def test_claude_silent_stdout_when_not_reminding(tmp_path) -> None:
+    """Non-Python edit → no envelope at all (empty stdout, exit 0)."""
+    payload = {"tool_name": "Edit", "tool_input": {"file_path": "README.md"}}
+    result = _run_claude_verify_first(json.dumps(payload), env=_isolated_env(tmp_path))
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_claude_emit_localizes_additional_context(claude_helper, tmp_path) -> None:
+    """AGENT_LOCALE=ko routes the ko table through the JSON envelope (IC-19)."""
+    payload = {"tool_name": "Edit", "tool_input": {"file_path": "src/foo.py"}}
+    result = _run_claude_verify_first(
+        json.dumps(payload), env=_isolated_env(tmp_path, locale="ko")
+    )
+    assert result.returncode == 0
+    envelope = json.loads(result.stdout)
+    context = envelope["hookSpecificOutput"]["additionalContext"]
+    assert context  # never blank (IC-19 fallback)
+    assert context != claude_helper.REMINDER_TEXT  # actually translated
+    assert "[verify-first]" in context  # shared tag survives translation
+
+
+# ---------------------------------------------------------------------------
+# 18e~18f. Registered wrapper path — bash verify-first.sh (#271 cross-review R1)
+# ---------------------------------------------------------------------------
+# settings.json registers the .sh wrapper (which pipes through
+# harness-python.sh), not the .py module. The delivery-channel contract is
+# only real if the wrapper forwards exactly one parseable JSON document on
+# stdout — launcher/wrapper noise on stdout would corrupt the envelope.
+CLAUDE_SH = REPO_ROOT / ".claude" / "hooks" / "verify-first.sh"
+
+
+def _run_claude_wrapper(
+    stdin: str, env: dict[str, str]
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603
+        ["bash", str(CLAUDE_SH)],
+        input=stdin,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+
+def test_wrapper_stdout_is_single_json_envelope(claude_helper, tmp_path) -> None:
+    payload = {"tool_name": "Edit", "tool_input": {"file_path": "src/foo.py"}}
+    result = _run_claude_wrapper(json.dumps(payload), env=_isolated_env(tmp_path))
+    assert result.returncode == 0
+    assert result.stderr.strip() == ""
+    envelope = json.loads(result.stdout)  # exactly one JSON document
+    assert envelope["hookSpecificOutput"]["hookEventName"] == "PostToolUse"
+    assert (
+        envelope["hookSpecificOutput"]["additionalContext"]
+        == claude_helper.REMINDER_TEXT
+    )
+
+
+def test_wrapper_silent_when_not_reminding(tmp_path) -> None:
+    payload = {"tool_name": "Edit", "tool_input": {"file_path": "README.md"}}
+    result = _run_claude_wrapper(json.dumps(payload), env=_isolated_env(tmp_path))
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Related Issue
- Fixes #271

## Change Summary
- `.claude/hooks/verify_first.py` emitted its reminder via plain stderr with exit 0 — per the Claude Code hooks reference that reaches only the user-facing transcript, **never the model**, so the verify-first nudge could not influence the agent's next action (verified empirically during the ADR 050 work; recorded as the D3 drift candidate in `docs/history/050-midtask-scope-expansion-gate.md`, PR #270).
- Emit path switched to the documented model-visible non-blocking PostToolUse channel: stdout JSON `{"hookSpecificOutput": {"hookEventName": "PostToolUse", "additionalContext": <reminder>}}` with exit 0, mirroring the PR #270 stage-gate pattern. Decision logic is untouched; IC-19 locale fallback, IC-11 READ_ONLY marker lifecycle, and HC-5.5/HC-3.3 fail-open advisory-only invariants unchanged.
- Tests: JSON-envelope output assertions (en + ko locale through the envelope), empty-stderr regression, silent-stdout non-remind case, plus coverage of the **registered entry point** (`bash .claude/hooks/verify-first.sh` through `harness-python.sh`) asserting stdout carries exactly one parseable JSON document — with launcher-control env vars (`HARNESS_LAUNCHER_STRICT`, `HARNESS_PYTHON_*`) scrubbed for determinism.
- Docs: `harness-asset-matrix.md` (2 stale "informational stderr only" notes) and `migration-strategy.md` Phase 3 Claude-adapter delivery contract updated.

## Codex side (assessed, deliberately untouched)
`.codex/hooks/verify_first.py` is not a registered hook — it is a helper consumed by the Stop hook `.codex/hooks/stop-sync-reminder.py`, which merges all advisories into one `{"systemMessage": ...}`. At Stop time the turn is already over, so the user is the intended audience; the only model-visible Stop channel (`decision: "block"`) would force continuation and violate the advisory-only invariant. No equivalent defect.

## Type of Change
- [x] fix: Bug fix

## Checklist
- [x] Architecture rules followed (no Domain -> Infrastructure imports)
- [x] Tests pass
- [x] Linting passes (`ruff check src/`)

## How to Test
- `uv run pytest tests/unit/agents_shared/ -q` — 514 passed (36 in `test_verify_first.py`, 6 new)
- Adverse-env wrapper check: `HARNESS_LAUNCHER_STRICT=1 HARNESS_PYTHON_VENV=/nonexistent uv run pytest tests/unit/agents_shared/test_verify_first.py -k wrapper` — passes (isolated env scrubs launcher overrides)
- Live proof: after the edit, every subsequent `.py` Edit in the implementing Claude Code session surfaced the reminder as model-visible `PostToolUse` additional context (previously: nothing reached the model)
- `pre-commit run` on changed files — green (ruff, language policy, hook-launcher rules, conventional commit)

## Governor Footer
- trigger: yes
- reviewer: codex-cli
- rounds: 3
- r-points-fixed: 4
- r-points-deferred: 0
- r-points-rejected: 0
- touched-adr-consequences: none
- pr-scope-notes: Governor-changing via .claude/hooks/** + docs/ai/shared/** (Tier A). Round 1 raised 3 R-points (migration-strategy.md stderr drift, missing registered-wrapper test coverage, docstring reference to a not-yet-on-main file) — all Fixed; round 2 confirmed 2 closed, re-flagged the docstring residual and added 1 launcher-env-hardening point — both Fixed; round 3 scoped confirmation: MERGE-READY. Emit-channel-only change; verify-first decision predicate untouched. Codex-side parity assessed as not-a-defect (Stop-time systemMessage targets the user by design) — documented, no change.
- final-verdict: merge-ready
- links: https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/271, https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/270
