### PR TITLE
refactor(skills): unify the review-skill family under a shared Review Protocol

### DIFF
--- a/.agents/skills/review-architecture/SKILL.md
+++ b/.agents/skills/review-architecture/SKILL.md
@@ -18,7 +18,7 @@ metadata:
 3. Resolve the audit target and load the shared rule sources (Phase 0).
 4. Audit the target against the 10 architecture checklist categories (Phase 1).
 5. Determine `Drift Candidates` and whether `Sync Required` is `true` or `false` (Phase 2).
-6. Report using the shared review contract: `Scope`, `Effect Answer`, `Sources Loaded`, `Findings`, `Drift Candidates`, `Next Actions`, `Completion State`, `Sync Required` (Phase 3). `Effect Answer` is mandatory — see `docs/ai/shared/skills/review-architecture.md` § Review Contract for the field definition and Guard H context.
+6. Report using the protocol output contract: `Scope`, `Effect Answer`, `Sources Loaded`, `Findings` (open only), `Coverage` (OK/SKIP), `Drift Candidates`, `Verdict: N/A (audit-only scope)`, `Next Actions`, `Completion State`, `Sync Required` (Phase 3). `Effect Answer` is mandatory — see `docs/ai/shared/review-protocol.md` §3 for the contract and Guard H context.
 
 For cross-tool review prompts, use the `Cross-Tool Review Prompt Template`
 section in `docs/ai/shared/skills/review-architecture.md`; do not duplicate it here.

--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-pr
-description: Review a pull request or local diff against the repository's shared architecture, security, and workflow rules.
+description: Review a pull request or local diff against the repository's shared Review Protocol (correctness, regression, stability, contract, architecture, security, governance).
 metadata:
   short-description: Review PR or local diff
 ---
@@ -13,13 +13,13 @@ metadata:
 - Recursion guard: do not invoke `/review-pr` recursively, do not invoke `/plan-feature` from inside
 
 ## Procedure
-1. Read `AGENTS.md` and `docs/ai/shared/skills/review-pr.md` for the full procedure.
-2. Read `docs/ai/shared/architecture-review-checklist.md`, `docs/ai/shared/security-checklist.md`, and `docs/ai/shared/project-dna.md` as shared rule sources.
-3. Resolve the review target and load the shared rule sources (Phase 0).
-4. Review changed files against the shared architecture and security rules (Phase 1).
+1. Read `AGENTS.md`, `docs/ai/shared/review-protocol.md`, and `docs/ai/shared/skills/review-pr.md` for the full procedure.
+2. Read `docs/ai/shared/architecture-review-checklist.md` (ARCH), `docs/ai/shared/security-checklist.md` (SEC), and `docs/ai/shared/project-dna.md` as the shared rule sources the protocol references.
+3. Resolve the review target, collect the diff + intent, and load the rule sources (Phase 0).
+4. Review changed files against the protocol dimensions — `CORR / REG / STAB / CONTRACT / ARCH / SEC / GOV`; each finding carries a dimension ID + a basis (Phase 1).
 5. Determine `Drift Candidates` and whether `Sync Required` is `true` or `false` (Phase 2).
-6. Report using the shared review contract: `Scope`, `Effect Answer`, `Sources Loaded`, `Findings`, `Drift Candidates`, `Next Actions`, `Completion State`, `Sync Required` (Phase 3). `Effect Answer` is mandatory — see `docs/ai/shared/skills/review-pr.md` § Review Contract for the field definition and Guard H context.
-7. Optionally post the final review after user confirmation (Phase 4).
+6. Report using the protocol output contract: `Scope`, `Effect Answer`, `Sources Loaded`, `Findings` (open only), `Coverage` (OK/SKIP), `Drift Candidates`, `Verdict`, `Next Actions`, `Completion State`, `Sync Required` (Phase 3). `Effect Answer` is mandatory — see `docs/ai/shared/review-protocol.md` §3 for the contract and Guard H context.
+7. Optionally post the final review per protocol §5 after user confirmation (Phase 4).
 
 For cross-tool review prompts, use the `Cross-Tool Review Prompt Template`
 section in `docs/ai/shared/skills/review-pr.md`; do not duplicate it here.

--- a/.agents/skills/security-review/SKILL.md
+++ b/.agents/skills/security-review/SKILL.md
@@ -18,7 +18,7 @@ metadata:
 3. Resolve the audit scope and run the feature-detection / reference-freshness preflight (Phase 0).
 4. Audit the target against the 12 security checklist categories using the shared applicability rules (Phase 1).
 5. Determine stale-reference drift, other `Drift Candidates`, and whether `Sync Required` is `true` or `false` (Phase 2).
-6. Report using the shared review contract: `Scope`, `Effect Answer`, `Sources Loaded`, `Findings`, `Drift Candidates`, `Next Actions`, `Completion State`, `Sync Required` (Phase 3). `Effect Answer` is mandatory — see `docs/ai/shared/skills/security-review.md` § Review Contract for the field definition and Guard H context.
+6. Report using the protocol output contract: `Scope`, `Effect Answer`, `Sources Loaded`, `Findings` (open only), `Coverage` (OK/SKIP), `Drift Candidates`, `Verdict: N/A (audit-only scope)`, `Next Actions`, `Completion State`, `Sync Required` (Phase 3). `Effect Answer` is mandatory — see `docs/ai/shared/review-protocol.md` §3 for the contract and Guard H context.
 
 For cross-tool review prompts, use the `Cross-Tool Review Prompt Template`
 section in `docs/ai/shared/skills/security-review.md`; do not duplicate it here.

--- a/.claude/skills/review-architecture/SKILL.md
+++ b/.claude/skills/review-architecture/SKILL.md
@@ -20,9 +20,11 @@ Target: $ARGUMENTS (domain name or "all")
 1. Resolve the audit target and load the shared rule sources (Phase 0)
 2. Audit the target against the 10 architecture checklist categories (Phase 1)
 3. Determine `Drift Candidates` and whether `Sync Required` is `true` or `false` (Phase 2)
-4. Report using the shared review contract (Phase 3)
+4. Report using the protocol output contract — `Findings` (open) + `Coverage` (OK/SKIP) + `Verdict: N/A (audit-only scope)` (Phase 3)
 
-Read `docs/ai/shared/skills/review-architecture.md` for detailed steps and output format.
+Read `docs/ai/shared/skills/review-architecture.md` for detailed steps, and
+[`docs/ai/shared/review-protocol.md`](../../../docs/ai/shared/review-protocol.md) for the shared
+output contract (this skill applies the `ARCH` dimension in depth).
 Also refer to `docs/ai/shared/architecture-review-checklist.md` for the full checklist.
 For cross-tool review prompts, use the shared procedure's
 `Cross-Tool Review Prompt Template` section; do not duplicate the template here.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -2,12 +2,13 @@
 name: review-pr
 argument-hint: "PR number, URL, or omit to detect current branch"
 description: |
-  Review a pull request against project architecture rules.
+  Review a pull request against the shared Review Protocol (correctness,
+  regression, stability, contract, architecture, security).
   Use when the user asks to "review PR", "check PR", "PR review",
-  or wants architecture-aware review of a pull request before merge.
+  or wants an evidence-grounded review of a pull request before merge.
 ---
 
-# Pull Request Architecture Review
+# Pull Request Quality Gate Review
 
 Target: $ARGUMENTS (PR number, GitHub URL, or empty for current branch)
 
@@ -17,17 +18,24 @@ Target: $ARGUMENTS (PR number, GitHub URL, or empty for current branch)
 - Recursion guard: do not invoke `/review-pr` recursively, do not invoke `/plan-feature` from inside
 
 ## Procedure Overview
-1. Resolve PR and load shared rule sources (Phase 0)
-2. Review changed files against shared architecture and security rules (Phase 1)
+1. Resolve PR; collect diff + **intent** (PR body / issue / acceptance criteria) and load the
+   Review Protocol + its checklists (Phase 0)
+2. Review changed files against the protocol dimensions — `CORR / REG / STAB / CONTRACT /
+   ARCH / SEC / GOV` (Phase 1)
 3. Determine `Drift Candidates` and whether `Sync Required` is `true` or `false` (Phase 2)
-4. Report using the shared review contract (Phase 3)
-5. Post to GitHub only after user confirmation (Phase 4)
+4. Report using the protocol output contract — `Findings` (open) + `Coverage` (OK/SKIP) +
+   `Verdict` (Phase 3)
+5. Post to GitHub per protocol §5 only after user confirmation (Phase 4)
 
-Read `docs/ai/shared/skills/review-pr.md` for detailed steps and output format.
-For cross-tool review prompts, use that shared procedure's
-`Cross-Tool Review Prompt Template` section; do not duplicate the template here.
+Read `docs/ai/shared/skills/review-pr.md` for detailed steps, and
+[`docs/ai/shared/review-protocol.md`](../../../docs/ai/shared/review-protocol.md) for the shared
+dimensions, finding basis, output contract, and posting rules.
+For cross-tool review prompts, use the shared procedure's `Cross-Tool Review Prompt Template`
+section; do not duplicate the template here.
 
-## Claude-Specific: Rule Sources
-You may cross-check the final wording against `.claude/rules/architecture-conventions.md`,
-but do not create findings that are not already backed by the shared rule
-sources loaded in `docs/ai/shared/skills/review-pr.md`.
+## Claude-Specific: Finding Basis
+Every finding obeys the protocol's [Finding Basis rule](../../../docs/ai/shared/review-protocol.md#2-finding-basis-anti-hallucination-rule):
+`ARCH` / `SEC` / `GOV` findings must cite a shared rule source (you may navigate via
+`.claude/rules/architecture-conventions.md`, but the citation is the shared checklist / `AGENTS.md`);
+`CORR` / `REG` / `STAB` / `CONTRACT` findings must cite `diff` / `contract` / `test` / `runtime`
+evidence. A concern with no basis is a `Question`, not a finding.

--- a/.claude/skills/security-review/SKILL.md
+++ b/.claude/skills/security-review/SKILL.md
@@ -20,9 +20,11 @@ Target: $ARGUMENTS (domain name, file path, or "all")
 1. Resolve the audit scope and run the feature-detection / reference-freshness preflight (Phase 0)
 2. Audit the target against the 12 security checklist categories (Phase 1)
 3. Determine stale-reference drift, other `Drift Candidates`, and whether `Sync Required` is `true` or `false` (Phase 2)
-4. Report using the shared review contract (Phase 3)
+4. Report using the protocol output contract — `Findings` (open) + `Coverage` (OK/SKIP) + `Verdict: N/A (audit-only scope)` (Phase 3)
 
-Read `docs/ai/shared/skills/security-review.md` for detailed steps and output format.
+Read `docs/ai/shared/skills/security-review.md` for detailed steps, and
+[`docs/ai/shared/review-protocol.md`](../../../docs/ai/shared/review-protocol.md) for the shared
+output contract (this skill applies the `SEC` dimension in depth).
 Also refer to `docs/ai/shared/security-checklist.md` for the full checklist.
 For cross-tool review prompts, use the shared procedure's
 `Cross-Tool Review Prompt Template` section; do not duplicate the template here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,7 +166,7 @@ Every R-point must be closed as one of: **Fixed** / **Explicitly deferred with r
 
 Classify each question: **effect** (is it working? what's the result?) vs **process** (what should we do? what's next?). Effect questions must be answered with evidence, not process content. Mixed questions: effect-first with evidence, then process options separately. In multi-round conversations, restate the original question before proposing process changes.
 
-**Review-skill enforcement:** `/review-pr`, `/review-architecture`, `/security-review` require a mandatory `Effect Answer` field (1–3 sentence evidence-based summary of what the change *actually* does) before `Findings`. Skipping this field violates Guard H. See `docs/ai/shared/skills/review-pr.md` § Review Contract.
+**Review-skill enforcement:** `/review-pr`, `/review-architecture`, `/security-review` require a mandatory `Effect Answer` field (1–3 sentence evidence-based summary of what the change *actually* does) before `Findings`. Skipping this field violates Guard H. See `docs/ai/shared/review-protocol.md` §3 (Output Contract).
 
 ### I. Self-Licensing Detection — Sanity Check Before Defending a Challenged Conclusion
 

--- a/docs/ai/shared/harness-asset-matrix.md
+++ b/docs/ai/shared/harness-asset-matrix.md
@@ -161,6 +161,7 @@ rather than primary entry points (`Overlay`).
 | `security-checklist.md` | Keep | Low | High |
 | `test-patterns.md` | Keep | Low | High |
 | `architecture-review-checklist.md` | Keep | Low | Medium |
+| `review-protocol.md` | Keep | Low | High |
 | `ai-infrastructure-overview.md` | Keep | Low | Medium |
 | `repo-facts.md` | Keep | Low | Medium |
 | `test-files.md` | Keep | Low | Medium |
@@ -236,6 +237,16 @@ rather than primary entry points (`Overlay`).
 - **Migration risk**: Low.
 - **Stability impact**: Medium.
 - **Notes**: Examples-profile carve-out (`examples/todo`) was added 2026-04-26 — see `repo-facts.md`.
+
+### `review-protocol.md`
+
+- **Current role**: Canonical protocol shared by the three review skills (`/review-pr`, `/review-architecture`, `/security-review`): concern dimensions + stable IDs, the Finding Basis rule, the `Findings`/`Coverage` output contract, the intent/PASS `Verdict`, and the GitHub posting/verdict rules.
+- **Why it exists**: Unifies the review-skill family so review points, output shape, and posting are deterministic; replaces the per-skill "Core Principle" that forbade correctness/regression findings (issue #274).
+- **Replacement feasibility**: None — project-specific review contract.
+- **Final location**: unchanged.
+- **Migration risk**: Low (read-only reference; skills point to it).
+- **Stability impact**: High. All three review skills resolve their contract, dimensions, and posting rules from here; the Reasoning-Level Consistency Guards stay canonical in `AGENTS.md`.
+- **Notes**: `review-pr` is the PR-scoped entry point (emits a behavior `Verdict`); the other two are audit-only (`Verdict: N/A (audit-only scope)`). Skills depend on this protocol + the shared checklists, never on each other's bodies.
 
 ### `ai-infrastructure-overview.md`
 

--- a/docs/ai/shared/review-protocol.md
+++ b/docs/ai/shared/review-protocol.md
@@ -1,0 +1,209 @@
+# Review Protocol
+
+> Canonical for **review dimensions, finding basis, output/coverage contract, intent/PASS
+> state, and GitHub posting/verdict rules** shared by the review-skill family. The
+> Reasoning-Level Consistency Guards (F/G/H/I) and the `Effect Answer` requirement remain
+> canonical in [`AGENTS.md` § Reasoning-Level Consistency Guards](../../../AGENTS.md#reasoning-level-consistency-guards); this doc references them, it does not redefine them.
+>
+> Consumed by: [`review-pr`](skills/review-pr.md), [`review-architecture`](skills/review-architecture.md),
+> [`security-review`](skills/security-review.md). Skills depend on this protocol + the shared
+> checklists — **never on each other's skill bodies**.
+
+## Purpose
+
+The review skills previously each embedded their own contract, which drifted and left three
+gaps: non-deterministic output (inline vs summary decided ad hoc), file-location review
+categories instead of concern-based ones, and a rule (`review-pr` "only shared rule sources
+may create findings") that structurally forbade correctness / regression / side-effect
+findings.
+
+This protocol fixes all three in one place: **what** to review (§1 dimensions), **what may
+become a finding** (§2 finding basis), **how** it is reported (§3 output contract, §5 posting),
+and **whether the change passes** (§4 intent/PASS). Each skill applies this protocol at its own
+scope; it does not invent review rules of its own.
+
+## §1 Review Dimensions (concern-based, stable IDs)
+
+Every finding is tagged with a stable dimension ID. IDs are the answer to "which points am I
+reviewing against?" — they replace the old file-location categories (`domain/`,
+`infrastructure/`, …), which are now only a *navigation* aid, not the review taxonomy.
+
+| ID | Dimension | What it asks | Rule source / evidence |
+|----|-----------|--------------|------------------------|
+| `CORR` | Correctness | Does the change do what it intends? Logic, off-by-one, wrong branch, bad default, mis-wired DI. | evidence (diff / test / runtime) |
+| `REG` | Regression / side-effects | Does it break or alter existing behavior outside its stated scope? Shared base classes, container wiring, migrations, cross-domain contracts. | evidence (diff / test / contract) |
+| `STAB` | Stability | Error handling, boundary/empty/None cases, exception translation, concurrency, resource cleanup, timeouts. | evidence (diff / runtime) |
+| `CONTRACT` | External contract | API request/response shapes, OpenAPI, status codes, event/task payloads, DB schema/migration compatibility. | evidence (contract / diff) |
+| `ARCH` | Architecture compliance | Layering, conversion patterns, DTO/VO/Model roles, DI, bootstrap, naming. | [`architecture-review-checklist.md`](architecture-review-checklist.md) (10 categories) |
+| `SEC` | Security | AuthN/Z, secrets, input validation, sensitive-data exposure, logging, storage, worker, AI provider. | [`security-checklist.md`](security-checklist.md) (12 categories) |
+| `GOV` | Governance / process | Tier-1 language policy, governor-path drift, edits to shared rule sources, review-process rules. | [`AGENTS.md`](../../../AGENTS.md) + [`governor-paths.md`](governor-paths.md) |
+
+- `ARCH`, `SEC`, and `GOV` are **rule-grounded**: they exist only to apply a shared rule source
+  (a checklist, `AGENTS.md`, or `governor-paths.md`) — no tool-local rule invention.
+- `CORR` / `REG` / `STAB` / `CONTRACT` are **evidence-grounded**: they are opened only against
+  concrete evidence (§2), never against taste or a hunch.
+- A single physical issue gets one finding under its most specific dimension. Do not split one
+  defect across dimensions, and do not merge distinct defects into one finding.
+
+## §2 Finding Basis (anti-hallucination rule)
+
+This replaces `review-pr`'s old "only shared rule sources may create findings" while keeping
+its intent: **no finding without a declared basis.**
+
+Every finding line MUST carry `basis: <type>` and cite the concrete anchor:
+
+| `basis` | Valid for | Must cite |
+|---------|-----------|-----------|
+| `rule-source` | `ARCH`, `SEC`, `GOV` | the checklist / `AGENTS.md` / `governor-paths.md` rule + section (e.g. `architecture-review-checklist §1`) |
+| `diff-evidence` | `CORR`, `REG`, `STAB`, `CONTRACT` | the changed `file:line` and what the code does |
+| `contract-evidence` | `CONTRACT`, `REG` | the schema / OpenAPI / payload / migration that conflicts |
+| `test-evidence` | `CORR`, `REG` | a failing test (name + expected vs actual). An **absent** test is a finding only when tied to a changed contract, a concrete regression risk, or a checklist rule (e.g. `architecture-review-checklist §5`) — never "untested, therefore a finding" |
+| `runtime-evidence` | `CORR`, `STAB` | the command run + observed output (e.g. a failing probe) |
+
+Rules:
+- If a concern cannot be tied to one of the bases above, it is **not a finding**. Record it as a
+  `Question` in `Next Actions` (to be resolved), not as a finding. This is what stops
+  speculative "looks unstable" / taste-refactor findings.
+- `ARCH` / `SEC` findings without a citable shared-rule section are invalid — downgrade to a
+  `Drift Candidate` if the rule itself is missing/stale.
+- Severity (§3) is independent of basis: a `diff-evidence` `CORR` finding can be `BLOCKING`.
+
+Evidence examples (valid finding vs `Question`):
+- Valid `CORR` / `diff-evidence`: "`src/x/service.py:42` returns `None` on the empty-list
+  branch, but the caller indexes `[0]` → `IndexError`." (cites code + the concrete failure)
+- Not a finding → record as a `Question`: "this could be more robust" / "there's probably a
+  race here" / "no tests for this file" (no changed contract, no cited regression, no rule).
+
+## §3 Output Contract
+
+Every review result emits these sections, in order. `review-pr`, `review-architecture`, and
+`security-review` share this contract; only `Scope` phrasing differs by skill.
+
+- **`Scope`** — target (PR #/branch, domain, or file), affected domains, changed-file count,
+  important exclusions.
+- **`Effect Answer`** — 1–3 sentence, evidence-based summary of what the change *actually* does
+  or exposes (Guard H; see [`AGENTS.md`](../../../AGENTS.md#reasoning-level-consistency-guards)).
+  Grounded in the diff/code read, never a restatement of procedure. For a process-only question,
+  write `Effect Answer: N/A — process question`.
+- **`Sources Loaded`** — the exact shared rule sources + checklists actually used.
+- **`Findings`** — **OPEN issues only.** Each line:
+  `[OPEN][<SEVERITY>][<DIM-ID>] <file:line> — basis: <type> (<citation>)`
+  then `Impact:` and `Recommended fix:` on following lines. For line-anchored code findings,
+  `Recommended fix` includes a copy-paste `before → after` block (§5).
+- **`Coverage`** — the `OK` / `SKIP` records that used to be mixed into `Findings`. Each line:
+  `[OK|SKIP][<DIM-ID>] <what was checked> — <evidence for OK, or why SKIP>`. Keeps `Findings`
+  purely actionable while still proving what was inspected.
+- **`Drift Candidates`** — shared docs / checklists / wrappers / `project-dna` that may need
+  sync; each with `target`, `reason`, `auto-fix`, `sync-required`.
+- **`Verdict`** — the intent/PASS decision (§4).
+- **`Next Actions`** — code fixes, `Question`s (unbased concerns), follow-up review, sync
+  request, optional GitHub posting.
+- **`Completion State`** — concise closure status, including any unresolved review threads (§5).
+- **`Sync Required`** — explicit `true` / `false`.
+
+### Severity + review state
+
+Keep the two axes separate (do not mix):
+
+- Review state: `OPEN`, `OK`, `SKIP`
+- Severity: `BLOCKING`, `HIGH`, `MEDIUM`, `LOW`, `NOTE`
+
+## §4 Intent & PASS State
+
+"Did it pass?" is only answerable against a stated intent. The review takes an **intent input**
+— the PR body, the linked issue, or explicit acceptance criteria — and emits one `Verdict`:
+
+- **`PASS`** — intent evidence exists AND there is no `OPEN` `BLOCKING` finding, nor any `OPEN`
+  `HIGH` finding that breaks the stated intent or an external contract.
+- **`FAIL`** — an `OPEN` `BLOCKING` finding, or an `OPEN` `HIGH` finding that breaks the stated
+  intent or an external contract.
+- **`CANNOT CERTIFY (intent evidence missing)`** — no PR body / issue / acceptance criteria to
+  judge against. Do **not** emit a false `PASS`; list exactly what intent evidence is needed.
+- **`N/A (audit-only scope)`** — the run audits a single dimension with no behavior intent to
+  certify (`review-architecture`, `security-review`). Emit `Findings`/`Coverage` normally, but a
+  behavior `PASS`/`FAIL` does not apply.
+
+`CORR`/`REG`/`STAB` findings feed `PASS`/`FAIL`; a clean architecture or security audit alone is
+never a behavior `PASS`.
+
+## §5 GitHub Posting & Verdict Contract
+
+Posting is **deterministic** — the same review never lands as inline one time and summary the
+next.
+
+### Inline vs summary (routing)
+
+- A finding is posted **inline** (GitHub reviews API, `side:RIGHT`, anchored to the head SHA)
+  when it has a concrete `file:line` **that falls inside the PR diff hunks**. Inline comments
+  include a copy-paste `before → after` block and are written in **English** (Tier-1 review
+  surface), and state explicitly when something must **not** be changed.
+- A finding goes into the **summary** body when it is cross-cutting, whole-file, or references a
+  line **outside** the diff hunks.
+- **Fallback:** if an inline anchor cannot attach (line not in the diff, API rejects the
+  position), demote the finding to the summary with the `file:line` quoted verbatim. Never drop
+  it.
+
+### Verdict → GitHub review action
+
+Evaluate the rules **in order; the first match wins**, so any concrete review state resolves to
+exactly one action (severity feeds the §4 verdict; the verdict + remaining-`OPEN`-findings + sync
+state decide the action — never the reviewer's discretion):
+
+1. `Verdict: FAIL` → **Request changes**.
+2. `Verdict: CANNOT CERTIFY` → **Comment** (state the missing intent evidence; never Approve).
+3. Any `OPEN` finding remains, or `Sync Required: true` → **Comment**.
+4. No `OPEN` findings, `Sync Required: false`, and `Verdict` is `PASS` or `N/A` → **Approve**.
+
+### Comment lifecycle (deterministic identity)
+
+- Every finding has a stable **finding key**:
+  `<DIM-ID> | <basis> | <file:line | summary-target> | <stable short title>`.
+- On re-review of the same PR: a key that still resolves → **update** the existing comment/thread
+  (never duplicate); a key that no longer appears → mark the thread **resolved/obsolete**; a new
+  key → **new** comment. This identity rule is what makes the same PR reviewed twice produce the
+  same comment set.
+- Posting always requires user confirmation first (the review is produced first; publishing is a
+  separate, explicit step). This protocol **reports** thread state; it does not auto-resolve or
+  merge (out of scope).
+
+### Merge-gate reality (report, do not automate)
+
+- The completion gate is **not** closed while `OPEN` `BLOCKING` inline threads remain unresolved,
+  or while branch protection (`require_conversation_resolution`) still blocks merge. Surface open
+  threads and blocked status in `Completion State`.
+- This protocol **reports** merge-gate status; it does not auto-resolve threads or merge (out of
+  scope).
+
+## §6 Reasoning-Level Consistency Guards (pointer only)
+
+The F/G/H/I guards apply to every review and are **canonical** in
+[`AGENTS.md` § Reasoning-Level Consistency Guards](../../../AGENTS.md#reasoning-level-consistency-guards).
+This protocol does not restate or re-label them. Two review-facing anchors:
+
+- The `Effect Answer` field (§3) is the enforcement point for Guard **H** (effect before
+  process).
+- Cross-review R-points close with the Guard **G** closure vocabulary defined in that AGENTS
+  section — use those exact tokens; do not invent variants.
+
+## §7 Independent Review & Fallback
+
+- Governor-changing changes require an independent review (cross-tool by default) per
+  [`AGENTS.md` § Default Coding Flow → Independent Review Trigger](../../../AGENTS.md#default-coding-flow).
+- Each skill keeps a **Cross-Tool Review Prompt Template** (input/output frame for a reviewing
+  tool) and a **Self-Structured Review Checklist** (single-tool fallback) specialized to its
+  scope; both produce R-points closed with the Guard G vocabulary and reference this protocol
+  for dimensions, basis, and output shape.
+
+## §8 Skill Scope Boundaries
+
+| Skill | Scope | Default Flow step |
+|-------|-------|-------------------|
+| `review-pr` | changed files of a PR / branch; the PR-scoped single entry point that applies this whole protocol, then decides drift + posting | `completion gate` |
+| `review-architecture` | a domain or the full repo structure, **outside** PR scope; applies the `ARCH` dimension in depth | `self-review` |
+| `security-review` | a file / domain / repo security surface; applies the `SEC` dimension in depth with a feature-freshness preflight | `self-review` |
+
+- The built-in generic `/code-review` is **not** project-aware; it may serve as an optional
+  extra `CORR` lens but is never an authoritative source of findings under this protocol.
+- Fan-out to project-aware sub-agents (seeded with this protocol + the shared checklists) is an
+  optional escalation for heavy reviews (security-sensitive, multi-domain, large diff,
+  concurrency/worker/provider changes) — not the default path, and never skill-calls-skill.

--- a/docs/ai/shared/skills/review-architecture.md
+++ b/docs/ai/shared/skills/review-architecture.md
@@ -19,28 +19,18 @@ shared architecture rules, then decide whether the audit also requires
 
 ## Review Contract
 
-Every result must include:
+This audit emits the shared [Review Protocol §3 output contract](../review-protocol.md#3-output-contract):
+`Scope`, `Effect Answer`, `Sources Loaded`, `Findings` (OPEN only), `Coverage` (OK/SKIP),
+`Drift Candidates`, `Verdict`, `Next Actions`, `Completion State`, `Sync Required`.
 
-- `Scope` - audit target, audited domains, important exclusions
-- `Effect Answer` - 1-3 sentence evidence-based summary of what the audited domain/code *actually*
-  does or exposes. Must come from reading the source, not from restating the checklist procedure.
-  Purpose: Guard H (AGENTS.md § Reasoning-Level Consistency Guards) — effect questions must be
-  answered with evidence first. Write `Effect Answer: N/A — process question` for checklist-only
-  process questions.
-- `Sources Loaded` - exact shared rule sources used for the audit
-- `Findings` - only open issues; each item includes `severity`, `rule source`,
-  `file:line`, `impact`, and `recommended fix`
-- `Drift Candidates` - shared docs, checklists, wrappers, or `project-dna`
-  targets that may need sync; each item includes `target`, `reason`,
-  `auto-fix`, and `sync-required`
-- `Next Actions` - implementation follow-up, verification, sync path
-- `Completion State` - concise closure status for the audit
-- `Sync Required` - explicit `true` or `false`
+- This skill applies the **`ARCH` dimension** ([Review Protocol §1](../review-protocol.md#1-review-dimensions-concern-based-stable-ids)) in depth via the 10-category checklist below; every `ARCH` finding is `rule-source`-based and cites its checklist category ([Finding Basis §2](../review-protocol.md#2-finding-basis-anti-hallucination-rule)).
+- `Verdict` is **`N/A (audit-only scope)`** — a structural audit, not a behavior PASS/FAIL ([Review Protocol §4](../review-protocol.md#4-intent--pass-state)).
+- `Effect Answer` is required (Guard H); write `Effect Answer: N/A — process question` for checklist-only process questions.
 
 ### Severity Taxonomy
 
-- Review state: `OPEN`, `OK`, `SKIP`
-- Severity: `BLOCKING`, `HIGH`, `MEDIUM`, `LOW`, `NOTE`
+State and severity are defined in [Review Protocol §3](../review-protocol.md#3-output-contract):
+review state `OPEN` / `OK` / `SKIP`; severity `BLOCKING` / `HIGH` / `MEDIUM` / `LOW` / `NOTE`.
 
 ## Audit Target
 
@@ -135,23 +125,31 @@ Scope
 - Target: docs
 - Audited domains: docs
 
+Effect Answer
+- The docs domain wires an RDB-backed query path; one service imports infrastructure directly.
+
 Sources Loaded
-- AGENTS.md
-- docs/ai/shared/project-dna.md
+- docs/ai/shared/review-protocol.md
 - docs/ai/shared/architecture-review-checklist.md
+- AGENTS.md
 
 Findings
-- [OPEN][BLOCKING] Architecture checklist - src/docs/domain/services/docs_service.py:12
+- [OPEN][BLOCKING][ARCH] src/docs/domain/services/docs_service.py:12 — basis: rule-source (architecture-review-checklist §1)
   Impact: domain layer imports infrastructure directly, breaking the layering rule.
   Recommended fix: introduce a Protocol in the domain layer and invert the dependency.
-- [OK][MEDIUM] Architecture checklist §4 - DI container: providers.DeclarativeContainer and providers.Factory used correctly
-- [SKIP] Architecture checklist §9 - DynamoDB domain compliance: no infrastructure/dynamodb/ directory found in docs domain
+
+Coverage
+- [OK][ARCH] architecture-review-checklist §4 DI container — providers.DeclarativeContainer + providers.Factory used correctly
+- [SKIP][ARCH] architecture-review-checklist §9 DynamoDB — no infrastructure/dynamodb/ directory in docs domain
 
 Drift Candidates
 - target: docs/ai/shared/project-dna.md
   reason: the current admin page pattern differs from the documented layout.
   auto-fix: yes
   sync-required: true
+
+Verdict
+- N/A (audit-only scope)
 
 Next Actions
 - Refactor the direct import.
@@ -164,8 +162,8 @@ Sync Required
 - true
 ```
 
-When the audit is clean, still emit `Findings: none`, `Drift Candidates: none`,
-and `Sync Required: false`.
+When the audit is clean, still emit every section: `Findings: none`, the `Coverage` records,
+`Verdict: N/A (audit-only scope)`, `Drift Candidates: none`, and `Sync Required: false`.
 
 ## Cross-Tool Review Prompt Template
 
@@ -216,11 +214,13 @@ Review Angles
 Output format
 - Scope
 - Sources Loaded
-- Findings: open issues only, each with severity, rule source, file:line,
+- Findings: OPEN issues only, each with severity, dimension ID (ARCH), basis, file:line,
   impact, and recommended fix
+- Coverage: OK/SKIP records with evidence
 - Drift Candidates: target, reason, auto-fix, sync-required
-- R-points: every cross-review point must include one closure category:
-  Fixed, Deferred-with-rationale, or Rejected. Do not use non-canonical labels.
+- R-points: every cross-review point closes as Fixed / Deferred-with-rationale / Rejected
+  (AGENTS Guard G vocabulary; no non-canonical labels)
+- Verdict: N/A (audit-only scope)
 - Final Verdict: clean / minor fixes recommended / still needs architecture
   review / block merge
 - Sync Required: true or false

--- a/docs/ai/shared/skills/review-pr.md
+++ b/docs/ai/shared/skills/review-pr.md
@@ -4,7 +4,7 @@
 
 This skill participates in the [Default Coding Flow](../../../../AGENTS.md#default-coding-flow) at the **`completion gate`** step.
 
-It is invoked at the end of work — after `implement`, `verify`, and `self-review` have settled — to apply a final architecture- and security-aware review against the change set as a whole.
+It is invoked at the end of work — after `implement`, `verify`, and `self-review` have settled — to apply a final review against the change set as a whole.
 
 After completion-gate review, route to:
 - `/sync-guidelines` if the review reported `Drift Candidates` or `Sync Required: true`
@@ -13,101 +13,78 @@ Recursion guard: do **not** invoke `/review-pr` recursively from within itself, 
 
 ## Core Principle
 
-This skill does not define custom review rules.
-It applies the project's shared rule sources to the PR diff and decides whether
-the quality gate can close or must continue into `/sync-guidelines`.
+This skill defines no review rules of its own. It is the **PR-scoped single entry point** that
+applies the shared [Review Protocol](../review-protocol.md) to a PR diff, then decides drift and
+posting.
 
-Only shared rule sources may create findings:
-- `AGENTS.md`
-- `docs/ai/shared/project-dna.md`
-- `docs/ai/shared/architecture-review-checklist.md`
-- `docs/ai/shared/security-checklist.md`
+- **What to review** — the protocol dimensions in [Review Protocol §1](../review-protocol.md#1-review-dimensions-concern-based-stable-ids): `CORR`, `REG`, `STAB`, `CONTRACT`, `ARCH`, `SEC`, `GOV`.
+- **What may become a finding** — the [Finding Basis rule (§2)](../review-protocol.md#2-finding-basis-anti-hallucination-rule): **no finding without a declared basis.** This replaces the old "only shared rule sources may create findings" — correctness / regression / side-effect findings are now in scope **when they carry `diff` / `contract` / `test` / `runtime` evidence**; `ARCH` / `SEC` / `GOV` findings still require a cited shared-rule source.
+- **How it is reported** — the [output contract (§3)](../review-protocol.md#3-output-contract), the [intent/PASS verdict (§4)](../review-protocol.md#4-intent--pass-state), and the [posting rules (§5)](../review-protocol.md#5-github-posting--verdict-contract).
 
-Tool-specific convention files, if available, may help with wording or
-navigation, but they must not introduce findings that are not already backed by
-the shared rule sources above.
+This skill depends on the protocol + the shared checklists it references — **never** on the
+`review-architecture` or `security-review` skill bodies.
 
-## Review Contract
-
-Every result must include the sections below.
-
-- `Scope` - PR number/title, base/head refs, affected domains, changed file count
-- `Effect Answer` - 1-3 sentence evidence-based summary of what this PR *actually* does or exposes.
-  Must be grounded in the diff read, not a restatement of the review procedure.
-  Purpose: Guard H (AGENTS.md § Reasoning-Level Consistency Guards) — effect questions must be
-  answered with evidence first, before process/procedure content. If the question is process-only
-  (e.g. "was the review checklist followed?"), write `Effect Answer: N/A — process question`.
-- `Sources Loaded` - exact shared rule sources used for the review
-- `Findings` - only open issues; each item includes `severity`, `rule source`,
-  `file:line`, `impact`, and `recommended fix`
-- `Drift Candidates` - shared docs, checklists, wrappers, or `project-dna`
-  targets that may need sync; each item includes `target`, `reason`,
-  `auto-fix`, and `sync-required`
-- `Next Actions` - code fixes, follow-up review, sync request, optional GitHub
-  posting
-- `Completion State` - concise closure status for the review
-- `Sync Required` - explicit `true` or `false`
-
-### Severity Taxonomy
-
-Use a separate review state and severity. Do not mix them.
-
-- Review state: `OPEN`, `OK`, `SKIP`
-- Severity: `BLOCKING`, `HIGH`, `MEDIUM`, `LOW`, `NOTE`
-
-## Difference from `/review-architecture`
+## Difference from `/review-architecture` and `/security-review`
 
 ```text
-/review-pr            -> review only changed files, then decide whether sync is required
-/review-architecture  -> audit a domain or the full repo structure outside PR scope
+/review-pr            -> apply the whole protocol to the CHANGED files of a PR, decide drift + posting
+/review-architecture  -> audit a domain or full repo structure (ARCH dimension in depth), outside PR scope
+/security-review      -> audit a file/domain/repo security surface (SEC dimension in depth) with a preflight
 ```
 
-## Phase 0: Resolve Target and Collect Evidence
+`review-pr` is the only one of the three that emits a behavior `Verdict` (§4); the other two are
+audit-only (`Verdict: N/A`). See [Review Protocol §8](../review-protocol.md#8-skill-scope-boundaries).
+
+## Phase 0: Resolve Target and Collect Evidence + Intent
 
 1. Resolve the review target.
-   - If a PR number or URL is given: inspect that PR
-   - If omitted: inspect the current branch diff or current branch PR
-   - If no review target exists, stop with instructions to create or identify one
-2. Collect the diff, changed filenames, affected domains, and surrounding code
-   when a changed file alone is not enough to judge the rule.
-3. Load the shared rule sources listed above before forming findings.
-4. AGENTS.md § Language Policy (cross-ref): if the diff inserts non-English
-   prose into Tier 1 paths, surface as a `Findings` violation and a
-   `Sync Required: true` candidate. Bilingual escape tokens are exempt.
+   - If a PR number or URL is given: inspect that PR.
+   - If omitted: inspect the current branch diff or current-branch PR.
+   - If no review target exists, stop with instructions to create or identify one.
+2. Collect the diff, changed filenames, affected domains, and surrounding code when a changed
+   file alone is not enough to judge a rule or reproduce an effect.
+3. **Collect the intent** (Review Protocol §4): the PR body, the linked issue, or explicit
+   acceptance criteria. If none exist, the `Verdict` will be `CANNOT CERTIFY` — do not invent one.
+4. Load the rule sources: the [Review Protocol](../review-protocol.md), plus the checklists it
+   references — [`architecture-review-checklist.md`](../architecture-review-checklist.md) (ARCH),
+   [`security-checklist.md`](../security-checklist.md) (SEC) — and `AGENTS.md` (incl. § Language
+   Policy for `GOV`).
 
-## Phase 1: Review Changed Files Against Shared Rules
+## Phase 1: Review Changed Files Against the Protocol Dimensions
 
-Walk through changed files and apply only the relevant checklist categories.
+Apply the protocol dimensions (§1) to the diff. File location (`domain/`, `infrastructure/`,
+…) is only a **navigation** aid now, not the review taxonomy.
 
-- `domain/` -> layer dependency, conversion patterns, DTO integrity
-- `application/` -> orchestration, dependency boundaries
-- `infrastructure/` -> DI, repository, provider, storage, worker, logging rules
-- `interface/` -> router, response exposure, admin, auth, validation rules
-- `migrations/` -> upgrade/downgrade completeness and compatibility concerns
-- shared docs / skill wrappers -> drift risk, source-of-truth alignment, quality
-  gate follow-up
+- `CORR` / `REG` / `STAB` / `CONTRACT` — evidence-grounded: open only against `diff` / `contract`
+  / `test` / `runtime` evidence. Read surrounding code, run a probe, or point at the failing/absent
+  test as the basis. An unbased concern is a `Question` in `Next Actions`, not a finding.
+- `ARCH` — apply `architecture-review-checklist.md`; cite the category.
+- `SEC` — apply `security-checklist.md`; cite the category.
+- `GOV` — Tier-1 Language Policy violations (non-English prose in a Tier-1 path outside the
+  bilingual-token allowlist), governor-path drift, and edits to shared rule sources.
 
-Use surrounding context whenever a rule depends on code outside the diff.
+Every finding carries a stable dimension ID + a declared `basis` (§2). Use surrounding context
+whenever a rule or an effect depends on code outside the diff.
 
 ## Phase 2: Determine Drift Candidates and Sync Requirement
 
-After findings are collected, determine whether the PR also created or exposed
-reference drift.
+After findings are collected, decide whether the PR also created or exposed reference drift.
 
-Mark `Sync Required: true` when at least one of the following is true:
-- the diff touches `AGENTS.md`, `docs/ai/shared/`, `project-dna`, checklist
-  files, skill procedures, or tool wrappers
-- the diff touches shared/base architecture files whose patterns are documented
-- the review discovers a mismatch between code and shared references
-- the review discovers stale feature detection assumptions that should update
-  `project-dna` or a checklist
+Mark `Sync Required: true` when at least one is true:
+- the diff touches `AGENTS.md`, `docs/ai/shared/`, `project-dna`, checklist files, skill
+  procedures, or tool wrappers;
+- the diff touches shared/base architecture files whose patterns are documented;
+- the review discovers a mismatch between code and shared references;
+- the review discovers stale feature-detection assumptions that should update `project-dna` or a
+  checklist.
 
-When a drift exists, create a `Drift Candidates` entry even if the code change
-itself is otherwise acceptable.
+When drift exists, create a `Drift Candidates` entry even if the code change itself is acceptable.
 
-## Phase 3: Report Using the Review Contract
+## Phase 3: Report Using the Protocol Contract
 
-Use the contract sections exactly and keep the result action-oriented.
+Emit the [Review Protocol §3](../review-protocol.md#3-output-contract) sections exactly, in order:
+`Scope`, `Effect Answer`, `Sources Loaded`, `Findings` (OPEN only), `Coverage` (OK/SKIP),
+`Drift Candidates`, `Verdict` (§4), `Next Actions`, `Completion State`, `Sync Required`.
 
 Example:
 
@@ -118,65 +95,80 @@ Scope
 - Changed files: 7
 
 Effect Answer
-- This PR adds a new DynamoDB-backed query path in the docs domain and
-  wires it through the DI container. It does not change existing RDB behaviour.
-  No security-sensitive surfaces are touched.
+- Adds a DynamoDB-backed query path in the docs domain and wires it through the DI container.
+  Existing RDB behaviour is unchanged; no security-sensitive surface is touched.
 
 Sources Loaded
-- AGENTS.md
-- docs/ai/shared/project-dna.md
+- docs/ai/shared/review-protocol.md
 - docs/ai/shared/architecture-review-checklist.md
 - docs/ai/shared/security-checklist.md
+- AGENTS.md
 
 Findings
-- [OPEN][HIGH] Architecture checklist - src/docs/infrastructure/di/docs_container.py:18
+- [OPEN][HIGH][ARCH] src/docs/infrastructure/di/docs_container.py:18 — basis: rule-source (architecture-review-checklist §4)
   Impact: container wiring uses the wrong dependency source for DynamoDB mode.
-  Recommended fix: switch to `core_container.dynamodb_client` and keep RDB wiring out.
-- [OK][MEDIUM] Architecture checklist §5 - Test coverage: all 3 baseline test files present for docs domain
-- [SKIP] Security checklist §4.2 - File Upload input validation: project-dna §8 and live code both confirm feature inactive
+  Recommended fix:
+    before: rdb = providers.Singleton(RdbClient, ...)
+    after:  dynamo = core_container.dynamodb_client  # keep RDB wiring out of this path
+- [OPEN][MEDIUM][CORR] src/docs/application/docs_query.py:44 — basis: diff-evidence
+  Impact: empty-result branch returns None but the caller indexes [0] → IndexError on no-match.
+  Recommended fix:
+    before: return rows[0]
+    after:  return rows[0] if rows else None  # caller already handles None
+
+Coverage
+- [OK][ARCH] architecture-review-checklist §5 Test coverage — all 3 baseline test files present for docs
+- [SKIP][SEC] security-checklist §4.2 File Upload — project-dna §8 and live code both confirm feature inactive
 
 Drift Candidates
 - target: docs/ai/shared/architecture-review-checklist.md
-  reason: PR introduces DynamoDB-specific guidance that the shared checklist does not mention consistently.
+  reason: PR introduces DynamoDB-specific guidance the shared checklist does not mention consistently.
   auto-fix: no
   sync-required: true
 
+Verdict
+- FAIL — OPEN HIGH (ARCH container wiring) breaks the intended DynamoDB path stated in the PR body.
+
 Next Actions
-- Fix the container wiring issue.
-- Run `/sync-guidelines` after the DynamoDB guidance is updated.
+- Fix the container wiring (ARCH) and the empty-result branch (CORR).
+- Run /sync-guidelines after the DynamoDB guidance is updated.
 - Post the review to GitHub only after the findings are addressed.
 
 Completion State
-- complete with findings
+- complete with findings; no inline threads posted yet
 
 Sync Required
 - true
 ```
 
-If no issues are found, still emit all sections and explicitly state
-`Findings: none`, `Drift Candidates: none`, and `Sync Required: false`.
+If nothing is open, still emit every section: `Findings: none`, `Coverage:` (the OK/SKIP records),
+`Verdict: PASS` (or `CANNOT CERTIFY` when intent evidence is missing), `Drift Candidates: none`,
+`Sync Required: false`.
 
 ## Phase 4: Post to GitHub (Optional)
 
-Ask before posting.
+Posting follows [Review Protocol §5](../review-protocol.md#5-github-posting--verdict-contract)
+exactly — it is not re-decided here:
 
-- `BLOCKING` findings present -> request changes
-- only `HIGH` / `MEDIUM` / `LOW` / `NOTE` findings -> comment
-- no findings and `Sync Required: false` -> approve or leave a clean comment
+- **Inline vs summary** — line-anchored findings inside the diff hunks post inline (reviews API,
+  `side:RIGHT`, head-SHA anchored, copy-paste `before → after`, English); cross-cutting / out-of-hunk
+  findings go in the summary; fallback to summary when an inline anchor cannot attach.
+- **Verdict → action** (first match wins) — `FAIL` → request changes; `CANNOT CERTIFY` → comment;
+  any remaining `OPEN` finding or `Sync Required: true` → comment; otherwise → approve.
+- **Finding key + lifecycle** — reuse the same comment/thread for a still-open finding key, mark
+  vanished keys resolved, post new only for new keys.
 
-If `Sync Required: true`, do not treat the review as fully closed until the
+Ask before posting. If `Sync Required: true`, do not treat the review as fully closed until the
 follow-up sync path is acknowledged.
 
 ## Cross-Tool Review Prompt Template
 
-Use this template when another tool or reviewer cross-checks a `/review-pr`
-result, a PR diff, or a readiness decision. The purpose is a consistent input
-and output frame; reviewers may disagree with the original review when the
-evidence supports it.
+Use this template when another tool or reviewer cross-checks a `/review-pr` result, a PR diff, or
+a readiness decision. The purpose is a consistent input and output frame; reviewers may disagree
+with the original review when the evidence supports it.
 
 ```text
-Cross-tool review for /review-pr (read-only). Do not modify files. Do not run
-git commands.
+Cross-tool review for /review-pr (read-only). Do not modify files. Do not run git commands.
 
 Context
 - Repo: fastapi-agent-blueprint
@@ -190,75 +182,71 @@ Context
 What you are reviewing
 - Summary: <one-paragraph change summary>
 - Changed files: <3-8 highest-signal paths>
-- Prior review result: <Findings / Drift Candidates / Sync Required summary>
+- Prior review result: <Findings / Coverage / Verdict / Drift Candidates / Sync Required summary>
 
 Sources Loaded
-- AGENTS.md
-- docs/ai/shared/project-dna.md
+- docs/ai/shared/review-protocol.md
 - docs/ai/shared/architecture-review-checklist.md
 - docs/ai/shared/security-checklist.md
-- docs/ai/shared/governor-paths.md when the change may be governor-changing
+- AGENTS.md; docs/ai/shared/governor-paths.md when the change may be governor-changing
 - Relevant changed files and surrounding code
 
 Review Angles
-1. Diff-scope correctness: did the review inspect the changed files and enough
-   surrounding code to judge the shared rules?
-2. Architecture and security rule grounding: are all findings backed by the
-   shared sources above, with no tool-local rule invention?
-3. Drift decision: is `Sync Required` correct, especially for shared rule
-   sources, skill procedures, wrappers, and documented patterns?
-4. Volatile facts: are branch, PR number, changed-file counts, file paths, and
-   line references verified from current evidence?
-5. Completion-gate closure: does the review distinguish open findings,
-   resolved items, and follow-up sync work without masking risk?
+1. Diff-scope correctness: did the review inspect the changed files and enough surrounding code
+   to judge the dimensions and reproduce the claimed effects?
+2. Dimension + basis grounding: is every finding tagged with a protocol dimension ID and a valid
+   `basis` (§2)? Are ARCH/SEC/GOV rule-cited and CORR/REG/STAB/CONTRACT evidence-cited, with no
+   unbased "taste" findings?
+3. Contract shape: are OPEN issues in `Findings` and OK/SKIP in `Coverage` (never mixed)? Is the
+   `Verdict` (§4) correct given the intent evidence?
+4. Drift decision: is `Sync Required` correct, especially for shared rule sources, skill
+   procedures, wrappers, and documented patterns?
+5. Volatile facts: are branch, PR number, changed-file counts, file paths, and line references
+   verified from current evidence?
 
 Output format
 - Scope
 - Sources Loaded
-- Findings: open issues only, each with severity, rule source, file:line,
-  impact, and recommended fix
+- Findings: OPEN issues only, each with severity, dimension ID, basis, file:line, impact, and fix
+- Coverage: OK/SKIP records with evidence
 - Drift Candidates: target, reason, auto-fix, sync-required
-- R-points: every cross-review point must include one closure category:
-  Fixed, Deferred-with-rationale, or Rejected. Do not use non-canonical labels.
-- Final Verdict: merge-ready / minor fixes recommended / still needs
-  reinforcement / block merge
+- R-points: every cross-review point closes as Fixed / Deferred-with-rationale / Rejected (the
+  AGENTS Guard G vocabulary; no non-canonical labels)
+- Verdict: PASS / FAIL / CANNOT CERTIFY / N/A
+- Final Verdict: merge-ready / minor fixes recommended / still needs reinforcement / block merge
 - Sync Required: true or false
 ```
 
 ## Self-Structured Review Checklist
 
 Use when a cross-tool reviewer is unavailable (single-tool environment). Record
-`reviewer: self-structured` in the Governor Footer. Work through each item
-below and surface any findings as R-points with the same closure categories
+`reviewer: self-structured` in the Governor Footer. Work through each item below and surface any
+findings as R-points with the AGENTS Guard G closure vocabulary
 (`Fixed` / `Deferred-with-rationale` / `Rejected`).
 
-**F — Volatile workspace facts**
-- [ ] All line numbers, file paths, branch names, and PR numbers cited in this
-  review have been re-verified from current tool output (not from memory or
-  prior-session snapshots).
+**F / G / H / I — Reasoning-Level Consistency Guards** (canonical in
+[AGENTS.md](../../../../AGENTS.md#reasoning-level-consistency-guards); see also
+[Review Protocol §6](../review-protocol.md#6-reasoning-level-consistency-guards-pointer-only)):
+- [ ] **F** — every `file:line`, branch, PR number, and count is re-verified from current tool
+  output, not memory.
+- [ ] **H** — the `Effect Answer` is evidence-based (grep / test run / diff scan), not a
+  restatement of procedure.
+- [ ] **I** — before defending a challenged verdict, the premise was re-verified and circular
+  reasoning checked.
 
-**G — Closure discipline**
-- [ ] Every question or alternative I raised during planning is closed with
-  `Fixed`, `Deferred-with-rationale`, or `Rejected`. Labels such as "preserve",
-  "maintain", or "leave as-is" are not used.
+**Contract shape**
+- [ ] `Findings` holds OPEN issues only; OK/SKIP are in `Coverage`. Every finding has a dimension
+  ID + a `basis`; no unbased "taste" finding.
+- [ ] `Verdict` matches §4: `CANNOT CERTIFY` when no intent evidence exists; `FAIL` when an OPEN
+  BLOCKING or intent/contract-breaking HIGH is present.
 
-**H — Effect vs process**
-- [ ] Effect questions ("does this break X?") are answered with evidence
-  (grep, test run, diff scan), not substituted by process descriptions
-  ("I followed the steps").
+**External contract (`CONTRACT`)**
+- [ ] API response shapes, OpenAPI spec, and `frontend-handoff.md` match the implementation.
 
-**I — Self-licensing check**
-- [ ] Before defending any challenged conclusion, I re-verified the premise
-  and checked for circular reasoning (concluding what I set out to prove).
+**Security surface (`SEC`)**
+- [ ] Any new endpoint, auth change, file upload, or external call is checked against
+  `docs/ai/shared/security-checklist.md`.
 
-**Contract verification**
-- [ ] External interfaces (API response shapes, OpenAPI spec, `frontend-handoff.md`)
-  match the implementation.
-
-**Security surface**
-- [ ] Any new endpoint, auth change, file upload, or external call has been
-  checked against `docs/ai/shared/security-checklist.md`.
-
-**Test coverage**
-- [ ] If the change touches build-out, security, or external-contract paths,
-  a regression test exists or the absence is explicitly deferred with rationale.
+**Test coverage (`REG` / `ARCH §5`)**
+- [ ] If the change touches build-out, security, or external-contract paths, a regression test
+  exists or the absence is explicitly deferred with rationale.

--- a/docs/ai/shared/skills/security-review.md
+++ b/docs/ai/shared/skills/security-review.md
@@ -33,29 +33,18 @@ Also run when the user explicitly asks for a security audit.
 
 ## Review Contract
 
-Every result must include:
+This audit emits the shared [Review Protocol §3 output contract](../review-protocol.md#3-output-contract):
+`Scope`, `Effect Answer`, `Sources Loaded`, `Findings` (OPEN only), `Coverage` (OK/SKIP),
+`Drift Candidates`, `Verdict`, `Next Actions`, `Completion State`, `Sync Required`.
 
-- `Scope` - audit target, audited domains/files, important exclusions
-- `Effect Answer` - 1-3 sentence evidence-based summary of what security properties the audited
-  code *actually* exposes or protects. Must come from reading the source, not from procedure
-  restatement. Purpose: Guard H (AGENTS.md § Reasoning-Level Consistency Guards) — security
-  questions are almost always effect-type; "I ran the security checklist" is a process answer,
-  not an effect answer. Write `Effect Answer: N/A — process question` only for checklist-only
-  process queries.
-- `Sources Loaded` - exact shared rule sources used for the audit
-- `Findings` - only open issues; each item includes `severity`, `rule source`,
-  `file:line`, `impact`, and `recommended fix`
-- `Drift Candidates` - shared docs, checklists, wrappers, or `project-dna`
-  targets that may need sync; each item includes `target`, `reason`,
-  `auto-fix`, and `sync-required`
-- `Next Actions` - remediation, verification, sync path
-- `Completion State` - concise closure status for the audit
-- `Sync Required` - explicit `true` or `false`
+- This skill applies the **`SEC` dimension** ([Review Protocol §1](../review-protocol.md#1-review-dimensions-concern-based-stable-ids)) in depth via the 12-category checklist below; every `SEC` finding is `rule-source`-based and cites its checklist category ([Finding Basis §2](../review-protocol.md#2-finding-basis-anti-hallucination-rule)).
+- `Verdict` is **`N/A (audit-only scope)`** — a security audit, not a behavior PASS/FAIL ([Review Protocol §4](../review-protocol.md#4-intent--pass-state)).
+- `Effect Answer` is required (Guard H); security questions are almost always effect-type, so "I ran the checklist" is a process answer, not an effect answer. Write `Effect Answer: N/A — process question` only for checklist-only process queries.
 
 ### Severity Taxonomy
 
-- Review state: `OPEN`, `OK`, `SKIP`
-- Severity: `BLOCKING`, `HIGH`, `MEDIUM`, `LOW`, `NOTE`
+State and severity are defined in [Review Protocol §3](../review-protocol.md#3-output-contract):
+review state `OPEN` / `OK` / `SKIP`; severity `BLOCKING` / `HIGH` / `MEDIUM` / `LOW` / `NOTE`.
 
 ## Audit Target
 
@@ -143,17 +132,22 @@ Scope
 - Target: all
 - Audited domains: docs, user, _core
 
+Effect Answer
+- One user write endpoint is exposed without an auth dependency; admin pages gate correctly.
+
 Sources Loaded
-- AGENTS.md
-- docs/ai/shared/project-dna.md
+- docs/ai/shared/review-protocol.md
 - docs/ai/shared/security-checklist.md
+- AGENTS.md
 
 Findings
-- [OPEN][BLOCKING] Security checklist - src/user/interface/server/routers/user_router.py:19
+- [OPEN][BLOCKING][SEC] src/user/interface/server/routers/user_router.py:19 — basis: rule-source (security-checklist §2)
   Impact: write endpoint has no authentication dependency and is exposed to unauthenticated callers.
   Recommended fix: add the project's auth dependency before allowing create/update/delete actions.
-- [OK][BLOCKING] Security checklist §2 - Admin dashboard: require_auth() awaited in all @ui.page handlers
-- [SKIP] Security checklist §4.2 - File Upload input validation: project-dna §8 and live code both confirm feature inactive
+
+Coverage
+- [OK][SEC] security-checklist §2 Admin dashboard — require_auth() awaited in all @ui.page handlers
+- [SKIP][SEC] security-checklist §4.2 File Upload — project-dna §8 and live code both confirm feature inactive
 
 Drift Candidates
 - target: docs/ai/shared/project-dna.md
@@ -164,6 +158,9 @@ Drift Candidates
   reason: active LLM usage exists but the applicable checklist wording is stale.
   auto-fix: no
   sync-required: true
+
+Verdict
+- N/A (audit-only scope)
 
 Next Actions
 - Fix the endpoint authentication gap.
@@ -176,8 +173,8 @@ Sync Required
 - true
 ```
 
-When there are no security findings, still emit all sections. In particular, do
-not omit `Drift Candidates` or `Sync Required`.
+When there are no security findings, still emit every section: `Findings: none`, the `Coverage`
+records, `Verdict: N/A (audit-only scope)`, and do not omit `Drift Candidates` or `Sync Required`.
 
 ## Cross-Tool Review Prompt Template
 
@@ -228,11 +225,13 @@ Review Angles
 Output format
 - Scope
 - Sources Loaded
-- Findings: open issues only, each with severity, rule source, file:line,
+- Findings: OPEN issues only, each with severity, dimension ID (SEC), basis, file:line,
   impact, and recommended fix
+- Coverage: OK/SKIP records with evidence
 - Drift Candidates: target, reason, auto-fix, sync-required
-- R-points: every cross-review point must include one closure category:
-  Fixed, Deferred-with-rationale, or Rejected. Do not use non-canonical labels.
+- R-points: every cross-review point closes as Fixed / Deferred-with-rationale / Rejected
+  (AGENTS Guard G vocabulary; no non-canonical labels)
+- Verdict: N/A (audit-only scope)
 - Final Verdict: clean / minor fixes recommended / still needs security review /
   block merge
 - Sync Required: true or false


### PR DESCRIPTION
## Summary

Unifies the three review skills (`review-pr`, `review-architecture`, `security-review`) under one
shared **Review Protocol** (`docs/ai/shared/review-protocol.md`), and makes `review-pr` the
PR-scoped single entry point that applies it.

Fixes three owner pains: non-deterministic output (inline vs summary decided ad hoc),
file-location review categories instead of concern-based ones, and a rule that structurally
forbade correctness / regression / side-effect findings.

## What changed

- **New** `docs/ai/shared/review-protocol.md` — concern dimensions + stable IDs
  (`CORR / REG / STAB / CONTRACT / ARCH / SEC / GOV`), the **Finding Basis** rule (rule-source for
  ARCH/SEC/GOV; `diff`/`contract`/`test`/`runtime` evidence for the rest — no finding without a
  basis), a `Findings` (open) / `Coverage` (OK/SKIP) output split, an intent/PASS `Verdict`, and
  deterministic GitHub posting (inline-vs-summary + finding key + verdict→action).
- `review-pr` rewritten as the entry point applying the protocol — replaces the old
  "only shared rule sources may create findings" Core Principle that forbade correctness findings.
- `review-architecture` / `security-review` aligned as audit-only
  (`Verdict: N/A (audit-only scope)`); OK/SKIP moved from `Findings` into `Coverage`.
- Claude wrappers + `.agents` mirrors + the `AGENTS.md` Guard H reference repointed to the protocol.
- `harness-asset-matrix.md` registers the new doc.

No `src/` runtime change.

## Verification

- `pre-commit` (Tier-1 language policy, secrets, large files, merge conflicts) passes on all 12
  changed files.
- Cross-reviewed with **codex gpt-5.5 xhigh**: round-0 design, protocol rounds 1–2 (6 R-points
  fixed), final whole-set review (2 R-points fixed). Final verdict: merge-ready; all four
  acceptance criteria met.

Closes #274.

## Governor Footer
- trigger: yes
- reviewer: codex-cli
- rounds: 3
- r-points-fixed: 8
- r-points-deferred: 0
- r-points-rejected: 0
- touched-adr-consequences: none
- pr-scope-notes: review-skill family consolidated under docs/ai/shared/review-protocol.md; docs/harness only, no src runtime change
- final-verdict: merge-ready
- links: https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/274
