### PR TITLE
chore(deps): regenerate uv.lock after the v0.9.0 version bump

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -993,7 +993,7 @@ wheels = [
 
 [[package]]
 name = "fastapi-agent-blueprint"
-version = "0.8.4"
+version = "0.9.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

`pyproject.toml` was bumped to `0.9.0` by the v0.9.0 release PR (#303, 308e1a6), but `uv.lock` was never regenerated and still recorded `version = "0.8.4"` for the `fastapi-agent-blueprint` root package.

Because any `uv run` / `uv sync` regenerates the lock, this surfaced as a permanent dirty working-tree entry (`M uv.lock`) that kept getting accidentally swept into unrelated commits.

## Change

Ran `uv lock` on an up-to-date `main`. The entire diff is one line:

```diff
 [[package]]
 name = "fastapi-agent-blueprint"
-version = "0.8.4"
+version = "0.9.0"
 source = { virtual = "." }
```

`uv` itself reports only `Updated fastapi-agent-blueprint v0.8.4 -> v0.9.0`.

## Verification

- `git diff --numstat` → `1 1 uv.lock` — no dependency resolution churn, no package versions moved, no new/removed entries.
- Regenerated blob hash matches the one produced independently in a separate checkout, so the result is reproducible.
- `pyproject.toml` untouched.
- Pre-commit hooks pass.

## Note (pre-existing, out of scope)

`uv lock` emits `warning: The package `anyio==4.12.1` does not have an extra named `asyncio`` — from `anyio[asyncio]>=4.0.0` in `pyproject.toml:95`. This warning also appears on unmodified `main`, so it predates this change and is left alone here.