### PR TITLE
fix(_core): require NOTIFICATION_WARNING_THRESHOLD for per-tier webhook URLs

### DIFF
--- a/_env/local.env.example
+++ b/_env/local.env.example
@@ -137,10 +137,16 @@ DYNAMODB_ENDPOINT_URL=http://localhost:8000
 #
 # Severity-based channel routing (#286, optional, on top of the above):
 #   Unset by default, the single target above is used for everything,
-#   exactly as without this section. Set NOTIFICATION_WARNING_THRESHOLD to
-#   also notify on a lower status-code band (e.g. 4xx) and route it to a
-#   second channel; each *_WEBHOOK_URL below falls back to the single
-#   target above when left unset.
+#   exactly as without this section.
+#
+#   NOTIFICATION_WARNING_THRESHOLD is the switch — it is what wires the
+#   router. It widens the gate to also notify on a lower status-code band
+#   (e.g. 4xx) and routes that band to the warning channel. The two
+#   *_WEBHOOK_URL overrides below do nothing on their own; setting either
+#   without the threshold is rejected at boot (#315), because without a
+#   router every alert goes to the single target above.
+#   Each override falls back to that single target when left unset, so a
+#   partial mapping degrades to a shared channel rather than dropping a tier.
 # NOTIFICATION_WARNING_THRESHOLD=400
 # NOTIFICATION_CRITICAL_WEBHOOK_URL=https://hooks.slack.com/services/.../alerts
 # NOTIFICATION_WARNING_WEBHOOK_URL=https://hooks.slack.com/services/.../monitoring

--- a/src/_core/config.py
+++ b/src/_core/config.py
@@ -366,8 +366,11 @@ class Settings(BaseSettings):
     )
 
     # ----------------------------------------------------------------
-    # Error Notification (Optional — Slack/Discord webhook alerts fired
-    # from the exception middleware on 5xx-and-above errors, #17)
+    # Error Notification (Optional — Slack/Discord webhook alerts, #17).
+    # Dispatched from the global exception handlers (#17) and from Taskiq
+    # worker task failures (#310). The alerting floor is
+    # NOTIFICATION_SEVERITY_THRESHOLD by default, and drops to
+    # NOTIFICATION_WARNING_THRESHOLD once severity routing is enabled (#286).
     # ----------------------------------------------------------------
     notification_provider: str | None = Field(
         default=None, validation_alias="NOTIFICATION_PROVIDER"
@@ -382,16 +385,23 @@ class Settings(BaseSettings):
         default=500,
         validation_alias="NOTIFICATION_SEVERITY_THRESHOLD",
         description=(
-            "Minimum HTTP status code that triggers a notification "
-            "(e.g. 500 notifies on server errors only)."
+            "Status code at or above which a notification is sent "
+            "(e.g. 500 notifies on server errors only). On the worker path "
+            "the code is synthesised, so this applies there too. Without "
+            "severity routing this is also the alerting floor; with "
+            "notification_warning_threshold set it becomes the critical-tier "
+            "boundary and the floor drops to that threshold (#286)."
         ),
     )
     notification_cooldown_seconds: int = Field(
         default=60,
         validation_alias="NOTIFICATION_COOLDOWN_SECONDS",
         description=(
-            "Per-process, per-error_code cooldown between repeat "
-            "notifications, to prevent notification storms."
+            "Per-process cooldown between repeat notifications, to prevent "
+            "notification storms. Keyed by error_code; scoped to "
+            "{tier}:{error_code} when severity routing is enabled (#286) so "
+            "a warning-tier 4xx cannot mute a critical-tier 5xx, and further "
+            "scoped by task name on the worker path (#310)."
         ),
     )
     # Severity-based channel routing (Optional, #286, on top of #17).
@@ -1023,9 +1033,12 @@ class Settings(BaseSettings):
     def notification_critical_target(self) -> str | None:
         """Webhook URL for critical-tier routed notifications (#286).
 
-        Falls back to the single-target notification_webhook_url when
-        no per-severity override is configured, so the default (unmapped)
-        case behaves exactly like #17.
+        Falls back to the single-target notification_webhook_url when no
+        per-severity override is configured. Only consumed once routing is
+        active — see ``_notification_routing_selector``, which gates the
+        router on notification_warning_threshold. Note that with the
+        threshold set and no overrides, both tiers share this target but the
+        gate and the cooldown key are *not* #17's.
         """
         return self.notification_critical_webhook_url or self.notification_webhook_url
 

--- a/src/_core/config.py
+++ b/src/_core/config.py
@@ -415,7 +415,10 @@ class Settings(BaseSettings):
         description=(
             "Webhook target for critical-tier (>= notification_severity_"
             "threshold) alerts. Falls back to the single-target webhook "
-            "(SLACK_WEBHOOK_URL / DISCORD_WEBHOOK_URL) when unset."
+            "(SLACK_WEBHOOK_URL / DISCORD_WEBHOOK_URL) when unset. "
+            "Requires notification_warning_threshold - that setting is what "
+            "wires the router, so this URL alone would be ignored and is "
+            "rejected at boot instead (#315)."
         ),
     )
     notification_warning_webhook_url: str | None = Field(
@@ -424,8 +427,9 @@ class Settings(BaseSettings):
         description=(
             "Webhook target for warning-tier (>= notification_warning_"
             "threshold, < notification_severity_threshold) alerts. Falls "
-            "back to the single-target webhook when unset. Only takes "
-            "effect when notification_warning_threshold is set."
+            "back to the single-target webhook when unset. Requires "
+            "notification_warning_threshold - rejected at boot without it "
+            "(#315)."
         ),
     )
 
@@ -830,6 +834,20 @@ class Settings(BaseSettings):
                 "NOTIFICATION_WARNING_WEBHOOK_URL require NOTIFICATION_PROVIDER "
                 "to be set (they select a channel within that provider, not a "
                 "transport of their own)"
+            )
+
+        if (
+            self.notification_critical_webhook_url
+            or self.notification_warning_webhook_url
+        ) and self.notification_warning_threshold is None:
+            errors.append(
+                "[Notification/Routing] NOTIFICATION_CRITICAL_WEBHOOK_URL / "
+                "NOTIFICATION_WARNING_WEBHOOK_URL require "
+                "NOTIFICATION_WARNING_THRESHOLD to be set — it is the switch "
+                "that wires the router. Without it no router exists and every "
+                "alert goes to the single SLACK_WEBHOOK_URL / "
+                "DISCORD_WEBHOOK_URL target, silently ignoring both per-tier "
+                "URLs"
             )
 
         if self.otel_enabled and not self.otel_exporter_otlp_endpoint:

--- a/src/_core/infrastructure/di/core_container.py
+++ b/src/_core/infrastructure/di/core_container.py
@@ -69,12 +69,16 @@ def _notification_warning_selector() -> str:
 
 
 def _notification_routing_selector() -> str:
-    """#286 severity routing is opt-in: only wire a NotificationRouter into
-    ErrorNotifier when NOTIFICATION_WARNING_THRESHOLD is actually set.
-    Otherwise notification_router stays None and ErrorNotifier's original
-    #17 single-target path (self._client) is the one actually taken —
-    matching the PR's stated "unset, byte-for-byte identical to #17"
-    contract in production, not just in tests that bypass the container."""
+    """#286 severity routing is opt-in, and NOTIFICATION_WARNING_THRESHOLD is
+    the only switch: a per-tier webhook URL does not enable routing on its own
+    (that combination is rejected at boot — see the [Notification/Routing]
+    checks in ``config.py``, #315).
+
+    With the threshold unset, ``notification_router`` resolves to ``None`` and
+    ``ErrorNotifier`` takes its ``else self._client`` branch — the #17
+    single-target path, gated at NOTIFICATION_SEVERITY_THRESHOLD with the
+    cooldown keyed on the bare ``error_code``. That path stays live in
+    production, not only in tests that construct ``ErrorNotifier`` directly."""
     return (
         "enabled" if settings.notification_warning_threshold is not None else "disabled"
     )
@@ -460,9 +464,11 @@ class CoreContainer(containers.DeclarativeContainer):
 
     #########################################################
     # Severity-based channel routing (optional — #286, on top of #17).
-    # Each tier resolves its own target (falling back to the single
-    # notification_client webhook above when no override is set), so an
-    # unmapped deployment behaves exactly like #17.
+    # Each tier resolves its own target, falling back to the single
+    # notification_client webhook above when no override is set.
+    # These two providers are consumed only by notification_router below,
+    # which is itself gated on NOTIFICATION_WARNING_THRESHOLD — so with
+    # routing off they are declared but never resolved.
     #########################################################
 
     notification_critical_client = providers.Selector(
@@ -487,10 +493,12 @@ class CoreContainer(containers.DeclarativeContainer):
         disabled=_noop_notification_client,
     )
 
-    # Only wired when NOTIFICATION_WARNING_THRESHOLD is set (#313 review,
-    # option A) — otherwise notification_router stays None and
-    # error_notifier's `notification_client` (the single-target base
-    # client, unchanged from #17) is the one actually sent through.
+    # Only wired when NOTIFICATION_WARNING_THRESHOLD is set — otherwise
+    # notification_router stays None and error_notifier's
+    # `notification_client` (the single-target base client, unchanged from
+    # #17) is the one actually sent through. See
+    # _notification_routing_selector for why the per-tier URLs cannot enable
+    # routing by themselves.
     notification_router = providers.Selector(
         _notification_routing_selector,
         enabled=providers.Singleton(

--- a/src/_core/infrastructure/notification/notification_router.py
+++ b/src/_core/infrastructure/notification/notification_router.py
@@ -16,10 +16,12 @@ class NotificationRouter:
       ``< severity_threshold``, only when ``warning_threshold`` is set →
       ``warning_client``.
 
-    When ``warning_threshold`` is ``None`` (the default), :meth:`resolve`
-    only ever returns ``critical_client`` (or ``None`` below it) — matching
-    #17's single-target behavior exactly, so severity routing is strictly
-    opt-in and never changes what gets notified unless configured.
+    ``warning_threshold=None`` degenerates to critical-only resolution, but
+    ``CoreContainer`` never builds a router in that state — with
+    NOTIFICATION_WARNING_THRESHOLD unset, ``notification_router()`` resolves
+    to ``None`` instead and ``ErrorNotifier`` keeps its #17 single-target
+    path (see ``_notification_routing_selector``). The ``None`` branch is
+    retained as a defensive unit-level contract, not as a production state.
 
     ``critical_client`` and ``warning_client`` are independently resolved
     by ``CoreContainer`` from ``NOTIFICATION_CRITICAL_WEBHOOK_URL`` /

--- a/src/_core/infrastructure/notification/taskiq_middleware.py
+++ b/src/_core/infrastructure/notification/taskiq_middleware.py
@@ -11,10 +11,12 @@ needs while reusing the same gating knobs:
   introducing a second severity model (the alternative #310 weighed and
   rejected: bypassing the threshold would leave operators no off switch short
   of unsetting the provider).
-- **Task-scoped cooldown key** — ``ErrorNotifier`` dedupes on ``error_code``
-  alone. A bare code would let one noisy task suppress every other task's
-  alert for the whole cooldown window, so the key is
-  ``{task_name}:{error_code}``.
+- **Task-scoped cooldown key** — a bare code would let one noisy task suppress
+  every other task's alert for the whole cooldown window, so this middleware
+  passes ``{task_name}:{error_code}``. ``ErrorNotifier`` then applies its own
+  scoping on top: without severity routing the key is used as given, and with
+  routing enabled it is tier-prefixed (#286), making the effective worker key
+  ``{tier}:{task_name}:{error_code}``.
 - **Final-attempt gating** — ``PermanentAwareSmartRetryMiddleware`` retries
   transient failures, so dispatching on every attempt would alert up to
   ``max_retries`` times for a single incident. Permanent errors are never

--- a/tests/unit/_core/test_config.py
+++ b/tests/unit/_core/test_config.py
@@ -1015,3 +1015,66 @@ class TestNotificationRoutingConfig:
         with patch.dict(os.environ, env, clear=True):
             with pytest.raises(ValidationError, match="Notification/Routing"):
                 _create_settings()
+
+    @pytest.mark.parametrize(
+        "tier_var",
+        ["NOTIFICATION_CRITICAL_WEBHOOK_URL", "NOTIFICATION_WARNING_WEBHOOK_URL"],
+    )
+    def test_per_tier_webhook_without_warning_threshold_rejected(self, tier_var):
+        """#315: a per-tier webhook URL is inert unless
+        NOTIFICATION_WARNING_THRESHOLD is set — _notification_routing_selector
+        gates the router on the threshold alone, so without it
+        notification_router() is None and every alert goes to the single base
+        webhook. Accepting that config at boot means silently delivering
+        incidents to the wrong channel, so reject it instead."""
+        env = {
+            "ENV": "local",
+            "NOTIFICATION_PROVIDER": "slack",
+            "SLACK_WEBHOOK_URL": "https://hooks.slack.com/services/T/B/BASE",
+            tier_var: "https://hooks.slack.com/services/T/B/ALERTS",
+            **_REQUIRED_VARS,
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(ValidationError, match="NOTIFICATION_WARNING_THRESHOLD"):
+                _create_settings()
+
+    def test_per_tier_webhook_with_warning_threshold_accepted(self):
+        """The corrected form of the config rejected above: adding the
+        threshold is what actually wires the router."""
+        env = {
+            "ENV": "local",
+            "NOTIFICATION_PROVIDER": "slack",
+            "SLACK_WEBHOOK_URL": "https://hooks.slack.com/services/T/B/BASE",
+            "NOTIFICATION_WARNING_THRESHOLD": "400",
+            "NOTIFICATION_CRITICAL_WEBHOOK_URL": "https://hooks.slack.com/services/T/B/ALERTS",
+            **_REQUIRED_VARS,
+        }
+        with patch.dict(os.environ, env, clear=True):
+            s = _create_settings()
+            assert s.notification_warning_threshold == 400
+            assert (
+                s.notification_critical_target
+                == "https://hooks.slack.com/services/T/B/ALERTS"
+            )
+
+    def test_warning_threshold_alone_still_accepted(self):
+        """The threshold on its own stays valid — both tiers then resolve to
+        the single base webhook, which is the documented degradation and not a
+        misconfiguration."""
+        env = {
+            "ENV": "local",
+            "NOTIFICATION_PROVIDER": "slack",
+            "SLACK_WEBHOOK_URL": "https://hooks.slack.com/services/T/B/BASE",
+            "NOTIFICATION_WARNING_THRESHOLD": "400",
+            **_REQUIRED_VARS,
+        }
+        with patch.dict(os.environ, env, clear=True):
+            s = _create_settings()
+            assert (
+                s.notification_critical_target
+                == "https://hooks.slack.com/services/T/B/BASE"
+            )
+            assert (
+                s.notification_warning_target
+                == "https://hooks.slack.com/services/T/B/BASE"
+            )


### PR DESCRIPTION
## Related Issue
- Closes #315

## Change Summary

`_notification_routing_selector` (`core_container.py:71-80`) gates the `NotificationRouter` on
`notification_warning_threshold` **alone**. Set a per-tier webhook URL without the threshold and
`notification_router()` resolves to `None`, `ErrorNotifier` takes its `else self._client` branch,
and every alert goes to the single `SLACK_WEBHOOK_URL` / `DISCORD_WEBHOOK_URL` target — silently
ignoring both per-tier URLs. Boot validation only required `NOTIFICATION_PROVIDER`, so the config
was accepted with no error and no log line.

Probed at `9cc1196` — operator intent "incidents go to #alerts", threshold omitted:

```text
NOTIFICATION_PROVIDER=slack
SLACK_WEBHOOK_URL=.../BASE
NOTIFICATION_CRITICAL_WEBHOOK_URL=.../ALERTS
# NOTIFICATION_WARNING_THRESHOLD not set

boot validation        passed
notification_router()  None
error_notifier._client .../BASE     <-- what actually sends
warning logged         none

500 incident  ->  .../BASE     (not .../ALERTS)
```

This PR rejects the combination at boot instead. Three changes:

- **`config.py` validator** — a per-tier URL now requires `NOTIFICATION_WARNING_THRESHOLD`, with a
  message that names the missing variable and says why. This matches the partial-config-group
  rejection already applied to S3, MinIO, DynamoDB, S3Vectors, SQS, Embedding, LLM and
  Notification, and it makes the silent state unrepresentable — so the docs *lose* a caveat
  rather than gaining one.
- **`config.py` field descriptions** — `notification_warning_webhook_url` already carried the
  "only takes effect when `notification_warning_threshold` is set" guard;
  `notification_critical_webhook_url` did not. That asymmetry was the tell. Both now state the
  requirement.
- **`_env/local.env.example`** — the routing block listed the three variables adjacently with the
  threshold reading as optional. After this change, uncommenting only the two URLs fails boot, so
  the block is rewritten to present the threshold as the switch that wires the router.

### Not done, deliberately

Gating the router on the URLs instead (so per-tier URLs alone would enable critical-tier routing)
was considered and rejected. It reads as friendlier, but it silently changes the cooldown key from
the bare `error_code` to `critical:{error_code}` on a configuration that previously used the bare
form, and it diverges from the reject-partial-config-group convention used everywhere else in
`config.py`.

## Type of Change
- [x] fix: Bug fix

## Checklist
- [x] Architecture rules followed (no Domain -> Infrastructure imports; `_core` config only, no container or provider-graph change)
- [x] Tests pass (`1557 passed, 32 skipped`; 10 DynamoDB integration errors are environmental — `dynamodb-local` not running, reproduced identically on `main`)
- [x] Linting passes (`ruff check`, `ruff format --check` on `src/` + `tests/`; `mypy` on `config.py`)

## How to Test

Test-first was followed — the two rejection cases failed with `DID NOT RAISE` before the validator
existed, while the three acceptance cases passed throughout.

```bash
uv run pytest tests/unit/_core/test_config.py -q -k "Routing"
```

Rejection fires:

```bash
NOTIFICATION_PROVIDER=slack \
SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T/B/BASE \
NOTIFICATION_CRITICAL_WEBHOOK_URL=https://hooks.slack.com/services/T/B/ALERTS \
uv run python -c "from src._core.config import settings"
# [Notification/Routing] NOTIFICATION_CRITICAL_WEBHOOK_URL / NOTIFICATION_WARNING_WEBHOOK_URL
# require NOTIFICATION_WARNING_THRESHOLD to be set — it is the switch that wires the router. ...
```

Corrected config boots, and the zero-config quickstart is unaffected:

```bash
NOTIFICATION_PROVIDER=slack \
SLACK_WEBHOOK_URL=https://hooks.slack.com/services/T/B/BASE \
NOTIFICATION_CRITICAL_WEBHOOK_URL=https://hooks.slack.com/services/T/B/ALERTS \
NOTIFICATION_WARNING_THRESHOLD=400 \
uv run python -c "from src._core.config import settings; print(settings.notification_critical_target)"

ENV=quickstart uv run python -c "from src._core.config import Settings; print(Settings().env)"
```

New test cases:

- `test_per_tier_webhook_without_warning_threshold_rejected` — parametrized over both URL variables
- `test_per_tier_webhook_with_warning_threshold_accepted` — the corrected form
- `test_warning_threshold_alone_still_accepted` — the threshold on its own stays valid; both tiers
  then resolve to the base webhook, which is the documented degradation, not a misconfiguration

Existing coverage was checked rather than assumed: `test_routing_webhook_without_provider_rejected`
now produces two errors instead of one, but both carry the `[Notification/Routing]` prefix so its
`pytest.raises(match=...)` still holds. The selector tests monkeypatch `settings` attributes
directly, so `model_validator` never re-runs and they are unaffected.

## Notes

Not governor-changing — `src/_core/**`, `tests/**` and `_env/**` match no Tier A/B/C glob in
`docs/ai/shared/governor-paths.md`, so no Governor Footer is required (verified against
`tools/check_governor_footer.py --require-governor-footer`).

### Second commit — `src/_core` prose (partially closes #316)

A separate commit corrects eight comment/docstring sites in `src/_core` that still described the
pre-#286-review wiring. No runtime behaviour changes. The split between this PR and #317's is by
**governor path**, not by issue: `src/**`, `tests/**` and `_env/local.env.example` are outside
Tier A/B/C and ship here; `AGENTS.md`, `docs/**` and `.claude/rules/**` are Tier A and ship in the
#316/#317 PR under full governor ceremony. Keeping `config.py` in one PR also avoids two PRs
racing on the same file.

Two of these were not in #316's original inventory and were found by a dedicated completeness
sweep:

- `taskiq_middleware.py` asserted "`ErrorNotifier` dedupes on `error_code` alone" — false whenever
  a router is wired. Traced through the code: the middleware passes `{task_name}:{error_code}` and
  `ErrorNotifier._cooldown_key` then tier-prefixes it, so the effective worker key is
  `{tier}:{task_name}:{error_code}`. No file in the repo stated the composed form.
- `config.py`'s section header attributed dispatch to "the exception middleware on 5xx-and-above
  errors" — wrong mechanism (handlers, not middleware), wrong band (a warning tier admits sub-500),
  and still missing the #310 worker surface.

Remaining #316/#317 work — the runbook, `project-dna`, `security-checklist`, `.claude/rules/*` and
`AGENTS.md` — is in the companion Tier-A PR.
