### PR TITLE
docs(security): add an Error Notification category to the security checklist (#305)

### DIFF
--- a/.agents/skills/security-review/SKILL.md
+++ b/.agents/skills/security-review/SKILL.md
@@ -16,7 +16,7 @@ metadata:
 1. Read `AGENTS.md` and `docs/ai/shared/skills/security-review.md` for the full procedure.
 2. Read `docs/ai/shared/security-checklist.md` and `docs/ai/shared/project-dna.md` as the shared security rule sources.
 3. Resolve the audit scope and run the feature-detection / reference-freshness preflight (Phase 0).
-4. Audit the target against the 12 security checklist categories using the shared applicability rules (Phase 1).
+4. Audit the target against the 13 security checklist categories using the shared applicability rules (Phase 1).
 5. Determine stale-reference drift, other `Drift Candidates`, and whether `Sync Required` is `true` or `false` (Phase 2).
 6. Report using the protocol output contract: `Scope`, `Effect Answer`, `Sources Loaded`, `Findings` (open only), `Coverage` (OK/SKIP), `Drift Candidates`, `Verdict: N/A (audit-only scope)`, `Next Actions`, `Completion State`, `Sync Required` (Phase 3). `Effect Answer` is mandatory — see `docs/ai/shared/review-protocol.md` §3 for the contract and Guard H context.
 

--- a/.claude/skills/security-review/SKILL.md
+++ b/.claude/skills/security-review/SKILL.md
@@ -18,7 +18,7 @@ Target: $ARGUMENTS (domain name, file path, or "all")
 
 ## Procedure Overview
 1. Resolve the audit scope and run the feature-detection / reference-freshness preflight (Phase 0)
-2. Audit the target against the 12 security checklist categories (Phase 1)
+2. Audit the target against the 13 security checklist categories (Phase 1)
 3. Determine stale-reference drift, other `Drift Candidates`, and whether `Sync Required` is `true` or `false` (Phase 2)
 4. Report using the protocol output contract — `Findings` (open) + `Coverage` (OK/SKIP) + `Verdict: N/A (audit-only scope)` (Phase 3)
 

--- a/docs/ai/shared/harness-asset-matrix.md
+++ b/docs/ai/shared/harness-asset-matrix.md
@@ -233,7 +233,7 @@ rather than primary entry points (`Overlay`).
 
 ### `security-checklist.md`
 
-- **Current role**: 369-line OWASP-aligned security review reference. Surface for `/security-review`.
+- **Current role**: 446-line OWASP-aligned security review reference (13 categories; §13 Error Notification Security added by #305). Surface for `/security-review`.
 - **Why it exists**: Project-specific security stance (auth, OWASP Top 10, key-rotation rules).
 - **Replacement feasibility**: None.
 - **Final location**: unchanged.

--- a/docs/ai/shared/planning-checklists.md
+++ b/docs/ai/shared/planning-checklists.md
@@ -86,7 +86,7 @@
 | Test generation | `/test-domain` | `{domain} generate` | baseline + conditional test files (see `docs/ai/shared/test-files.md`) |
 | Test execution | `/test-domain` | `{domain} run` | unit + integration + e2e |
 | Architecture verification | `/review-architecture` | `{domain}` or `all` | 10 categories, severity-tagged architecture audit |
-| Security audit | `/security-review` | `{domain}`, `{file}`, or `all` | 12 categories, feature-freshness preflight, stale-drift detection |
+| Security audit | `/security-review` | `{domain}`, `{file}`, or `all` | 13 categories, feature-freshness preflight, stale-drift detection |
 | Guideline sync | `/sync-guidelines` | (none) | Close the quality gate after design changes or review drift |
 | Approved plan execution | `/execute-plan` / `$execute-plan` | `{Execution Packet or plan ref}` | Native execution workflow for complex, architecture-changing, governor-changing, or multi-task plans |
 | Bug fix | `/fix-bug` | `"{description}"` | Reproduce -> Trace -> Fix -> Verify |

--- a/docs/ai/shared/review-protocol.md
+++ b/docs/ai/shared/review-protocol.md
@@ -35,7 +35,7 @@ reviewing against?" — they replace the old file-location categories (`domain/`
 | `STAB` | Stability | Error handling, boundary/empty/None cases, exception translation, concurrency, resource cleanup, timeouts. | evidence (diff / runtime) |
 | `CONTRACT` | External contract | API request/response shapes, OpenAPI, status codes, event/task payloads, DB schema/migration compatibility. | evidence (contract / diff) |
 | `ARCH` | Architecture compliance | Layering, conversion patterns, DTO/VO/Model roles, DI, bootstrap, naming. | [`architecture-review-checklist.md`](architecture-review-checklist.md) (10 categories) |
-| `SEC` | Security | AuthN/Z, secrets, input validation, sensitive-data exposure, logging, storage, worker, AI provider. | [`security-checklist.md`](security-checklist.md) (12 categories) |
+| `SEC` | Security | AuthN/Z, secrets, input validation, sensitive-data exposure, logging, storage, worker, AI provider, outbound notification. | [`security-checklist.md`](security-checklist.md) (13 categories) |
 | `GOV` | Governance / process | Tier-1 language policy, governor-path drift, edits to shared rule sources, review-process rules. | [`AGENTS.md`](../../../AGENTS.md) + [`governor-paths.md`](governor-paths.md) |
 
 - `ARCH`, `SEC`, and `GOV` are **rule-grounded**: they exist only to apply a shared rule source

--- a/docs/ai/shared/security-checklist.md
+++ b/docs/ai/shared/security-checklist.md
@@ -407,3 +407,40 @@ Check LLM model factory, configuration, and Agent-using services:
   - Grep: `LLMException` (and subclasses) wrap provider errors -> verify raw `error_message` is not surfaced in user-facing responses
   - Known exceptions (`LLMAuthenticationException`, `LLMRateLimitException`, `LLMModelNotFoundException`, `LLMContextLengthExceededException`) use sanitized messages
   - Stack traces / model identifiers / credentials never leaked to API responses or logs in stg/prod
+
+## 13. Error Notification Security (Slack/Discord webhooks)
+
+Check notification adapters, `ErrorNotifier`, the global exception handlers, and configuration files:
+
+### Webhook Credential Management
+- [ ] [When applicable][HIGH] Webhook URLs are loaded from Settings and never reach the log stream
+  - Detection condition: Check **project-dna.md section 8** "Error Notification (Slack/Discord webhooks)" status -> [SKIP] if "not implemented"
+  - Grep: `slack_webhook_url|discord_webhook_url` declared with `Field(validation_alias=...)` in `config.py` (not hardcoded string literals)
+  - Grep: `SlackNotificationAdapter\(|DiscordNotificationAdapter\(` **under `src/` only** -> the sole production construction site is `_build_notification_client` (`core_container.py`), which passes `settings.notification_webhook_url` through DI. Unit tests construct the adapters directly with synthetic URLs (`tests/unit/_core/infrastructure/notification/test_notification_adapters.py`) — that is expected and not a finding
+  - Grep: `exc_info` / `str(exc)` / `repr(exc)` absent from the **send-failure** path — `ErrorNotifier._safe_send` logs `exc_type=type(exc).__name__` only
+  - Not a finding: `_dispatch_error_notification` in `exception_handlers.py` logs with `exc_info=True`. That path wraps only the synchronous container lookup and `asyncio.create_task` call, so the exceptions it catches never carry the webhook URL — the network send fails inside the task and is handled by `_safe_send`
+  - Reason: a webhook URL is a bearer credential — possession alone authorizes posting to the channel. `aiohttp`'s `ClientResponseError` message embeds the request URL, so `exc_info=True` on a failed send writes the credential into the log stream (the leak fixed during PR #304 review). Section 5's secret-management greps key off `(SECRET|PASSWORD|TOKEN|AUTH|KEY)` and do not match `*_WEBHOOK_URL`
+
+### Committed Artefacts
+- [ ] [When applicable][MEDIUM] No working webhook URL is committed to env templates, compose files, or operations docs
+  - Detection condition: Same as above
+  - Grep: `(?:SLACK|DISCORD)_WEBHOOK_URL\s*[=:]\s*["']?https?://` in `_env/*.example`, `docker-compose*.yml`, and `docs/operations/`
+  - Both separators are required: env templates use `KEY=value`, while every compose file in this repo declares environment as a YAML map (`KEY: value`), so an `=`-only pattern silently misses a webhook URL committed into Compose
+  - Committed values must be obvious non-deployable placeholders (a truncated path such as `https://hooks.slack.com/services/...`, or `REPLACE_ME`), and the surrounding comment must state that real values are secrets — the same standard section 5 applies to secret-bearing env templates
+  - Reason: section 5's secret-bearing greps match `(SECRET|PASSWORD|TOKEN|AUTH|KEY)`, so a committed `SLACK_WEBHOOK_URL` / `DISCORD_WEBHOOK_URL` is invisible to them. Unlike an API key, a webhook URL carries no separate identifier to revoke against — leaking it means rotating the webhook itself
+
+### Notification Message Content
+- [ ] [When applicable][MEDIUM] The notification payload carries no more than the exception text — no request body, headers, or auth context
+  - Detection condition: Same as above
+  - Grep: `_dispatch_error_notification\(` call sites in `src/_core/exceptions/exception_handlers.py` -> inspect every `message=` argument. The three current call sites pass `str(exc)` (`custom_exception_handler`), `str(mapped)` (mapped provider errors), and `f"{type(exc).__name__}: {exc}"` (`generic_exception_handler`)
+  - Verify no call site widens that: `exc.details`, `request.body()`, `request.headers`, path/query parameters, or the authenticated principal must not reach `message=`
+  - Verify `ErrorNotifier.maybe_dispatch` still receives `message` as an already-rendered string and does not re-read the request
+  - Reason: the payload crosses the trust boundary to a third-party chat service whose audience and retention differ from the log aggregator. This item is the **regression guard** on payload width, which is what a reviewer can actually decide
+  - Accepted design property (not a per-review finding): the exception text itself is un-redacted, so an unhandled driver exception (e.g. SQLAlchemy `IntegrityError`) renders the failing statement and its bound parameters — a duplicate-email insert can carry that email to the channel. Treat this as a deployment decision to disclose to operators (tracked in #307), not as an `OPEN` finding on every audit. Raise it to `OPEN` only if a change *widens* the payload or the caveat stops being disclosed
+
+### Configuration Validation
+- [ ] [When applicable][MEDIUM] Notification provider configuration is validated as a complete group at startup
+  - Detection condition: Same as above
+  - Grep: `_validate_environment_safety` in `config.py` -> `notification_provider` checked against `KNOWN_NOTIFICATION_PROVIDERS`, and `slack` / `discord` each reject a missing matching `*_WEBHOOK_URL`
+  - Not a finding: an unset `NOTIFICATION_PROVIDER` is a designed fallback, not a misconfiguration — `_notification_selector` resolves to `NoopNotificationClient` when `settings.notification_webhook_url` is `None` (ADR 042 Protocol + Selector pattern), which is what keeps the zero-config quickstart booting
+  - Reason: an unknown provider, or a provider missing its URL, would otherwise surface at first-error dispatch — the moment the system is already failing — instead of at boot

--- a/docs/ai/shared/skills/security-review.md
+++ b/docs/ai/shared/skills/security-review.md
@@ -37,7 +37,7 @@ This audit emits the shared [Review Protocol §3 output contract](../review-prot
 `Scope`, `Effect Answer`, `Sources Loaded`, `Findings` (OPEN only), `Coverage` (OK/SKIP),
 `Drift Candidates`, `Verdict`, `Next Actions`, `Completion State`, `Sync Required`.
 
-- This skill applies the **`SEC` dimension** ([Review Protocol §1](../review-protocol.md#1-review-dimensions-concern-based-stable-ids)) in depth via the 12-category checklist below; every `SEC` finding is `rule-source`-based and cites its checklist category ([Finding Basis §2](../review-protocol.md#2-finding-basis-anti-hallucination-rule)).
+- This skill applies the **`SEC` dimension** ([Review Protocol §1](../review-protocol.md#1-review-dimensions-concern-based-stable-ids)) in depth via the 13-category checklist below; every `SEC` finding is `rule-source`-based and cites its checklist category ([Finding Basis §2](../review-protocol.md#2-finding-basis-anti-hallucination-rule)).
 - `Verdict` is **`N/A (audit-only scope)`** — a security audit, not a behavior PASS/FAIL ([Review Protocol §4](../review-protocol.md#4-intent--pass-state)).
 - `Effect Answer` is required (Guard H); security questions are almost always effect-type, so "I ran the checklist" is a process answer, not an effect answer. Write `Effect Answer: N/A — process question` only for checklist-only process queries.
 
@@ -54,7 +54,7 @@ review state `OPEN` / `OK` / `SKIP`; severity `BLOCKING` / `HIGH` / `MEDIUM` / `
 
 ## Category Coverage
 
-Inspect the 12 security checklist categories defined in
+Inspect the 13 security checklist categories defined in
 `docs/ai/shared/security-checklist.md`.
 
 1. Injection Prevention
@@ -69,6 +69,7 @@ Inspect the 12 security checklist categories defined in
 10. S3 Vectors Security
 11. Embedding API Security
 12. LLM API Security
+13. Error Notification Security (Slack/Discord webhooks)
 
 ## Phase 0: Feature Detection and Reference Freshness Preflight
 
@@ -94,7 +95,7 @@ Before the main audit, compare shared references against live code.
 Live code is authoritative. `project-dna` is a cached shared reference, not the
 final source of truth.
 
-## Phase 1: Run the 12-Category Audit
+## Phase 1: Run the 13-Category Audit
 
 Each checklist item is either `Always` or `When applicable`.
 


### PR DESCRIPTION
## Summary

`/security-review` had **zero** inspection items for the Slack/Discord error-notification webhook infra shipped in #17 / PR #304, even though `project-dna.md` §8 lists it as an `Active` feature. That gap was flagged as a `REVIEW` item during the post-#304 `/sync-guidelines` run and deferred to #305 rather than auto-fixed, because a checklist-meaning change needs human judgment.

This adds `security-checklist.md` **§13 Error Notification Security** — four `[When applicable]` items keyed to the §8 row — and resyncs the category count `12 → 13` across the harness.

## The four items

| Item | Severity | What it actually checks |
|---|---|---|
| Webhook Credential Management | **HIGH** | URLs declared with `Field(validation_alias=...)`; adapters constructed only under `src/` via DI; `_safe_send` logs `exc_type` only |
| Committed Artefacts | MEDIUM | no working webhook URL in `_env/*.example`, `docker-compose*.yml`, `docs/operations/` |
| Notification Payload Width | MEDIUM | regression guard on what reaches `message=` — no `details`/body/headers/principal |
| Configuration Validation | MEDIUM | provider allowlist + complete config group at startup |

Why a webhook URL earns its own HIGH item: possession alone authorizes posting to the channel, and there is no separate identifier to revoke against. `aiohttp`'s `ClientResponseError` message embeds the request URL, so `exc_info=True` on a failed send writes the credential straight into the log stream — the exact class of leak fixed during PR #304 review (`b103f8c`). Separately, §5's secret greps key off `(SECRET|PASSWORD|TOKEN|AUTH|KEY)` and therefore never see `*_WEBHOOK_URL`, which is why the committed-artefact check lives here rather than as a §5 extension.

## Two design decisions worth reviewing

**1. Item 3 is a regression guard, not a redaction mandate.** The first draft ended with "redaction or an allowlisted message format is required before stg/prod use." Dry-running it revealed that would report `OPEN` on **every** future audit, since no redaction exists and none is planned — a rule that always fires trains reviewers to ignore it. Reframed: the auditable check is payload *width* (which can regress and which a reviewer can decide), while the un-redacted exception text is recorded as an **accepted design property** to disclose to operators. An unhandled `IntegrityError` still renders the failing statement and its bound parameters, so a duplicate-email insert can carry that email to a chat channel — that caveat is real, and #307 owns disclosing it.

**2. Two explicit "Not a finding" carve-outs**, so the category cannot false-positive on correct code:

- `_dispatch_error_notification` (`exception_handlers.py:37`) *does* use `exc_info=True`. That path wraps only the synchronous container lookup and `asyncio.create_task`, so the exceptions it catches never carry the webhook URL — the network send fails inside the task and is handled by `_safe_send`. Without this note a reviewer greps `exc_info`, hits line 37, and files a false finding.
- An unset `NOTIFICATION_PROVIDER` resolving to `NoopNotificationClient` is intended ADR 042 optional-infra behaviour, not a misconfiguration — it is what keeps `make quickstart` booting.

## Verification

Every grep pattern was executed against live code; a checklist item whose pattern does not match produces a silent false-`OK`, which is worse than no item at all.

| Gate | Result |
|---|---|
| `tools/check_language_policy.py` | 0 violations, 228 files |
| `pre-commit run --all-files` | all Passed |
| 4× item grep-pattern proof | all match; item 2 resolves `[OK]` (3 hits, all commented truncated placeholders) |
| `/security-review src/_core/infrastructure/notification` | 0 OPEN findings; all 4 items reach a definite state |
| Residual count sweep | only `docs/history/053` retains "(12 categories)", by decision |

## Count sync (12 → 13)

`review-protocol.md:38` (+ `outbound notification` added to the `SEC` surface list) · `skills/security-review.md` ×3 + the numbered list gains a 13th entry · `planning-checklists.md:89` · `.claude/skills/security-review/SKILL.md:21` · `.agents/skills/security-review/SKILL.md:19` · `harness-asset-matrix.md:236` (line + category count + issue attribution, matching the sibling `architecture-review-checklist.md` entry shape at line 256).

`docs/history/053-shared-review-protocol.md:94` is **intentionally unchanged** — an ADR records state at decision time.

## Scope

- **Excluded**: extending §5's `Always` secret-grep with `WEBHOOK` (kept scoped to §13); operator runbook / `docs/operations/` page (→ #307); `src/` and `examples/`; new ADR.
- **Considered and dropped**: a `NOTIFICATION_SEVERITY_THRESHOLD < 500` item (client-triggerable 4xx driving outbound webhook traffic) and a `NoopNotificationClient.send` INFO-logging item. Both are real but judged out of scope for this category; the cross-review re-raised the threshold one and it closed as `Deferred-with-rationale`.

## Cross-review

`codex exec --sandbox read-only`, 1 round, 2 R-points — **both Fixed and re-verified**:

- **R1** — item 1 said adapters are "never constructed with a literal URL", but `test_notification_adapters.py` legitimately does exactly that. Scoped the pattern to `src/` and named the test exemption explicitly.
- **R2** — the committed-artefact pattern was `WEBHOOK_URL\s*=\s*https?://`, which cannot see the YAML map form `SLACK_WEBHOOK_URL: https://…`. **Every** compose file in this repo uses the map form, so the original pattern would have missed a Compose-committed webhook entirely. Broadened to `(?:SLACK|DISCORD)_WEBHOOK_URL\s*[=:]\s*["']?https?://` and confirmed with a negative control: the old pattern found nothing on a simulated YAML-form leak, the new one catches it.

Also raised and rejected as non-issues (both carve-outs verified technically accurate and correctly bounded): the `exc_info=True` exclusion, and the `NoopNotificationClient` fallback.

Closes #305

## Governor Footer
- trigger: yes
- reviewer: codex-cli
- rounds: 1
- r-points-fixed: 2
- r-points-deferred: 2
- r-points-rejected: 2
- touched-adr-consequences: none
- pr-scope-notes: checklist content + count sync only; §5 Always grep left unextended, operator runbook deferred to #307
- final-verdict: merge-ready
- links: https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/305, https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/307
