### PR TITLE
refactor(governor): fix manual-stage mypy errors in fail-open shims

### DIFF
--- a/.agents/shared/governor/verify.py
+++ b/.agents/shared/governor/verify.py
@@ -56,7 +56,7 @@ def extract_file_path(payload: dict) -> str | None:
 def is_python_source(file_path: str | None) -> bool:
     """Return True iff ``file_path`` is a non-empty ``.py`` path."""
 
-    return bool(file_path) and file_path.endswith(".py")
+    return file_path is not None and file_path.endswith(".py")
 
 
 def should_remind_claude(payload: dict, state_dir: Path) -> bool:

--- a/.claude/hooks/completion_gate.py
+++ b/.claude/hooks/completion_gate.py
@@ -63,11 +63,11 @@ except Exception:  # noqa: BLE001 — HC-5.5 fail-open
     GOVERNOR_REMINDER_WITH_PR = ""
     GOVERNOR_REMINDER_NO_PR = ""
     MarkerLifecycle = None  # type: ignore[assignment,misc]
-    _shared_read_latest_token = None
-    _shared_consume_phase2_markers = None
-    _shared_changed_files = None
-    _shared_governor_subset = None
-    _shared_is_sync_cosmetic_only = None
+    _shared_read_latest_token = None  # type: ignore[assignment]
+    _shared_consume_phase2_markers = None  # type: ignore[assignment]
+    _shared_changed_files = None  # type: ignore[assignment]
+    _shared_governor_subset = None  # type: ignore[assignment]
+    _shared_is_sync_cosmetic_only = None  # type: ignore[assignment]
     _SHARED_OK = False
 
     def _within_24h(ts: str) -> bool:  # type: ignore[no-redef]
@@ -87,7 +87,7 @@ except Exception:  # noqa: BLE001 — HC-5.5 fail-open
     ) -> bool:
         return False
 
-    def match_log_entry(  # type: ignore[no-redef]
+    def match_log_entry(  # type: ignore[no-redef, misc]
         changed: list[str], current_pr: int | None
     ) -> str:
         return "missing"

--- a/.codex/hooks/completion_gate.py
+++ b/.codex/hooks/completion_gate.py
@@ -75,10 +75,10 @@ except Exception:  # noqa: BLE001 — HC-5.5 fail-open
     GOVERNOR_REMINDER_WITH_PR = ""
     GOVERNOR_REMINDER_NO_PR = ""
     MarkerLifecycle = None  # type: ignore[assignment,misc]
-    _shared_read_latest_token = None
-    _shared_consume_phase2_markers = None
-    _shared_governor_subset = None
-    _shared_is_sync_cosmetic_only = None
+    _shared_read_latest_token = None  # type: ignore[assignment]
+    _shared_consume_phase2_markers = None  # type: ignore[assignment]
+    _shared_governor_subset = None  # type: ignore[assignment]
+    _shared_is_sync_cosmetic_only = None  # type: ignore[assignment]
     _SHARED_OK = False
 
     def _within_24h(ts: str) -> bool:  # type: ignore[no-redef]
@@ -98,7 +98,7 @@ except Exception:  # noqa: BLE001 — HC-5.5 fail-open
     ) -> bool:
         return False
 
-    def match_log_entry(  # type: ignore[no-redef]
+    def match_log_entry(  # type: ignore[no-redef, misc]
         changed: list[str], current_pr: int | None
     ) -> str:
         return "missing"

--- a/.codex/hooks/verify_first.py
+++ b/.codex/hooks/verify_first.py
@@ -48,7 +48,7 @@ except Exception:  # noqa: BLE001 — HC-5.5 fail-open
     EXPLORATION_TOKENS = frozenset()
     REMINDER_TEXT = ""
     MarkerLifecycle = None  # type: ignore[assignment,misc]
-    _shared_read_latest_token = None
+    _shared_read_latest_token = None  # type: ignore[assignment]
     _SHARED_OK = False
 
     def _within_24h(ts: str) -> bool:  # type: ignore[no-redef]


### PR DESCRIPTION
## Summary

Annotation-only pass so `pre-commit run --hook-stage manual mypy` is clean on the governor fail-open shims, with zero runtime change. Closes #283.

### Scope amendment (7 → 13 errors, 3 → 4 files)

The issue counted 7 errors in 3 files. During execution, 6 more same-class errors surfaced in `.claude/hooks/completion_gate.py` — previously masked because mypy only resolves the shared `governor` package (and thus the real callable types) when a `.agents/shared/governor/*` file shares the invocation; standalone runs degrade those imports to `Any` via `--ignore-missing-imports`. Since the issue's acceptance criteria explicitly cover `.claude/hooks/`, the scope was amended (user-approved) to 4 files / 13 errors.

## Changes

- **10× `# type: ignore[assignment]`** on the `except Exception: <name> = None` fail-open rebinds
  (`.codex/hooks/verify_first.py`, `.codex/hooks/completion_gate.py`, `.claude/hooks/completion_gate.py`)
- **`is_python_source` None-guard** (`.agents/shared/governor/verify.py`): `bool(x) and x.endswith(...)` → `x is not None and x.endswith(...)` — behavior-identical (empty string still returns `False`); resolves `[union-attr]` without a suppression
- **`match_log_entry` fallback defs**: `# type: ignore[no-redef]` → `[no-redef, misc]` in both completion-gate shims (fallback returns `str`, the shared original returns the `LogEntryStatus` Literal; alignment would duplicate the Literal set across copies)

No executable-behavior change: the diff is comments plus one logically-equivalent guard.

## Verification

- Scoped manual-stage mypy, 3 invocation shapes (each with the `governor` package resolvable): **0 errors**
- `pytest tests/unit/agents_shared/` (covers `test_fail_open.py`, `test_completion_gate.py`, `test_governor_boundary.py`): **688 passed**
- Full pre-commit commit-stage hooks: passed

## Out of scope (explicit)

- **`--all-files` duplicate-module collision** — the three same-named `completion_gate.py` shims (`.claude/`/`.codex/`/`.antigravity/`, no `__init__.py`) abort mypy under `--hook-stage manual --all-files` before any type error is reported; pre-dates this PR (Antigravity #65 layout), split out per plan decision
- **`.antigravity/hooks/` same-class errors** — 7 errors in 3 files (`completion_gate.py`, `verify_first.py`, `user-prompt-submit.py`) under a resolvable-governor invocation, same masking artifact; cross-review R2, deferred as follow-up
- **Promoting the mypy hook from manual to CI** — deferred in the issue itself
- Issue #283 metadata still says "7 errors"; superseded by this PR's scope note

## Cross-review (Codex, 1 round)

- **R1 [nit]** — `[no-redef]` is vestigial on mypy 1.14.1 and signature alignment via importing `LogEntryStatus` is possible → **Rejected as non-issue**: `[misc]` is the precise fix; dropping `[no-redef]` or adding a cross-copy import is out-of-contract churn for an annotation-minimal PR (empirically confirmed `no-redef` does not fire on 1.14.1 in either invocation shape; harmless without `--warn-unused-ignores`)
- **R2 [non-blocking]** — same-class errors remain in `.antigravity/hooks/` → **Explicitly deferred with rationale**: outside the approved 4-file scope; count corrected from Codex's 6-in-2-files to 7-in-3-files (verified); follow-up issue to track
- Drift: no stale shared/root doc references; `Sync Required: false`
- Final verdict: **merge-ready**

## Governor Footer
- trigger: yes
- reviewer: codex-cli
- rounds: 1
- r-points-fixed: 0
- r-points-deferred: 1
- r-points-rejected: 1
- touched-adr-consequences: none
- pr-scope-notes: annotation-only mypy cleanup of governor fail-open shims; scope amended 3-to-4 files (13 errors) after module-resolution masking was found; fail-open runtime contract unchanged
- final-verdict: merge-ready
- links: n/a