### PR TITLE
fix(examples): bound ChatReply.confidence to [0, 1] across chatbot examples

### DIFF
--- a/examples/chatbot_with_guardrails/domain/dtos/chatbot_dto.py
+++ b/examples/chatbot_with_guardrails/domain/dtos/chatbot_dto.py
@@ -8,7 +8,10 @@ class ChatReply(BaseModel):
 
     reply: str = Field(..., description="The assistant response text")
     confidence: float = Field(
-        ..., description="The confidence score of the reply, between 0.0 and 1.0"
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="The confidence score of the reply, between 0.0 and 1.0",
     )
 
 

--- a/examples/chatbot_with_memory/domain/dtos/chatbot_memory_dto.py
+++ b/examples/chatbot_with_memory/domain/dtos/chatbot_memory_dto.py
@@ -8,7 +8,10 @@ class ChatReply(BaseModel):
 
     reply: str = Field(..., description="The assistant response text")
     confidence: float = Field(
-        ..., description="The confidence score of the reply, between 0.0 and 1.0"
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="The confidence score of the reply, between 0.0 and 1.0",
     )
 
 
@@ -40,6 +43,6 @@ class ConversationTurnDTO(BaseModel):
     session_id: str
     user_message: str
     assistant_reply: str
-    confidence: float
+    confidence: float = Field(..., ge=0.0, le=1.0)
     tokens_used: int
     created_at: datetime

--- a/examples/simple_chatbot/domain/dtos/chatbot_dto.py
+++ b/examples/simple_chatbot/domain/dtos/chatbot_dto.py
@@ -8,7 +8,10 @@ class ChatReply(BaseModel):
 
     reply: str = Field(..., description="The assistant response text")
     confidence: float = Field(
-        ..., description="The confidence score of the reply, between 0.0 and 1.0"
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="The confidence score of the reply, between 0.0 and 1.0",
     )
 
 

--- a/examples/web_search_chatbot/domain/dtos/chatbot_dto.py
+++ b/examples/web_search_chatbot/domain/dtos/chatbot_dto.py
@@ -8,7 +8,10 @@ class ChatReply(BaseModel):
 
     reply: str = Field(..., description="The assistant response text")
     confidence: float = Field(
-        ..., description="The confidence score of the reply, between 0.0 and 1.0"
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="The confidence score of the reply, between 0.0 and 1.0",
     )
 
 

--- a/tests/unit/chatbot_with_guardrails/chatbot_test.py
+++ b/tests/unit/chatbot_with_guardrails/chatbot_test.py
@@ -116,3 +116,23 @@ def test_request_validation() -> None:
 
     with pytest.raises(ValidationError):
         ChatRequest(prompt="a" * 1001)
+
+
+def test_chat_reply_confidence_bounds() -> None:
+    """ChatReply.confidence must be within [0.0, 1.0].
+
+    The bound lives on the PydanticAI agent output schema, so an out-of-range
+    model confidence is rejected at output-validation time -- before the service
+    persists the turn (no orphan row, no duplicate on client retry). See #294.
+    """
+    from pydantic import ValidationError
+
+    # Boundary values are accepted
+    assert ChatReply(reply="ok", confidence=0.0).confidence == 0.0
+    assert ChatReply(reply="ok", confidence=1.0).confidence == 1.0
+
+    # Out-of-range values are rejected
+    with pytest.raises(ValidationError):
+        ChatReply(reply="ok", confidence=1.2)
+    with pytest.raises(ValidationError):
+        ChatReply(reply="ok", confidence=-0.1)

--- a/tests/unit/chatbot_with_guardrails/chatbot_test.py
+++ b/tests/unit/chatbot_with_guardrails/chatbot_test.py
@@ -136,3 +136,49 @@ def test_chat_reply_confidence_bounds() -> None:
         ChatReply(reply="ok", confidence=1.2)
     with pytest.raises(ValidationError):
         ChatReply(reply="ok", confidence=-0.1)
+
+
+@pytest.mark.anyio
+async def test_out_of_range_confidence_fails_before_persistence(
+    test_db, monkeypatch
+) -> None:
+    """An out-of-range model confidence fails inside the agent run -- before any DB write.
+
+    Pins the #294 fix end-to-end through the real adapter and service (with a
+    benign prompt that passes the input guardrail): FunctionModel forces
+    confidence=1.2, the agent's output validation rejects it (retries exhaust
+    into UnexpectedModelBehavior), and the service never reaches its insert --
+    no orphan row, no duplicate on client retry.
+    """
+    pytest.importorskip("pydantic_ai")
+    from pydantic_ai import UnexpectedModelBehavior
+    from pydantic_ai.messages import ModelMessage, ModelResponse, ToolCallPart
+    from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+    def agent_function(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name="final_result",
+                    args={"reply": "ok", "confidence": 1.2},
+                )
+            ]
+        )
+
+    repository = ChatbotRepository(database=test_db)
+    insert_calls: list[object] = []
+    original_insert = repository.insert_data
+
+    async def counting_insert(dto):  # noqa: ANN001, ANN202
+        insert_calls.append(dto)
+        return await original_insert(dto)
+
+    monkeypatch.setattr(repository, "insert_data", counting_insert)
+
+    chatbot = PydanticAIChatbot(llm_model=FunctionModel(agent_function))
+    service = ChatService(chatbot=chatbot, repository=repository)
+
+    with pytest.raises(UnexpectedModelBehavior):
+        await service.reply("Hello AI")
+
+    assert insert_calls == []

--- a/tests/unit/chatbot_with_memory/test_chatbot_memory.py
+++ b/tests/unit/chatbot_with_memory/test_chatbot_memory.py
@@ -165,6 +165,45 @@ def test_confidence_bounds() -> None:
             created_at=datetime(2026, 1, 1),
         )
 
+    assert _turn(0.0).confidence == 0.0
     assert _turn(1.0).confidence == 1.0
     with pytest.raises(ValidationError):
         _turn(1.2)
+    with pytest.raises(ValidationError):
+        _turn(-0.1)
+
+
+@pytest.mark.anyio
+async def test_out_of_range_confidence_fails_before_persistence(test_db) -> None:
+    """An out-of-range model confidence fails inside the agent run -- before any DB write.
+
+    Pins the #294 fix end-to-end through the real adapter and service:
+    FunctionModel forces confidence=1.2, the agent's output validation rejects
+    it (retries exhaust into UnexpectedModelBehavior), and the service never
+    reaches its two inserts -- neither the user nor the assistant row is
+    persisted, so a client retry cannot duplicate the turn.
+    """
+    pytest.importorskip("pydantic_ai")
+    from pydantic_ai import UnexpectedModelBehavior
+    from pydantic_ai.messages import ModelMessage, ModelResponse, ToolCallPart
+    from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+    def agent_function(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name="final_result",
+                    args={"reply": "ok", "confidence": 1.2},
+                )
+            ]
+        )
+
+    repository = ChatbotMemoryRepository(database=test_db)
+    chatbot = PydanticAIChatbotMemory(llm_model=FunctionModel(agent_function))
+    service = ChatMemoryService(chatbot=chatbot, repository=repository)
+
+    with pytest.raises(UnexpectedModelBehavior):
+        await service.reply(session_id="session-out-of-range", prompt="Hello AI")
+
+    # Neither the user nor the assistant row was persisted
+    assert await service.get_history(session_id="session-out-of-range") == []

--- a/tests/unit/chatbot_with_memory/test_chatbot_memory.py
+++ b/tests/unit/chatbot_with_memory/test_chatbot_memory.py
@@ -130,3 +130,41 @@ def test_chat_memory_request_validation() -> None:
     # session_id too long
     with pytest.raises(ValidationError):
         ChatMemoryRequest(session_id="a" * 129, prompt="Hello")
+
+
+def test_confidence_bounds() -> None:
+    """confidence must be within [0.0, 1.0] on both the agent output and the turn DTO.
+
+    The bound on ``ChatReply`` (the PydanticAI agent output schema) rejects an
+    out-of-range model confidence at output-validation time -- before the service
+    persists the two turn rows (no orphan rows, no duplicates on client retry).
+    ``ConversationTurnDTO`` carries the same bound as defense-in-depth. See #294.
+    """
+    from datetime import datetime
+
+    from pydantic import ValidationError
+
+    from examples.chatbot_with_memory.domain.dtos.chatbot_memory_dto import ChatReply
+
+    # ChatReply (agent output) -- boundaries accepted, out-of-range rejected
+    assert ChatReply(reply="ok", confidence=0.0).confidence == 0.0
+    assert ChatReply(reply="ok", confidence=1.0).confidence == 1.0
+    with pytest.raises(ValidationError):
+        ChatReply(reply="ok", confidence=1.2)
+    with pytest.raises(ValidationError):
+        ChatReply(reply="ok", confidence=-0.1)
+
+    # ConversationTurnDTO carrier -- same bound
+    def _turn(confidence: float) -> ConversationTurnDTO:
+        return ConversationTurnDTO(
+            session_id="s",
+            user_message="hi",
+            assistant_reply="yo",
+            confidence=confidence,
+            tokens_used=0,
+            created_at=datetime(2026, 1, 1),
+        )
+
+    assert _turn(1.0).confidence == 1.0
+    with pytest.raises(ValidationError):
+        _turn(1.2)

--- a/tests/unit/simple_chatbot/chatbot_test.py
+++ b/tests/unit/simple_chatbot/chatbot_test.py
@@ -106,3 +106,48 @@ def test_chat_reply_confidence_bounds() -> None:
         ChatReply(reply="ok", confidence=1.2)
     with pytest.raises(ValidationError):
         ChatReply(reply="ok", confidence=-0.1)
+
+
+@pytest.mark.anyio
+async def test_out_of_range_confidence_fails_before_persistence(
+    test_db, monkeypatch
+) -> None:
+    """An out-of-range model confidence fails inside the agent run -- before any DB write.
+
+    Pins the #294 fix end-to-end through the real adapter and service:
+    FunctionModel forces confidence=1.2, the agent's output validation rejects
+    it (retries exhaust into UnexpectedModelBehavior), and the service never
+    reaches its insert -- no orphan row, no duplicate on client retry.
+    """
+    pytest.importorskip("pydantic_ai")
+    from pydantic_ai import UnexpectedModelBehavior
+    from pydantic_ai.messages import ModelMessage, ModelResponse, ToolCallPart
+    from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+    def agent_function(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name="final_result",
+                    args={"reply": "ok", "confidence": 1.2},
+                )
+            ]
+        )
+
+    repository = ChatbotRepository(database=test_db)
+    insert_calls: list[object] = []
+    original_insert = repository.insert_data
+
+    async def counting_insert(dto):  # noqa: ANN001, ANN202
+        insert_calls.append(dto)
+        return await original_insert(dto)
+
+    monkeypatch.setattr(repository, "insert_data", counting_insert)
+
+    chatbot = PydanticAIChatbot(llm_model=FunctionModel(agent_function))
+    service = ChatService(chatbot=chatbot, repository=repository)
+
+    with pytest.raises(UnexpectedModelBehavior):
+        await service.reply("Hello AI")
+
+    assert insert_calls == []

--- a/tests/unit/simple_chatbot/chatbot_test.py
+++ b/tests/unit/simple_chatbot/chatbot_test.py
@@ -86,3 +86,23 @@ def test_chatbot_request_validation() -> None:
     # 3. Prompt > 1000 chars should fail (max_length=1000)
     with pytest.raises(ValidationError):
         ChatRequest(prompt="a" * 1001)
+
+
+def test_chat_reply_confidence_bounds() -> None:
+    """ChatReply.confidence must be within [0.0, 1.0].
+
+    The bound lives on the PydanticAI agent output schema, so an out-of-range
+    model confidence is rejected at output-validation time -- before the service
+    persists the turn (no orphan row, no duplicate on client retry). See #294.
+    """
+    from pydantic import ValidationError
+
+    # Boundary values are accepted
+    assert ChatReply(reply="ok", confidence=0.0).confidence == 0.0
+    assert ChatReply(reply="ok", confidence=1.0).confidence == 1.0
+
+    # Out-of-range values are rejected
+    with pytest.raises(ValidationError):
+        ChatReply(reply="ok", confidence=1.2)
+    with pytest.raises(ValidationError):
+        ChatReply(reply="ok", confidence=-0.1)

--- a/tests/unit/web_search_chatbot/chatbot_test.py
+++ b/tests/unit/web_search_chatbot/chatbot_test.py
@@ -160,3 +160,23 @@ def test_chatbot_request_validation() -> None:
     # 3. Prompt > 1000 chars should fail (max_length=1000)
     with pytest.raises(ValidationError):
         ChatRequest(prompt="a" * 1001)
+
+
+def test_chat_reply_confidence_bounds() -> None:
+    """ChatReply.confidence must be within [0.0, 1.0].
+
+    The bound lives on the PydanticAI agent output schema, so an out-of-range
+    model confidence is rejected at output-validation time -- before the service
+    persists the turn (no orphan row, no duplicate on client retry). See #294.
+    """
+    from pydantic import ValidationError
+
+    # Boundary values are accepted
+    assert ChatReply(reply="ok", confidence=0.0).confidence == 0.0
+    assert ChatReply(reply="ok", confidence=1.0).confidence == 1.0
+
+    # Out-of-range values are rejected
+    with pytest.raises(ValidationError):
+        ChatReply(reply="ok", confidence=1.2)
+    with pytest.raises(ValidationError):
+        ChatReply(reply="ok", confidence=-0.1)

--- a/tests/unit/web_search_chatbot/chatbot_test.py
+++ b/tests/unit/web_search_chatbot/chatbot_test.py
@@ -180,3 +180,51 @@ def test_chat_reply_confidence_bounds() -> None:
         ChatReply(reply="ok", confidence=1.2)
     with pytest.raises(ValidationError):
         ChatReply(reply="ok", confidence=-0.1)
+
+
+@pytest.mark.anyio
+async def test_out_of_range_confidence_fails_before_persistence(
+    test_db, monkeypatch
+) -> None:
+    """An out-of-range model confidence fails inside the agent run -- before any DB write.
+
+    Pins the #294 fix end-to-end through the real adapter and service:
+    FunctionModel forces confidence=1.2 as the final result (no tool call, so
+    the real duckduckgo_search_tool is never invoked -- fully offline), the
+    agent's output validation rejects it (retries exhaust into
+    UnexpectedModelBehavior), and the service never reaches its insert -- no
+    orphan row, no duplicate on client retry.
+    """
+    pytest.importorskip("pydantic_ai")
+    pytest.importorskip("pydantic_ai.common_tools.duckduckgo")
+    from pydantic_ai import UnexpectedModelBehavior
+    from pydantic_ai.messages import ModelMessage, ModelResponse, ToolCallPart
+    from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+    def agent_function(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(
+            parts=[
+                ToolCallPart(
+                    tool_name="final_result",
+                    args={"reply": "ok", "confidence": 1.2},
+                )
+            ]
+        )
+
+    repository = ChatbotRepository(database=test_db)
+    insert_calls: list[object] = []
+    original_insert = repository.insert_data
+
+    async def counting_insert(dto):  # noqa: ANN001, ANN202
+        insert_calls.append(dto)
+        return await original_insert(dto)
+
+    monkeypatch.setattr(repository, "insert_data", counting_insert)
+
+    chatbot = PydanticAIChatbot(llm_model=FunctionModel(agent_function))
+    service = ChatService(chatbot=chatbot, repository=repository)
+
+    with pytest.raises(UnexpectedModelBehavior):
+        await service.reply("Hello AI")
+
+    assert insert_calls == []


### PR DESCRIPTION
## Problem

The PydanticAI agent output schema `ChatReply.confidence` had **no numeric constraint** (only a description), while the API response schema enforced `ge=0.0, le=1.0`. Because the service **persists the turn before the router builds the response**, a model confidence outside `[0, 1]` (e.g. `1.2`) wrote the DB row first, then failed `ChatResponse(...)` construction with a pydantic `ValidationError` → generic handler returns **500**. A client retry then created a **duplicate persisted turn**.

`chatbot_with_memory` was a worse instance: it persists **two** rows (user + assistant) before building the response, so an out-of-range confidence orphaned **two** rows.

## Fix

Add `ge=0.0, le=1.0` to `ChatReply.confidence` in all four chatbot examples, so an out-of-range value is rejected at the agent's **output-validation stage** — before persistence. This eliminates the orphan row(s) and the duplicate-on-retry. (If the model exhausts PydanticAI's output retries it still surfaces a 500, but *before* any persistence, so a retry is safe.)

Also bound `chatbot_with_memory`'s `ConversationTurnDTO.confidence` carrier as defense-in-depth.

## Affected examples

- `examples/simple_chatbot/`
- `examples/chatbot_with_memory/`
- `examples/chatbot_with_guardrails/`
- `examples/web_search_chatbot/`

## Tests

- Per-example unit test asserting boundary values (`0.0`, `1.0`) are accepted and out-of-range values (`1.2`, `-0.1`) raise `ValidationError`. The memory test also covers `ConversationTurnDTO` (both bounds).
- Per-example end-to-end regression test (cross-review follow-up): an invalid `FunctionModel` (`confidence=1.2`) wired through the **real adapter + service** raises `UnexpectedModelBehavior` at output validation and performs **zero inserts** (memory example: neither the user nor the assistant row) — pinning the #294 mechanism (`output_type` wiring + validate-before-persist order) against regression.

## Verification

- `pytest` for all four example suites — pass, including the `TestModel`/`FunctionModel` real-agent paths (confirming the new constraint doesn't break agent output generation)
- `tools/check_examples_copyflow.py` — 0 violations
- `ruff format` + `ruff check` + full `pre-commit` on changed files — pass

`examples/`-only; no `src/` runtime change.

Closes #294.
