### PR TITLE
fix(tests): guard OpenAI embedding tests and drop read-only property monkeypatch (#288)

### DIFF
--- a/tests/integration/classification/test_classification_stub_fallback.py
+++ b/tests/integration/classification/test_classification_stub_fallback.py
@@ -26,7 +26,6 @@ class TestClassificationStubFallback:
         """Force the LLM selector into its ``disabled`` branch."""
         monkeypatch.setattr(settings, "llm_provider", None)
         monkeypatch.setattr(settings, "llm_model", None)
-        monkeypatch.setattr(settings, "llm_model_name", None)
 
     @pytest.mark.asyncio
     async def test_stub_classifier_produces_dto(self):

--- a/tests/unit/_core/infrastructure/embedding/test_pydantic_ai_embedding_adapter.py
+++ b/tests/unit/_core/infrastructure/embedding/test_pydantic_ai_embedding_adapter.py
@@ -6,6 +6,10 @@ import pytest
 from src._core.domain.value_objects.embedding_config import EmbeddingConfig
 
 _has_pydantic_ai = importlib.util.find_spec("pydantic_ai") is not None
+_has_openai_embeddings = (
+    importlib.util.find_spec("pydantic_ai") is not None
+    and importlib.util.find_spec("openai") is not None
+)
 
 
 class TestEmbeddingConfigValueObject:
@@ -156,7 +160,9 @@ class TestPydanticAIEmbeddingAdapter:
             await adapter.embed_text("test")
 
 
-@pytest.mark.skipif(not _has_pydantic_ai, reason="pydantic-ai not installed")
+@pytest.mark.skipif(
+    not _has_openai_embeddings, reason="pydantic-ai + openai not installed"
+)
 class TestOpenAIBatchSplitting:
     """OpenAI 프로바이더의 배치 분할 로직 테스트."""
 


### PR DESCRIPTION
Extends the `skipif` guard on `TestOpenAIBatchSplitting` to require both `pydantic_ai` and `openai`, and removes a monkeypatch on a read-only property in the classification stub-fallback fixture. Both were latent bugs discovered during #287's CI review, tracked here per your request.

## Related Issue
- Fixes #288

## Change Summary
- Extended the `skipif` guard on `TestOpenAIBatchSplitting` (`test_pydantic_ai_embedding_adapter.py`) to require both `pydantic_ai` and `openai`, since `_build_model` imports `pydantic_ai.embeddings.openai` which needs the `openai` package.
- Removed `monkeypatch.setattr(settings, "llm_model_name", None)` in the classification stub-fallback fixture — it's a read-only derived property that already resolves to `None` once `llm_provider`/`llm_model` are patched.

## Type of Change
- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] refactor: Code restructuring
- [ ] docs: Documentation
- [ ] chore: Build/tooling
- [x] test: Tests
- [ ] ci: CI/CD
- [ ] perf: Performance
- [ ] style: Code style

## Checklist
- [x] Architecture rules followed (no Domain -> Infrastructure imports)
- [x] Tests pass
- [x] Linting passes (`ruff check src/`)

## How to Test
```bash
uv sync --extra pydantic-ai
uv run pytest tests/ -v --tb=short
# affected tests pass or skip cleanly

uv sync --extra pydantic-ai --extra openai
uv run pytest tests/unit/_core/infrastructure/embedding/test_pydantic_ai_embedding_adapter.py -v --tb=short
# TestOpenAIBatchSplitting (4 tests) run and pass
```

Scope kept to just these two test fixes as requested — the CI-matrix decision (whether the test job should install `--extra pydantic-ai`/`openai`) is left out of scope.

---

## Governor Footer
- trigger: yes
- reviewer: self-structured
- rounds: 1
- r-points-fixed: 0
- r-points-deferred: 0
- r-points-rejected: 0
- touched-adr-consequences: none
- pr-scope-notes: test-only fix scoped to the two latent bugs from #288; CI-matrix extras decision intentionally out of scope
- final-verdict: merge-ready
- links: https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/291