### PR TITLE
fix(governor): close test-file path-traversal bypass in secret check

### DIFF
--- a/.agents/shared/governor/code_safety.py
+++ b/.agents/shared/governor/code_safety.py
@@ -22,6 +22,7 @@ writes) remains in the Claude hook shim because it is tool-specific.
 
 from __future__ import annotations
 
+import posixpath
 import re
 
 # Quoted-value fragment: matches triple-quoted or single-quoted literals >= 3 chars.
@@ -72,6 +73,30 @@ _EXECUTE_FORMAT_RE = re.compile(r'\.execute\s*\(["\x27].*\.format\s*\(', re.IGNO
 _DOMAIN_INFRA_RE = re.compile(r"from\s+src\..*\.infrastructure")
 
 
+def _path_segments(path: str) -> list[str]:
+    """Return the canonical POSIX path segments of *path*, with ``.``/``..`` collapsed.
+
+    ``posixpath.normpath`` resolves ``.`` and ``..`` lexically without touching
+    the filesystem (safe for a not-yet-written target), so a traversal such as
+    ``./tests/../src/config.py`` resolves to its real target (``src/config.py``)
+    *before* any segment is inspected. Callers then match on whole path
+    segments rather than substrings, which stops a bare ``/tests/`` or
+    ``/domain/`` fragment from being spoofed inside another component.
+
+    Separators are POSIX-only by design: the hooks run on macOS/Linux and a
+    backslash is a *valid filename character* there, so folding ``\\`` to ``/``
+    would let ``src\\tests\\config.py`` (a single production filename) masquerade
+    as a ``tests/`` path and skip the secret check. Backslashes are therefore
+    left intact.
+
+    Residual limits (not resolved here — lexical, not filesystem, analysis):
+    symlinked directories and case-insensitive aliases (e.g. ``Domain`` on a
+    case-preserving APFS/HFS+ volume) can still make a real target differ from
+    its textual segments.
+    """
+    return posixpath.normpath(path).split("/")
+
+
 def check_code_safety(path: str, content: str) -> list[str]:
     """Check *content* (to be written to *path*) for security violations.
 
@@ -111,8 +136,13 @@ def check_code_safety(path: str, content: str) -> list[str]:
             'SQL injection risk: execute("...".format()) detected. Use parameterized queries'
         )
 
+    # Canonical, traversal-resolved segments — reused by the test-file and
+    # domain-layer checks below so neither can be spoofed by a crafted path
+    # (e.g. "./tests/../src/config.py").
+    segments = _path_segments(path)
+
     # 2. Hardcoded secrets (skip test files; skip env-var / Pydantic allow-list patterns)
-    is_test_file = "/tests/" in path or path.endswith("_test.py")
+    is_test_file = "tests" in segments or segments[-1].endswith("_test.py")
     if not is_test_file:
         secret_patterns = [
             kw + r"\s*=\s*" + _QUOTED_VALUE_RE for kw in _SENSITIVE_KEYWORDS
@@ -127,7 +157,7 @@ def check_code_safety(path: str, content: str) -> list[str]:
                     break
 
     # 3. Domain -> Infrastructure import violation
-    if "/domain/" in path:
+    if "domain" in segments:
         if _DOMAIN_INFRA_RE.search(content):
             errors.append(
                 "Architecture violation: Domain layer must not import Infrastructure. "

--- a/tests/unit/agents_shared/test_code_safety.py
+++ b/tests/unit/agents_shared/test_code_safety.py
@@ -200,3 +200,55 @@ def test_clean_service_code_passes() -> None:
 )
 def test_safe_content_passes(content: str) -> None:
     assert check_code_safety(_SRC, content) == []
+
+
+# ---------------------------------------------------------------------------
+# Path-normalization regressions — a crafted path must not spoof the
+# test-file skip (or the domain-layer classification) via a bare substring.
+# ---------------------------------------------------------------------------
+
+
+def test_traversal_into_src_does_not_bypass_secret_check() -> None:
+    # "./tests/../src/config.py" contains the substring "/tests/" but resolves
+    # to a production file, so it must NOT be treated as a test file.
+    content = _PWD + " = " + _DQ + "my_super_s3cret_val" + _DQ
+    errors = check_code_safety("./tests/../src/config.py", content)
+    assert any("Hardcoded secret" in e for e in errors)
+
+
+def test_deep_traversal_resolving_to_src_flagged() -> None:
+    content = _PWD + " = " + _DQ + "another_s3cret_here" + _DQ
+    errors = check_code_safety("tests/x/../../src/config.py", content)
+    assert any("Hardcoded secret" in e for e in errors)
+
+
+def test_relative_tests_dir_is_exempted() -> None:
+    # A relative test path (no leading slash) is exempted via segment match,
+    # which the old "/tests/" substring check missed.
+    content = _PWD + " = " + _DQ + "hardcoded_in_test" + _DQ
+    assert check_code_safety("tests/unit/conftest.py", content) == []
+
+
+def test_domain_check_survives_traversal() -> None:
+    # A traversal that resolves into a domain path is still flagged.
+    content = "from src.user.infrastructure import UserRepo"
+    errors = check_code_safety("src/user/foo/../domain/service.py", content)
+    assert any("Domain layer" in e for e in errors)
+
+
+def test_domain_substring_in_component_not_treated_as_domain() -> None:
+    # "domain_events" is not a "domain" segment — the infra import must pass.
+    content = "from src.user.infrastructure import UserRepo"
+    assert check_code_safety("src/user/domain_events/service.py", content) == []
+
+
+def test_backslash_is_not_a_posix_separator() -> None:
+    # On POSIX a backslash is a valid filename char, not a separator. A path
+    # like "src\tests\config.py" is a single production filename and must NOT
+    # be exempted as a test file (folding "\" -> "/" would reintroduce the
+    # bypass this fix closes).
+    content = _PWD + " = " + _DQ + "backslash_s3cret_val" + _DQ
+    errors = check_code_safety(
+        "src" + chr(92) + "tests" + chr(92) + "config.py", content
+    )
+    assert any("Hardcoded secret" in e for e in errors)


### PR DESCRIPTION
## Summary

The hardcoded-secret check in `.agents/shared/governor/code_safety.py::check_code_safety`
exempted test files with a **substring** test — `"/tests/" in path or path.endswith("_test.py")`.
That is bypassable: a crafted path like `./tests/../src/config.py` contains the substring
`/tests/` but resolves to a production file, so a hardcoded secret in production code passed
the check. The domain→infrastructure import check carried the same substring anti-pattern
(`"/domain/" in path`).

**Before**

```python
check_code_safety("src/config.py",            <secret>)  # -> ["Hardcoded secret detected. ..."]
check_code_safety("./tests/../src/config.py", <secret>)  # -> []   ← bypass
```

**After** — both resolve to the same production target and are flagged.

## Fix

- New `_path_segments(path)` helper: `posixpath.normpath` collapses `.`/`..` **lexically**
  (no filesystem access — safe for a not-yet-written target), then matching is on whole path
  **segments** instead of substrings. Applied to both the test-file skip and the
  domain→infra check, so neither can be spoofed by a crafted component.
- **POSIX-only separators by design.** A backslash is a valid filename character on POSIX
  (where these hooks run), so `\` is *not* folded to `/` — folding would let
  `src\tests\config.py` (a single production filename) masquerade as a `tests/` path.
- Regression tests: `./tests/../` traversal, deep traversal into `src`, backslash-as-filename,
  relative `tests/` dirs (now correctly exempted), and the domain segment match.

Fixed at the **policy layer** (the module's documented single source of truth) rather than at
each hook boundary: on this branch only `.claude/hooks/pre_tool_security.py` passes a raw
`file_path` to `check_code_safety` (`.codex` does shell-safety only; `.antigravity` / PR #285
is not merged here), so the policy fix closes the hole for the current caller **and** any
future harness.

## Scope / residual limits (accepted)

This is a **fail-open, best-effort** content linter (it is already defeatable by content
obfuscation — the repo's own tests dodge it via `chr()`). The fix closes the entire lexical
`..`/separator traversal class. Two vectors that require real-filesystem resolution are
consciously **deferred** and documented in the `_path_segments` docstring:

- **Symlinked dirs** (e.g. a pre-planted `tests -> src` symlink) — resolving this needs
  `os.path.realpath`; the vector is strictly *harder* than the content-obfuscation bypasses
  that already defeat this linter, so realpath adds ~no real security while coupling the
  policy to filesystem/cwd state.
- **Case-insensitive aliases** (`Domain/` on APFS/HFS+) — same root cause; not resolved lexically.

## Verification

- Bypass closed; legit test files still exempted; e2e through the real `.claude` hook now
  exits `2` (BLOCKED) on the traversal payload and `0` (allow) on a genuine `tests/` fixture.
- `tests/unit/agents_shared/` — **666 passed**; `ruff format`/`check` clean; pre-commit green
  (incl. the hardcoded-secret detector).

## Governor Footer

- trigger: yes
- reviewer: codex:gpt-5.6-terra
- rounds: 1
- r-points-fixed: 2
- r-points-deferred: 3
- r-points-rejected: 0
- touched-adr-consequences: none
- pr-scope-notes: Governor-changing (`.agents/shared/governor/**`, Tier B). Independent codex read-only review, 1 round, 5 findings. FIXED: a backslash-folding regression introduced mid-fix (would have re-opened the bypass on POSIX) + its regression test. DEFERRED with documented rationale + owner sign-off (fail-open best-effort linter): symlinked-dir resolution (codex HIGH), case-insensitive alias (MEDIUM), and the pre-existing `_test.py` suffix name-trust (MEDIUM, not introduced/worsened here). No ADR Consequence or project-dna invariant changed.
- final-verdict: merge-ready
- links: n/a
