### PR TITLE
fix(tools): accept 'n/a' as a links list entry in the Governor Footer checker

### DIFF
--- a/tests/unit/tools/test_governor_footer.py
+++ b/tests/unit/tools/test_governor_footer.py
@@ -192,6 +192,64 @@ def test_links_na_passes():
     assert violations == []
 
 
+def test_links_url_then_na_entry_passes():
+    """#314: the PR template prescribes `<PR url>, <prior-log url or "n/a">`.
+    A first-round PR has no prior log, so `n/a` must be valid as a trailing
+    list entry — not only as the entire value."""
+    good = VALID_FOOTER.replace(
+        "https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/158",
+        "https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/158, n/a",
+    )
+    body = _wrap_body(good)
+    violations = cgf.check_body(
+        body, source="t", require_governor_footer=False, changed_files=[]
+    )
+    assert violations == []
+
+
+def test_links_template_literal_example_passes():
+    """Pins the exact shape `.github/pull_request_template.md` documents, so the
+    template and the checker cannot drift apart again (#314)."""
+    template = (REPO_ROOT / ".github" / "pull_request_template.md").read_text(
+        encoding="utf-8"
+    )
+    assert '- links: <PR url>, <prior-log url or "n/a">' in template, (
+        "template links shape changed — update this test and the checker together"
+    )
+    good = VALID_FOOTER.replace(
+        "https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/158",
+        "https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/313, n/a",
+    )
+    violations = cgf.check_body(
+        _wrap_body(good), source="t", require_governor_footer=False, changed_files=[]
+    )
+    assert violations == []
+
+
+@pytest.mark.parametrize("bad_entry", ["N/A", "TBD", "none", ""])
+def test_links_rejects_non_url_non_na_entries(bad_entry):
+    """Loosening `n/a` must not loosen anything else — `n/a` is case-sensitive
+    and is the only accepted non-URL entry."""
+    bad = VALID_FOOTER.replace(
+        "https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/158",
+        f"https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/158, {bad_entry}",
+    )
+    violations = cgf.check_body(
+        _wrap_body(bad), source="t", require_governor_footer=False, changed_files=[]
+    )
+    assert any("http(s) URL or 'n/a'" in v.reason for v in violations)
+
+
+def test_touched_adr_none_as_list_entry_still_fails():
+    """The `n/a`-per-entry affordance is deliberately NOT mirrored onto
+    touched-adr-consequences, whose `none` stays whole-value only."""
+    bad = VALID_FOOTER.replace("ADR047-G3, ADR047-G24", "ADR047-G3, none")
+    violations = cgf.check_body(
+        _wrap_body(bad), source="t", require_governor_footer=False, changed_files=[]
+    )
+    assert any("touched-adr-consequences" in v.reason for v in violations)
+
+
 def test_omitted_footer_passes_without_require_flag():
     body = "# PR description\n\nNo footer here.\n"
     violations = cgf.check_body(

--- a/tools/check_governor_footer.py
+++ b/tools/check_governor_footer.py
@@ -16,9 +16,13 @@ V1 validates block shape only:
 - Enum vocabularies for ``trigger`` and ``final-verdict`` match exactly.
 - Integer fields parse as non-negative ints; ``rounds: 0`` is rejected when
   ``trigger: yes``.
-- ``touched-adr-consequences`` entries match ``ADR\\d{3}-G\\d+`` or are the
-  literal ``none``.
-- ``links`` accepts URLs or the literal ``n/a``.
+- ``touched-adr-consequences`` is either the literal ``none`` as the **whole**
+  value, or a comma-separated list of ``ADR\\d{3}-G\\d+`` IDs.
+- ``links`` is a comma-separated list of http(s) URLs in which ``n/a`` is also
+  valid as an **individual entry**, so the template's documented
+  ``<PR url>, <prior-log url or "n/a">`` shape passes (#314). The asymmetry with
+  ``touched-adr-consequences`` above is deliberate: a PR always has at least one
+  real link, so the placeholder is only ever needed for a trailing slot.
 
 Does NOT validate: that touched-adr-consequences IDs actually exist in any
 ADR (semantic check); round count consistency with R-points totals.
@@ -180,21 +184,24 @@ def _validate_value(
                         Violation(
                             source,
                             lineno,
-                            f"touched-adr-consequences entry must match ADR\\d{{3}}-G\\d+ or 'none', got {entry!r}",
+                            f"touched-adr-consequences must be the literal 'none' or a comma-separated list of ADR\\d{{3}}-G\\d+ IDs, got entry {entry!r}",
                         )
                     )
     elif field == "links":
-        if value != "n/a":
-            entries = [v.strip() for v in value.split(",")]
-            for entry in entries:
-                if not URL_RE.match(entry):
-                    violations.append(
-                        Violation(
-                            source,
-                            lineno,
-                            f"links entry must be an http(s) URL or 'n/a', got {entry!r}",
-                        )
+        # 'n/a' is valid per entry, not only as the whole value (#314): the
+        # template's documented shape is `<PR url>, <prior-log url or "n/a">`,
+        # and a first-round PR has no prior log. Contrast
+        # touched-adr-consequences above, whose 'none' stays whole-value only.
+        entries = [v.strip() for v in value.split(",")]
+        for entry in entries:
+            if entry != "n/a" and not URL_RE.match(entry):
+                violations.append(
+                    Violation(
+                        source,
+                        lineno,
+                        f"links entry must be an http(s) URL or 'n/a', got {entry!r}",
                     )
+                )
     return violations
 
 


### PR DESCRIPTION
## Related Issue
- Closes #314

## Change Summary

`.github/pull_request_template.md:48` documents the Governor Footer `links` shape as
`- links: <PR url>, <prior-log url or "n/a">`, but `tools/check_governor_footer.py`
accepted `n/a` only as the **entire** value. Inside a comma-separated list every entry
had to match `URL_RE`, so a first-round PR with no prior review log failed
`Governor Footer Lint` for following the template verbatim.

Chose **Option B** from the issue (loosen the checker) over Option A (edit the template):
`tools/**` and `tests/**` match no Tier A/B/C glob in `docs/ai/shared/governor-paths.md`,
so this PR is **not** governor-changing and carries no footer. Option A would have had to
edit `.github/pull_request_template.md` — Tier A — dragging full footer ceremony into a
one-line bug fix, and requiring that footer to be written in the very shape under dispute.

- `links`: `n/a` is now valid as an individual list entry. This also makes the existing
  error message (`links entry must be an http(s) URL or 'n/a'`) true, which it was not.
- `touched-adr-consequences` keeps its whole-value-only `none`. The asymmetry is deliberate
  — a PR always has at least one real link, so the placeholder is only ever needed for a
  trailing slot — and is now stated in the module docstring. Its error message previously
  claimed `'none'` was valid per entry; corrected.
- No change to which footers are *rejected* beyond the single `n/a` entry.

## Type of Change
- [x] fix: Bug fix

## Checklist
- [x] Architecture rules followed (no Domain -> Infrastructure imports; tooling-only change)
- [x] Tests pass (`39 passed`, was 32 — 7 new cases)
- [x] Linting passes (`ruff check`, `ruff format --check` on `tools/` + `tests/unit/tools/`)

## How to Test

End-to-end against the shape that broke PR #313:

```bash
cat > /tmp/repro.md <<'BODY'
## Governor Footer
- trigger: yes
- reviewer: self-structured
- rounds: 1
- r-points-fixed: 0
- r-points-deferred: 0
- r-points-rejected: 0
- touched-adr-consequences: none
- pr-scope-notes: reproduction of the template's literal links shape
- final-verdict: merge-ready
- links: https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/313, n/a
BODY

git show origin/main:tools/check_governor_footer.py > /tmp/old.py
uv run python /tmp/old.py /tmp/repro.md          # 1 violation, exit 1
uv run python tools/check_governor_footer.py /tmp/repro.md   # 0 violations, exit 0
```

Regression coverage added to `tests/unit/tools/test_governor_footer.py`:

- `test_links_url_then_na_entry_passes` — the trailing-`n/a` case itself
- `test_links_template_literal_example_passes` — reads
  `.github/pull_request_template.md` and asserts the documented shape is still what the
  checker accepts, so template and checker cannot drift apart again
- `test_links_rejects_non_url_non_na_entries` — `N/A` / `TBD` / `none` / empty still fail
  (loosening `n/a` must not loosen anything else; it stays case-sensitive)
- `test_touched_adr_none_as_list_entry_still_fails` — the affordance is not mirrored onto
  `touched-adr-consequences`

```bash
uv run pytest tests/unit/tools/test_governor_footer.py -v
```

## Notes

`docs/ai/shared/harness-asset-matrix.md:415` records this suite as "31 cases" while `main`
already has 32, and this PR takes it to 39. That line is pre-existing drift and syncing it
would pull `docs/ai/shared/**` (Tier A) into this PR; it is tracked in #317 instead.
