### PR TITLE
docs(changelog): add v0.8.4 compare-link refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -395,7 +395,8 @@ Quality Gate review contract, `/plan-feature` Approach Options stage,
 - ADR documentation (001-013)
 - CONTRIBUTING guide and issue templates
 
-[Unreleased]: https://github.com/Mr-DooSun/fastapi-agent-blueprint/compare/v0.8.3...HEAD
+[Unreleased]: https://github.com/Mr-DooSun/fastapi-agent-blueprint/compare/v0.8.4...HEAD
+[0.8.4]: https://github.com/Mr-DooSun/fastapi-agent-blueprint/compare/v0.8.3...v0.8.4
 [0.8.3]: https://github.com/Mr-DooSun/fastapi-agent-blueprint/compare/v0.8.2...v0.8.3
 [0.8.2]: https://github.com/Mr-DooSun/fastapi-agent-blueprint/compare/v0.8.1...v0.8.2
 [0.8.1]: https://github.com/Mr-DooSun/fastapi-agent-blueprint/compare/v0.8.0...v0.8.1


### PR DESCRIPTION
## Change Summary
- Adds the `[0.8.4]` compare-link ref and bumps `[Unreleased]` to `v0.8.4...HEAD` at the bottom of `CHANGELOG.md`. These reference-style links were missed when v0.8.4 was cut in #279, so the `[0.8.4]` heading did not resolve and `[Unreleased]` still diffed against v0.8.3.

## Type of Change
- [x] docs: Documentation

## How to Test
- Bottom of `CHANGELOG.md`: `[Unreleased]` → `compare/v0.8.4...HEAD`, new `[0.8.4]: .../compare/v0.8.3...v0.8.4` line present.