### PR TITLE
test: add Locust performance-test harness (#3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup quickstart demo demo-rag dev worker langfuse-env observability-langfuse observability-langfuse-down test lint format check check-core check-full check-minimal smoke-examples clean diagrams
+.PHONY: help setup quickstart demo demo-rag dev worker langfuse-env observability-langfuse observability-langfuse-down test lint format check check-core check-full check-minimal smoke-examples perf-test clean diagrams
 
 LANGFUSE_ENV_FILE := _env/langfuse.env
 MINIMAL_UV_ENV := /tmp/fastapi-agent-blueprint-minimal-venv
@@ -107,6 +107,26 @@ test-dynamo:
 ## Run tests with coverage
 test-cov:
 	uv run pytest tests/ -v --cov=src --cov-report=term-missing
+
+# Locust performance-test defaults — override per run, e.g.
+#   make perf-test PERF_USERS=50 PERF_RUN_TIME=2m
+PERF_HOST ?= http://127.0.0.1:8001
+PERF_USERS ?= 10
+PERF_SPAWN_RATE ?= 2
+PERF_RUN_TIME ?= 30s
+
+# Admin CRUD scenario needs LOCUST_ADMIN_USERNAME / LOCUST_ADMIN_PASSWORD —
+# see docs/operations/performance-locust.md. Numbers are illustrative only.
+## Headless Locust perf run against a local server (start `make quickstart` first)
+perf-test:
+	uv run locust \
+		-f tests/perf/locustfile.py \
+		--headless \
+		--host $(PERF_HOST) \
+		--users $(PERF_USERS) \
+		--spawn-rate $(PERF_SPAWN_RATE) \
+		--run-time $(PERF_RUN_TIME) \
+		--stop-timeout 10
 
 ## Run linter
 lint:

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ Quick index for the `docs/` folder.
 |---|---|
 | [operations/observability-otel.md](operations/observability-otel.md) | OpenTelemetry — Jaeger / Tempo / Phoenix setup |
 | [operations/observability-langfuse.md](operations/observability-langfuse.md) | Langfuse opt-in for LLM prompt tracing |
+| [operations/performance-locust.md](operations/performance-locust.md) | Locust performance-test harness — `make perf-test`, scenarios, reading output |
 
 ## Architecture decisions
 

--- a/docs/operations/performance-locust.md
+++ b/docs/operations/performance-locust.md
@@ -1,0 +1,167 @@
+# Locust Performance Testing — Operations Recipe
+
+This document covers the repo's Locust harness: how to run it against the
+zero-config quickstart server, how to read the output, and how to enable the
+optional admin CRUD scenario.
+
+This is a ready-to-adapt harness for a blueprint, not benchmarking
+infrastructure. Any numbers it produces are illustrative for the local
+quickstart setup (SQLite + InMemory broker on one machine) — treat them as a
+smoke reference, not production guarantees. Adopters should rerun the harness
+against their own infrastructure. It is intentionally **not** wired into CI.
+
+Never point the harness at a shared or production environment: the customer
+scenario registers accounts and the admin scenario creates and deletes users.
+
+## What you get
+
+`tests/perf/locustfile.py` defines three scenarios:
+
+| Scenario | User class | Requires | What it measures |
+|---|---|---|---|
+| Customer auth flow | `CustomerAuthUser` | nothing | `POST /v1/auth/register` (once per virtual user), `GET /v1/auth/me`, `POST /v1/auth/refresh`, and `POST /v1/auth/logout` on stop — all on the customer JWT realm |
+| Concurrent health reads | `HealthCheckUser` | nothing | `GET /health` (no-op app baseline) and `GET /health/db` (connection-pool acquisition + a real `SELECT 1`; 503 when the DB is down) |
+| Admin CRUD flow | `AdminCrudUser` | `LOCUST_ADMIN_*` env vars | `POST /v1/admin/login`, paginated `GET /v1/users`, and a create → read → update → delete cycle on `/v1/user` |
+
+`/health` and `/health/db` are tracked as separate stat rows on purpose — the
+first isolates app/HTTP responsiveness, the second adds a database roundtrip.
+The per-ID CRUD requests are grouped under one `/v1/user/[id]` row so each
+generated ID does not create its own statistics line.
+
+## Run it
+
+```bash
+make quickstart      # terminal 1 — zero-config server on 127.0.0.1:8001
+make perf-test       # terminal 2 — 30s headless run, summary printed on exit
+```
+
+Without admin credentials the run covers the customer + health scenarios and
+logs one line noting that the admin scenario is disabled. That default run is
+the supported zero-setup path.
+
+### Configuration
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `PERF_HOST` | `http://127.0.0.1:8001` | Target base URL |
+| `PERF_USERS` | `10` | Peak number of concurrent virtual users |
+| `PERF_SPAWN_RATE` | `2` | Users started per second until the peak |
+| `PERF_RUN_TIME` | `30s` | Total run duration (`30s`, `2m`, …) |
+
+```bash
+make perf-test PERF_USERS=50 PERF_SPAWN_RATE=5 PERF_RUN_TIME=2m
+```
+
+For Locust's web UI, charts, or CSV output, invoke Locust directly —
+`uv run locust -f tests/perf/locustfile.py --host http://127.0.0.1:8001`
+(then open http://localhost:8089).
+
+## Enabling the admin CRUD scenario
+
+All `/v1/user` routes are admin-only (#199) and require a token from the
+separate admin JWT realm (#218). Two things follow:
+
+- A **customer** token cannot run the CRUD scenario — the admin verifier
+  rejects it with `401 INVALID_TOKEN`.
+- The quickstart bootstrap account (`admin`/`admin`) is **setup-only**: the
+  token API (`POST /v1/admin/login`) rejects bootstrap and temp-password
+  admins with `401`.
+
+So the scenario needs a real (non-bootstrap) admin, provisioned once through
+the browser dashboard:
+
+1. With the quickstart server running, open http://127.0.0.1:8001/admin and
+   log in with the bootstrap credentials (`admin`/`admin` unless changed in
+   `_env/quickstart.env`). You are redirected to the one-time setup page.
+2. Create the first real admin account. Copy the generated temporary password
+   — it is shown exactly once, and the bootstrap account is deleted.
+3. Log in again with the temporary password and complete the forced password
+   change.
+
+Then export the credentials and rerun:
+
+```bash
+export LOCUST_ADMIN_USERNAME=<your-admin-username>
+export LOCUST_ADMIN_PASSWORD=<your-admin-password>
+make perf-test
+```
+
+Credential behavior:
+
+- **Both unset** — the admin user class is never spawned; the run stays
+  zero-setup and useful.
+- **Set but wrong** — the `/v1/admin/login` failure is recorded loudly in
+  Locust's failure table and that virtual user stops. It never silently
+  downgrades.
+- Credentials are read from the environment only — never hardcode them, and
+  they are not logged.
+
+The CRUD cycle deletes the users it creates; a hard abort mid-cycle can leave
+a stray `crud…` user behind in the local quickstart database (delete it via
+the admin dashboard or remove `quickstart.db`).
+
+## Reading the output
+
+A headless run prints a stats table while running and a final summary:
+
+```
+Type  Name                 # reqs  # fails  |  Avg  Min  Max  Med  |  req/s  failures/s
+GET   /health                 312     0(0.00%)     3    1   18    2      10.4    0.00
+GET   /v1/auth/me             208     0(0.00%)     9    4   61    7       6.9    0.00
+...
+Response time percentiles (approximated)
+Type  Name             50%  66%  75%  80%  90%  95%  98%  99%  ...
+```
+
+What to look at:
+
+- **# reqs / req/s** — total volume and sustained throughput per endpoint.
+- **# fails** — anything above 0% needs an explanation before the numbers
+  mean anything (auth failures, 5xx, connection errors all land here).
+- **Med (p50)** — typical latency; compare `/health` vs `/health/db` vs
+  authenticated endpoints to see where time is spent.
+- **p95 / p99** (percentiles block) — tail latency; the first thing to watch
+  when raising `PERF_USERS`.
+
+The `Aggregated` row summarizes everything; per-endpoint rows are usually
+more actionable.
+
+`make perf-test` exits non-zero when any request failed during the run, so a
+clean exit code doubles as a quick pass/fail signal.
+
+## Illustrative local baseline
+
+One measured default run (customer + health scenarios; admin scenario
+inactive), recorded to show the expected shape of the output — not a
+performance guarantee of any kind:
+
+| Field | Value |
+|---|---|
+| Date | 2026-07-15 |
+| Machine / OS | Apple M3 Pro, 18 GB — macOS (Darwin 24.6.0) |
+| Python / project version | Python 3.13.8 / v0.8.4 (Locust 2.43.0) |
+| Server | `make quickstart` (SQLite + InMemory broker, single process) |
+| Profile | `PERF_USERS=10`, `PERF_SPAWN_RATE=2`, `PERF_RUN_TIME=30s` |
+| Total requests / failures | 327 / 0 (0.00%) |
+| Aggregated RPS | 10.9 |
+| Aggregated p50 / p95 / p99 | 3 ms / 25 ms / 220 ms |
+
+Per-endpoint medians from the same run: `/health` 2 ms, `/health/db` 4 ms,
+`/v1/auth/me` 4 ms, `/v1/auth/refresh` 13 ms, `/v1/auth/logout` 20 ms,
+`/v1/auth/register` 220 ms (bcrypt password hashing dominates registration —
+it runs once per virtual user, and its tail is what pushes the aggregated p99
+up). Throughput here is bounded by the scenario think-times (`wait_time`),
+not by the server.
+
+## Limitations
+
+- Local quickstart topology only (SQLite, single process, same machine as the
+  load generator) — the load generator and server compete for CPU.
+- Admin access tokens expire after 15 minutes by default
+  (`ADMIN_JWT_ACCESS_TOKEN_MINUTES`) and the harness does not refresh them —
+  keep admin-enabled runs under that limit or expect `401` rows near the end.
+  The customer scenario self-heals via its refresh task.
+- Illustrative, not authoritative: no thresholds, no regression gating, no CI.
+- The customer scenario grows the local database (one account per virtual
+  user per run); reset with `rm quickstart.db` when it matters.
+- Worker/broker load (Taskiq scenarios) is out of scope.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -297,7 +297,7 @@ for the live view.
 ### Phase 3 — Ecosystem
 
 - [ ] Test coverage expansion ([#2](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/2))
-- [ ] Performance testing — Locust ([#3](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/3))
+- [x] Performance testing — Locust ([#3](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/3))
 - [ ] Serverless deployment ([#6](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/6))
 - [ ] WebSocket documentation ([#1](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/1))
 

--- a/tests/perf/locustfile.py
+++ b/tests/perf/locustfile.py
@@ -1,0 +1,216 @@
+"""Locust performance-test harness for the FastAPI Agent Blueprint.
+
+Run headless against the zero-config quickstart server::
+
+    make quickstart      # terminal 1
+    make perf-test       # terminal 2
+
+Scenarios (see docs/operations/performance-locust.md):
+
+- ``CustomerAuthUser`` (always on) — register a unique customer account, then
+  exercise ``GET /v1/auth/me`` and token refresh on the customer JWT realm.
+- ``HealthCheckUser`` (always on) — concurrent reads of ``GET /health`` (no-op
+  baseline) and ``GET /health/db`` (pool acquisition + a real ``SELECT 1``).
+- ``AdminCrudUser`` (opt-in) — admin-realm login, then the ``/v1/user`` CRUD
+  cycle. Activated only when ``LOCUST_ADMIN_USERNAME`` and
+  ``LOCUST_ADMIN_PASSWORD`` are both set; the bootstrap ``admin`` account
+  cannot be used (setup-only — see the docs for one-time provisioning).
+
+Numbers produced by this harness are illustrative for the local quickstart
+setup only; adopters should rerun it against their own infrastructure.
+"""
+
+import logging
+import os
+import secrets
+import uuid
+
+from locust import HttpUser, between, task
+from locust.exception import StopUser
+
+logger = logging.getLogger(__name__)
+
+ADMIN_USERNAME = os.getenv("LOCUST_ADMIN_USERNAME", "")
+ADMIN_PASSWORD = os.getenv("LOCUST_ADMIN_PASSWORD", "")
+ADMIN_SCENARIO_ENABLED = bool(ADMIN_USERNAME and ADMIN_PASSWORD)
+
+if not ADMIN_SCENARIO_ENABLED:
+    logger.warning(
+        "LOCUST_ADMIN_USERNAME / LOCUST_ADMIN_PASSWORD not set — the admin "
+        "/v1/user CRUD scenario is disabled; running customer + health "
+        "scenarios only."
+    )
+
+
+def _unique_name(prefix: str) -> str:
+    """Collision-safe username that fits the 20-char schema limit."""
+    return f"{prefix}{uuid.uuid4().hex[:12]}"
+
+
+def _bearer(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _error_code(response) -> str:
+    """API errorCode for failure messages — never echo the response body.
+
+    Bodies can carry submitted values in dev-mode error details, and unique
+    bodies would fragment Locust's error table into one row per occurrence.
+    """
+    try:
+        return str(response.json().get("errorCode", ""))
+    except (ValueError, AttributeError):
+        return ""
+
+
+class CustomerAuthUser(HttpUser):
+    """Customer-realm flow: one-time register, then profile reads + refresh."""
+
+    weight = 3
+    wait_time = between(0.5, 2.0)
+
+    def on_start(self) -> None:
+        username = _unique_name("perf")
+        payload = {
+            "username": username,
+            "fullName": "Perf Customer",
+            "email": f"{username}@example.com",
+            "password": secrets.token_urlsafe(12),
+        }
+        with self.client.post(
+            "/v1/auth/register", json=payload, catch_response=True
+        ) as response:
+            if response.status_code != 200:
+                response.failure(
+                    f"customer register failed "
+                    f"({response.status_code} {_error_code(response)})"
+                )
+                raise StopUser()
+            data = response.json()["data"]
+            self._access_token = data["accessToken"]
+            self._refresh_token = data["refreshToken"]
+
+    def on_stop(self) -> None:
+        # Revoke the final refresh token so runs do not accumulate live
+        # sessions. on_stop also runs when on_start failed, hence the guard.
+        refresh_token = getattr(self, "_refresh_token", None)
+        if refresh_token:
+            self.client.post("/v1/auth/logout", json={"refreshToken": refresh_token})
+
+    @task(3)
+    def get_me(self) -> None:
+        self.client.get("/v1/auth/me", headers=_bearer(self._access_token))
+
+    @task(1)
+    def refresh_tokens(self) -> None:
+        with self.client.post(
+            "/v1/auth/refresh",
+            json={"refreshToken": self._refresh_token},
+            catch_response=True,
+        ) as response:
+            if response.status_code in (401, 403):
+                # The refresh token is dead (revoked/expired) — retrying it
+                # forever would only stack failures, so stop this user.
+                response.failure(
+                    f"refresh token no longer valid "
+                    f"({response.status_code} {_error_code(response)}) — "
+                    "stopping this user"
+                )
+                self._refresh_token = None
+                raise StopUser()
+            if response.status_code != 200:
+                response.failure(
+                    f"token refresh failed "
+                    f"({response.status_code} {_error_code(response)})"
+                )
+                return
+            data = response.json()["data"]
+            self._access_token = data["accessToken"]
+            self._refresh_token = data["refreshToken"]
+
+
+class HealthCheckUser(HttpUser):
+    """Concurrent unauthenticated reads against the health endpoints."""
+
+    weight = 2
+    wait_time = between(0.2, 1.0)
+
+    @task(5)
+    def health(self) -> None:
+        self.client.get("/health")
+
+    @task(1)
+    def health_db(self) -> None:
+        # Not a no-op: acquires a pool connection and runs SELECT 1 (503 when
+        # the database is unreachable).
+        self.client.get("/health/db")
+
+
+class AdminCrudUser(HttpUser):
+    """Admin-realm /v1/user CRUD cycle. Spawned only when credentials are set.
+
+    Locust skips user classes with ``abstract = True`` at collection time, so
+    without credentials this scenario never spawns and the default run stays
+    zero-setup. Invalid credentials fail loudly in the stats table instead.
+    """
+
+    abstract = not ADMIN_SCENARIO_ENABLED
+    weight = 1
+    wait_time = between(0.5, 2.0)
+
+    def on_start(self) -> None:
+        with self.client.post(
+            "/v1/admin/login",
+            json={"username": ADMIN_USERNAME, "password": ADMIN_PASSWORD},
+            catch_response=True,
+        ) as response:
+            if response.status_code != 200:
+                response.failure(
+                    f"admin login rejected ({response.status_code}) — check "
+                    "LOCUST_ADMIN_USERNAME / LOCUST_ADMIN_PASSWORD (bootstrap "
+                    "and temp-password admins cannot use the token API)"
+                )
+                raise StopUser()
+            self._access_token = response.json()["data"]["accessToken"]
+
+    @task(2)
+    def list_users(self) -> None:
+        self.client.get(
+            "/v1/users",
+            params={"page": 1, "pageSize": 10},
+            headers=_bearer(self._access_token),
+        )
+
+    @task(1)
+    def user_crud_cycle(self) -> None:
+        headers = _bearer(self._access_token)
+        username = _unique_name("crud")
+        create = self.client.post(
+            "/v1/user",
+            json={
+                "username": username,
+                "fullName": "Perf Crud",
+                "email": f"{username}@example.com",
+                "password": secrets.token_urlsafe(12),
+            },
+            headers=headers,
+        )
+        if create.status_code != 200:
+            return
+        user_id = create.json()["data"]["id"]
+        try:
+            self.client.get(
+                f"/v1/user/{user_id}", headers=headers, name="/v1/user/[id]"
+            )
+            self.client.put(
+                f"/v1/user/{user_id}",
+                json={"fullName": "Perf Crud Updated"},
+                headers=headers,
+                name="/v1/user/[id]",
+            )
+        finally:
+            # Always try to remove the record so repeated runs do not
+            # accumulate rows (a hard abort can still leave residue).
+            self.client.delete(
+                f"/v1/user/{user_id}", headers=headers, name="/v1/user/[id]"
+            )

--- a/tests/perf/locustfile.py
+++ b/tests/perf/locustfile.py
@@ -171,7 +171,17 @@ class AdminCrudUser(HttpUser):
                     "and temp-password admins cannot use the token API)"
                 )
                 raise StopUser()
-            self._access_token = response.json()["data"]["accessToken"]
+            data = response.json()["data"]
+            self._access_token = data["accessToken"]
+            self._refresh_token = data["refreshToken"]
+
+    def on_stop(self) -> None:
+        # Mirror CustomerAuthUser: revoke the admin refresh token so opt-in
+        # runs don't leave live admin sessions behind (on_stop also runs when
+        # on_start failed, hence the guard).
+        refresh_token = getattr(self, "_refresh_token", None)
+        if refresh_token:
+            self.client.post("/v1/admin/logout", json={"refreshToken": refresh_token})
 
     @task(2)
     def list_users(self) -> None:


### PR DESCRIPTION
## Related Issue
- Closes #3

## Change Summary
- `tests/perf/locustfile.py` — Locust harness with three scenarios: an always-on customer auth flow (`/v1/auth/register` → `/v1/auth/me` → `/v1/auth/refresh`, `/v1/auth/logout` on stop), always-on concurrent health reads (`/health` and `/health/db` as separate stat rows), and an env-gated admin CRUD flow on `/v1/user` (paginated list + create → read → update → delete with grouped `/v1/user/[id]` stats and self-cleanup)
- `make perf-test` — headless run against a local server; `PERF_HOST` / `PERF_USERS` / `PERF_SPAWN_RATE` / `PERF_RUN_TIME` overridable; exits non-zero if any request failed
- `docs/operations/performance-locust.md` — how to run, how to read the output, the one-time admin provisioning flow, a measured illustrative local baseline, and limitations (quickstart-local, illustrative only, no CI — per the scoping comment)
- Index updates: `docs/README.md` Operations table row + roadmap checkbox in `docs/reference.md`
- No `src/` changes, no new dependencies (locust was already in the dev group), no CI wiring

## Type of Change
- [x] test: Tests
- [x] docs: Documentation

## Checklist
- [x] Architecture rules followed (no Domain -> Infrastructure imports) — no `src/` changes
- [x] Tests pass — 1371 passed; one pre-existing failure unrelated to this PR (see Notes)
- [x] Linting passes (`ruff check src/`) — plus `ruff check tests/perf/` and all pre-commit hooks on the changed files

## How to Test
```bash
make quickstart      # terminal 1
make perf-test       # terminal 2 — 30s headless run, exits 0 with a stats summary
```
- Default run needs zero setup (customer + health scenarios). Measured here: 327 requests / 0 failures, 10.9 RPS, p50 3 ms / p95 25 ms / p99 220 ms — recorded in the docs as an illustrative baseline.
- Admin scenario: provision a real admin once via the dashboard (documented three-step flow), then `LOCUST_ADMIN_USERNAME=… LOCUST_ADMIN_PASSWORD=… make perf-test`.
- Negative probe: `LOCUST_ADMIN_USERNAME=admin LOCUST_ADMIN_PASSWORD=admin make perf-test` — the bootstrap admin is rejected by the token API, the login failure shows loudly in Locust's error report, and `make` exits non-zero.

## Scenario shape — as requested, pinging for your input (@Mr-DooSun)
- The requested "auth + CRUD flow on `/v1/user`" hit a wall: all `/v1/user` routes are admin-realm-gated (#199/#218), and the bootstrap admin is setup-only (rejected by `POST /v1/admin/login`). So the CRUD scenario is **env-gated** behind `LOCUST_ADMIN_*` credentials, and I added an always-on **customer-realm auth scenario** so the default `make perf-test` produces useful output with zero manual setup. Happy to reshape if you prefer a different split.
- Optional follow-up question: a dev-only admin seed script could make the admin scenario turnkey. There is an in-repo precedent (`_seed_real_admin` e2e fixture), but it bypasses the normal first-admin lifecycle (in-process DI, no setup gate), so I left it out pending your call.

## Notes
- Drift (deferred): `.claude/rules/commands.md` does not yet list `make perf-test`. Deliberately left out to keep this PR non-governor-changing — happy to include it or leave it for a follow-up `/sync-guidelines`, your preference.
- Pre-existing test failure (unrelated): `tests/unit/agents_shared/test_antigravity_hardening.py::test_native_write_file_edit_is_formatted` fails identically on current `main` in my environment (formatting-hook subprocess appears environment-dependent). Not touched by this PR.

