### PR TITLE
fix(_core): run bcrypt off the event loop and equalise the login miss path

### DIFF
--- a/src/_core/common/security.py
+++ b/src/_core/common/security.py
@@ -1,9 +1,67 @@
+"""Password hashing helpers.
+
+bcrypt is deliberately slow — roughly 220 ms per operation at the default cost
+on current hardware. That is the point for an attacker, and a problem for an
+event loop: a synchronous call from ``async def`` blocks **every** concurrent
+task in the process for the duration, health checks included. It is a
+process-wide stall, not per-request latency.
+
+So request-path callers use the ``*_async`` helpers, which run the work in a
+worker thread. The synchronous helpers stay for callers that are not on a loop
+(Alembic seeds, CLI tooling) — offloading there would only add overhead.
+"""
+
+from __future__ import annotations
+
+import anyio.to_thread
 import bcrypt
+
+# Verifying against a throwaway digest is what makes the "principal not found"
+# branch cost the same as a real check. Generated once at import: the value is
+# never compared against anything real, only used to burn one bcrypt round.
+_DUMMY_DIGEST = bcrypt.hashpw(b"unused-placeholder-input", bcrypt.gensalt()).decode()
 
 
 def hash_password(password: str) -> str:
+    """Synchronous hash. Use :func:`hash_password_async` on the request path."""
     return bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
 
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
-    return bcrypt.checkpw(plain_password.encode(), hashed_password.encode())
+    """Synchronous verify. Use :func:`verify_password_async` on the request path."""
+    try:
+        return bcrypt.checkpw(plain_password.encode(), hashed_password.encode())
+    except ValueError:
+        # A malformed or truncated stored digest makes bcrypt raise rather than
+        # return False. Failing closed keeps that a failed login instead of a 500.
+        return False
+
+
+async def hash_password_async(password: str) -> str:
+    """Hash off the event loop."""
+    return await anyio.to_thread.run_sync(hash_password, password)
+
+
+async def verify_password_async(plain_password: str, hashed_password: str) -> bool:
+    """Verify off the event loop."""
+    return await anyio.to_thread.run_sync(
+        verify_password, plain_password, hashed_password
+    )
+
+
+async def verify_or_dummy(plain_password: str, hashed_password: str | None) -> bool:
+    """Verify a credential, paying the same cost when the principal is absent.
+
+    The natural spelling of a login check —
+    ``if principal is None or not verify_password(...)`` — short-circuits before
+    bcrypt when the username is unknown, so an unknown account answers ~220 ms
+    faster than a known one with a wrong password. That gap is remotely
+    measurable and enumerates accounts.
+
+    Passing ``None`` here still runs one verification, against a throwaway
+    digest, and returns ``False``.
+    """
+    if not hashed_password:
+        await verify_password_async(plain_password, _DUMMY_DIGEST)
+        return False
+    return await verify_password_async(plain_password, hashed_password)

--- a/src/admin_identity/application/use_cases/admin_account_use_case.py
+++ b/src/admin_identity/application/use_cases/admin_account_use_case.py
@@ -4,7 +4,7 @@ import secrets
 
 import structlog
 
-from src._core.common.security import verify_password
+from src._core.common.security import verify_password_async
 from src._core.infrastructure.admin.permission_registry import AdminPermissionRegistry
 from src.admin_identity.domain.dtos.admin_identity_dto import (
     AdminIdentityDTO,
@@ -157,7 +157,7 @@ class AdminAccountUseCase:
     ) -> None:
         """Change an admin's password, clear the temp flag, revoke refresh tokens."""
         admin = await self._admin_auth_service.get_admin_by_id(admin_id)
-        if not verify_password(current_password, admin.password):
+        if not await verify_password_async(current_password, admin.password):
             raise AdminInvalidCredentialsException()
 
         await self._admin_identity_service.change_admin_password(admin_id, new_password)

--- a/src/admin_identity/domain/services/admin_auth_service.py
+++ b/src/admin_identity/domain/services/admin_auth_service.py
@@ -12,7 +12,7 @@ from src._core.common.jwt_codec import (
     JwtTokenCodec,
     TokenExpiredError,
 )
-from src._core.common.security import verify_password
+from src._core.common.security import verify_or_dummy
 from src._core.exceptions.base_exception import BaseCustomException
 from src.admin_identity.domain.dtos.admin_identity_dto import (
     AdminIdentityDTO,
@@ -55,7 +55,9 @@ class AdminAuthService:
         self, username: str, password: str
     ) -> AdminIdentityDTO:
         admin = await self._admin_repository.select_data_by_username(username)
-        if admin is None or not verify_password(password, admin.password):
+        # Same constant-work contract as the customer realm — see verify_or_dummy.
+        matched = await verify_or_dummy(password, admin.password if admin else None)
+        if admin is None or not matched:
             raise AdminInvalidCredentialsException()
         return admin
 

--- a/src/admin_identity/domain/services/admin_identity_service.py
+++ b/src/admin_identity/domain/services/admin_identity_service.py
@@ -1,7 +1,7 @@
 import structlog
 from pydantic import BaseModel, Field
 
-from src._core.common.security import hash_password
+from src._core.common.security import hash_password_async
 from src._core.domain.services.base_service import BaseService
 from src._core.domain.validation import collect_unique_field_errors
 from src.admin_identity.domain.dtos.admin_identity_dto import (
@@ -79,7 +79,7 @@ class AdminIdentityService(
             updated = await self._admin_repository.update_data_by_data_id(
                 data_id=existing.id,
                 entity=_BootstrapPasswordUpdateDTO(
-                    password=hash_password(entity.password)
+                    password=await hash_password_async(entity.password)
                 ),
             )
             _logger.info(
@@ -94,7 +94,7 @@ class AdminIdentityService(
                 username=entity.username,
                 full_name=entity.full_name,
                 email=str(entity.email),
-                password=hash_password(entity.password),
+                password=await hash_password_async(entity.password),
             )
         )
         _logger.info(
@@ -141,7 +141,7 @@ class AdminIdentityService(
                 username=dto.username,
                 full_name=dto.full_name,
                 email=str(dto.email),
-                password=hash_password(temp_password),
+                password=await hash_password_async(temp_password),
                 permissions=dto.permissions,
             )
         )
@@ -151,5 +151,7 @@ class AdminIdentityService(
     ) -> AdminIdentityDTO:
         return await self._admin_repository.update_data_by_data_id(
             data_id=admin_id,
-            entity=_PasswordChangeClearTempDTO(password=hash_password(new_password)),
+            entity=_PasswordChangeClearTempDTO(
+                password=await hash_password_async(new_password)
+            ),
         )

--- a/src/auth/domain/services/auth_service.py
+++ b/src/auth/domain/services/auth_service.py
@@ -12,7 +12,7 @@ from src._core.common.jwt_codec import (
     JwtTokenCodec,
     TokenExpiredError,
 )
-from src._core.common.security import verify_password
+from src._core.common.security import verify_or_dummy
 from src._core.exceptions.base_exception import BaseCustomException
 from src.auth.domain.dtos.auth_dto import (
     AuthTokenConfig,
@@ -46,7 +46,13 @@ class AuthService:
 
     async def verify_credentials(self, username: str, password: str) -> UserDTO:
         user = await self._user_repository.select_data_by_username(username)
-        if user is None or not verify_password(password, user.password):
+        # Await unconditionally, then branch: verify_or_dummy runs one bcrypt
+        # round even when the user is absent, so an unknown username cannot be
+        # told from a wrong password by timing. Keeping `user is None` in the
+        # branch (rather than folding it into the call) is what lets the type
+        # checker see that the returned value is non-None.
+        matched = await verify_or_dummy(password, user.password if user else None)
+        if user is None or not matched:
             raise InvalidCredentialsException()
         return user
 

--- a/src/user/domain/services/user_service.py
+++ b/src/user/domain/services/user_service.py
@@ -1,4 +1,4 @@
-from src._core.common.security import hash_password
+from src._core.common.security import hash_password_async
 from src._core.domain.services.base_service import BaseService
 from src.user.domain.dtos.user_dto import UserDTO
 from src.user.domain.protocols.user_repository_protocol import UserRepositoryProtocol
@@ -19,12 +19,16 @@ class UserService(BaseService[CreateUserRequest, UpdateUserRequest, UserDTO]):
         self._user_repository = user_repository
 
     async def create_data(self, entity: CreateUserRequest) -> UserDTO:
-        entity = entity.model_copy(update={"password": hash_password(entity.password)})
+        entity = entity.model_copy(
+            update={"password": await hash_password_async(entity.password)}
+        )
         return await super().create_data(entity=entity)
 
     async def create_datas(self, entities: list[CreateUserRequest]) -> list[UserDTO]:
         hashed_entities = [
-            entity.model_copy(update={"password": hash_password(entity.password)})
+            entity.model_copy(
+                update={"password": await hash_password_async(entity.password)}
+            )
             for entity in entities
         ]
         return await super().create_datas(entities=hashed_entities)
@@ -34,7 +38,7 @@ class UserService(BaseService[CreateUserRequest, UpdateUserRequest, UserDTO]):
     ) -> UserDTO:
         if entity.password:
             entity = entity.model_copy(
-                update={"password": hash_password(entity.password)}
+                update={"password": await hash_password_async(entity.password)}
             )
         return await super().update_data_by_data_id(data_id=data_id, entity=entity)
 

--- a/src/user/interface/server/routers/user_router.py
+++ b/src/user/interface/server/routers/user_router.py
@@ -1,5 +1,8 @@
+from typing import Annotated
+
 from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends, Query
+from pydantic import Field
 
 from src._core.application.dtos.base_response import SuccessResponse
 from src.admin_identity.interface.server.dependencies.admin_auth_dependencies import (
@@ -17,6 +20,14 @@ from src.user.interface.server.schemas.user_schema import (
 # exposes other users' PII. Self-service profile reads use /v1/auth/me.
 # New routes added to this router inherit the admin gate by default (default-deny).
 router = APIRouter(dependencies=[Depends(require_admin)])
+
+# Collection bounds (#322). Batch create is the sharp one: every element costs a
+# bcrypt round (~220 ms), so an unbounded list is one request holding a worker
+# thread for N x that. Bounding at the schema layer rejects it with a 422 before
+# any hashing starts. by-ids is bounded for the same reason a page size is —
+# it expands straight into an IN (...) clause.
+MAX_BATCH_SIZE = 100
+MAX_IDS_PER_QUERY = 100
 
 
 # ==========================================================================================
@@ -48,7 +59,7 @@ async def create_user(
 )
 @inject
 async def create_users(
-    items: list[CreateUserRequest],
+    items: Annotated[list[CreateUserRequest], Field(max_length=MAX_BATCH_SIZE)],
     user_service: UserService = Depends(Provide[UserContainer.user_service]),
 ) -> SuccessResponse[list[UserResponse]]:
     datas = await user_service.create_datas(entities=items)
@@ -90,7 +101,9 @@ async def get_user(
 @inject
 async def get_user_by_ids(
     ids: list[int] = Query(
-        ..., description="Comma-separated list of IDs (e.g., 0,1,2)"
+        ...,
+        description="Comma-separated list of IDs (e.g., 0,1,2)",
+        max_length=MAX_IDS_PER_QUERY,
     ),
     user_service: UserService = Depends(Provide[UserContainer.user_service]),
 ) -> SuccessResponse[list[UserResponse]]:

--- a/tests/unit/_core/common/test_security.py
+++ b/tests/unit/_core/common/test_security.py
@@ -1,0 +1,139 @@
+"""Contract tests for the shared password helper (#322).
+
+Two properties are pinned here because both are invisible to a functional test:
+
+1. The bcrypt work must not run on the event loop. bcrypt is deliberately slow
+   (~220 ms measured), so a synchronous call from ``async def`` stalls **every**
+   concurrent task in the process, health checks included — it is not per-request
+   latency.
+2. Verification must cost the same whether or not the principal exists, so an
+   unauthenticated caller cannot enumerate usernames by timing the response.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+
+import pytest
+
+from src._core.common import security
+
+
+class TestPasswordHelperIsAwaitable:
+    """The async API is what callers must use; the sync one stays for tooling."""
+
+    async def test_hash_and_verify_round_trip(self):
+        raw = uuid.uuid4().hex
+        digest = await security.hash_password_async(raw)
+        assert await security.verify_password_async(raw, digest) is True
+        assert await security.verify_password_async(uuid.uuid4().hex, digest) is False
+
+    async def test_hash_does_not_block_the_event_loop(self):
+        """A concurrent 10 ms heartbeat must keep ticking while a hash runs.
+
+        Without offloading, the worst tick equals the bcrypt cost (~220 ms) and
+        every other request on the worker is frozen for that long.
+        """
+        ticks: list[float] = []
+
+        async def heartbeat() -> None:
+            try:
+                while True:
+                    started = time.perf_counter()
+                    await asyncio.sleep(0.01)
+                    ticks.append((time.perf_counter() - started) * 1000)
+            except asyncio.CancelledError:
+                pass
+
+        beat = asyncio.create_task(heartbeat())
+        await asyncio.sleep(0.05)
+        await security.hash_password_async(uuid.uuid4().hex)
+        await asyncio.sleep(0.05)
+        beat.cancel()
+        await asyncio.gather(beat, return_exceptions=True)
+
+        assert ticks, "heartbeat never ran"
+        # bcrypt costs ~220 ms; a 100 ms ceiling fails loudly if the offload is
+        # removed while staying far above normal scheduler jitter.
+        assert max(ticks) < 100, (
+            f"event loop stalled for {max(ticks):.1f} ms during hashing — "
+            "the bcrypt call is running on the loop"
+        )
+
+    async def test_verify_does_not_block_the_event_loop(self):
+        raw = uuid.uuid4().hex
+        digest = await security.hash_password_async(raw)
+        ticks: list[float] = []
+
+        async def heartbeat() -> None:
+            try:
+                while True:
+                    started = time.perf_counter()
+                    await asyncio.sleep(0.01)
+                    ticks.append((time.perf_counter() - started) * 1000)
+            except asyncio.CancelledError:
+                pass
+
+        beat = asyncio.create_task(heartbeat())
+        await asyncio.sleep(0.05)
+        await security.verify_password_async(raw, digest)
+        await asyncio.sleep(0.05)
+        beat.cancel()
+        await asyncio.gather(beat, return_exceptions=True)
+
+        assert max(ticks) < 100, (
+            f"event loop stalled for {max(ticks):.1f} ms during verification"
+        )
+
+
+class TestConstantWorkOnTheMissPath:
+    """`verify_or_dummy` must pay the bcrypt cost even with no stored digest.
+
+    `if principal is None or not verify_password(...)` short-circuits before
+    bcrypt on the miss path, so an unknown username answers ~220 ms faster than a
+    wrong password. That difference is remotely measurable and enumerates accounts.
+    """
+
+    async def test_absent_principal_still_costs_a_verification(self):
+        digest = await security.hash_password_async(uuid.uuid4().hex)
+
+        async def timed(stored: str | None) -> float:
+            started = time.perf_counter()
+            await security.verify_or_dummy("guess", stored)
+            return (time.perf_counter() - started) * 1000
+
+        absent = min([await timed(None) for _ in range(3)])
+        present = min([await timed(digest) for _ in range(3)])
+
+        # Both paths run one bcrypt operation, so the gap must be a small
+        # fraction of the ~220 ms a skipped verification would save.
+        assert abs(present - absent) < present * 0.5, (
+            f"timing side channel: absent={absent:.1f} ms present={present:.1f} ms"
+        )
+
+    async def test_absent_principal_returns_false(self):
+        assert await security.verify_or_dummy("anything", None) is False
+
+    async def test_present_principal_still_verifies_correctly(self):
+        raw = uuid.uuid4().hex
+        digest = await security.hash_password_async(raw)
+        assert await security.verify_or_dummy(raw, digest) is True
+        assert await security.verify_or_dummy(uuid.uuid4().hex, digest) is False
+
+
+class TestSyncHelpersRemain:
+    """The sync helpers stay importable — Alembic seeds and CLI tooling use them
+    outside an event loop, where offloading would be pointless."""
+
+    def test_sync_round_trip(self):
+        raw = uuid.uuid4().hex
+        assert security.verify_password(raw, security.hash_password(raw)) is True
+
+
+@pytest.mark.parametrize("stored", ["", "not-a-bcrypt-digest"])
+async def test_verify_or_dummy_tolerates_a_malformed_digest(stored):
+    """A corrupted stored value must fail closed, not raise — bcrypt raises
+    ValueError on a malformed salt, which would surface as a 500 on login."""
+    assert await security.verify_or_dummy("guess", stored) is False

--- a/tests/unit/user/interface/test_user_router_bounds.py
+++ b/tests/unit/user/interface/test_user_router_bounds.py
@@ -1,0 +1,48 @@
+"""Collection bounds on the user router (#322).
+
+Both endpoints took an unbounded collection. The batch-create one is the sharper
+of the two: every element costs one bcrypt round, so an unbounded list is a
+request that occupies a worker thread for N x ~220 ms. Bounding it at the schema
+layer turns that into a 422 before any work starts.
+"""
+
+from __future__ import annotations
+
+from src.user.interface.server.routers import user_router
+
+MAX_BATCH = user_router.MAX_BATCH_SIZE
+MAX_IDS = user_router.MAX_IDS_PER_QUERY
+
+
+def _param(endpoint, name):
+    import inspect
+
+    return inspect.signature(endpoint).parameters[name]
+
+
+class TestBatchCreateIsBounded:
+    def test_limit_is_declared_and_sane(self):
+        assert 1 < MAX_BATCH <= 1000, (
+            f"MAX_BATCH_SIZE={MAX_BATCH} — an unbounded or very large batch is "
+            "N x one bcrypt round in a single request"
+        )
+
+    def test_items_parameter_carries_the_bound(self):
+        annotation = _param(user_router.create_users, "items").annotation
+        assert str(MAX_BATCH) in str(annotation) or "max_length" in str(annotation), (
+            f"items is not bounded: {annotation}"
+        )
+
+
+class TestByIdsIsBounded:
+    def test_limit_is_declared_and_sane(self):
+        assert 1 < MAX_IDS <= 1000, f"MAX_IDS_PER_QUERY={MAX_IDS}"
+
+    def test_ids_query_carries_the_bound(self):
+        # FastAPI's Query keeps the constraint in `.metadata` as an annotated_types
+        # MaxLen, not as a `max_length` attribute — assert on what is actually there.
+        default = _param(user_router.get_user_by_ids, "ids").default
+        bounds = [
+            getattr(m, "max_length", None) for m in getattr(default, "metadata", [])
+        ]
+        assert MAX_IDS in bounds, f"ids Query is not bounded: {default!r}"


### PR DESCRIPTION
## Related Issue
- Refs #322 (audit cluster E) · Part of #336

> **Deliberately `Refs`, not `Closes`.** #322 also asks for a request body-size middleware,
> which is deferred to #324 with rationale (see the bottom of this description). A linking
> keyword would auto-close the issue on merge and take that remaining item with it — the same way
> a `partially closes` phrase silently shut issue 316 during the previous wave. Shut issue 322
> by hand once the middleware lands.
>
> (Note the phrasing above avoids putting a linking keyword next to an issue number at all —
> GitHub's parser does not care that the sentence is a warning about linking keywords.)

## Change Summary

bcrypt costs **~220 ms** per operation by design. Called synchronously from `async def` that is
not per-request latency — it stalls the **whole process**, health checks included. Measured with a
10 ms heartbeat running alongside one verification:

```text
sync verify  (before)   worst heartbeat tick   233.0 ms
async verify (after)    worst heartbeat tick    23.1 ms
```

### The issue undercounted the blast radius

An AST scan for `hash_password` / `verify_password` inside `async def` found **10 sites, not 4**:

```text
[async] admin_identity/application/use_cases/admin_account_use_case.py:160  verify_password
[async] admin_identity/domain/services/admin_auth_service.py:58             verify_password
[async] admin_identity/domain/services/admin_identity_service.py:82,97,144,154  hash_password
[async] auth/domain/services/auth_service.py:49                             verify_password
[async] user/domain/services/user_service.py:22,27,37                       hash_password
=> 10 of 10 sit inside async def
```

`rg -c 'to_thread|run_in_executor|anyio' src/` returned nothing beforehand. All ten now go through
`hash_password_async` / `verify_password_async`, which offload via `anyio.to_thread`. Re-running the
scan after the change returns **0**.

The sync helpers stay for callers that are not on a loop — Alembic seeds, CLI tooling — where
offloading would only add overhead.

### Login miss path — an enumeration oracle in both realms

`if principal is None or not verify_password(...)` short-circuits before bcrypt when the username is
unknown, so an unknown account answered ~220 ms faster than a known one with a wrong password. The
code was byte-identical in the customer and admin realms.

`verify_or_dummy` runs one bcrypt round against a throwaway digest when there is no stored hash:

```text
principal absent    226.1 ms
principal present   225.6 ms
delta                 0.5 ms   (0.2% of one round)
```

It lives in the shared `_core/common/security.py` so both realms get it from one place — ADR049-G3
keeps the *mechanism* shared while the trust boundary stays split. **Rate limiting is a stated §0
non-goal and is deliberately not the remedy.**

### One shape worth noting

The verify is awaited **unconditionally** and `principal is None` stays in the branch:

```python
matched = await verify_or_dummy(password, user.password if user else None)
if user is None or not matched:
    raise InvalidCredentialsException()
return user
```

Folding the None test into the call read better, and broke type narrowing — mypy correctly pointed
out the function could then return `None`. This shape keeps constant work *and* the return type.

### Collection bounds

`list[CreateUserRequest]` was unbounded and every element costs a bcrypt round, so one request could
hold a worker thread for N × 220 ms. Bounded at 100, rejected before any hashing starts:

```text
101 items -> rejected: too_long
100 items -> accepted
```

`GET /v1/user/by-ids` bounded the same way — it expands straight into an `IN (...)`.

### Fail-closed on a malformed digest

`bcrypt.checkpw` raises `ValueError` rather than returning False when the stored digest is corrupt
or truncated, which would surface as a **500 on login** instead of a failed login. Now guarded and
pinned by test.

## Type of Change
- [x] fix: Bug fix

## Checklist
- [x] Architecture rules followed (no Domain → Infrastructure import; the helper stays in `_core/common`, both realms consume it)
- [x] Tests pass (`1570 passed, 32 skipped` — was 1557 on `main`, +13 new; the 10 DynamoDB integration errors are environmental, `dynamodb-local` not running, identical on `main`)
- [x] Linting passes (`ruff check`, `ruff format --check`, `mypy` on all 7 changed src files)

## How to Test

Test-first was followed — 8 of the 9 helper tests failed with `AttributeError` before the async
helpers existed, and the one that passed was the sync round-trip.

```bash
uv run pytest tests/unit/_core/common/test_security.py tests/unit/user/interface/test_user_router_bounds.py -v
```

Reproduce the stall measurement:

```bash
uv run python -c "
import asyncio, time, uuid
from src._core.common.security import hash_password, verify_password, verify_password_async
s = uuid.uuid4().hex; d = hash_password(s)
async def measure(fn, label):
    ticks = []
    async def hb():
        try:
            while True:
                t = time.perf_counter(); await asyncio.sleep(0.01)
                ticks.append((time.perf_counter() - t) * 1000)
        except asyncio.CancelledError: pass
    h = asyncio.create_task(hb()); await asyncio.sleep(0.05); await fn(); await asyncio.sleep(0.05)
    h.cancel(); await asyncio.gather(h, return_exceptions=True)
    print(f'{label:24} worst tick {max(ticks):7.1f} ms')
async def main():
    async def old(): verify_password(s, d)
    async def new(): await verify_password_async(s, d)
    await measure(old, 'sync (old path)'); await measure(new, 'async (new path)')
asyncio.run(main())"
```

Confirm no blocking call remains on the loop:

```bash
uv run python -c "
import ast, pathlib
T = {'hash_password', 'verify_password'}
bad = [f'{p}:{s.lineno}' for p in pathlib.Path('src').rglob('*.py')
       for n in ast.walk(ast.parse(p.read_text())) if isinstance(n, ast.AsyncFunctionDef)
       for s in ast.walk(n) if isinstance(s, ast.Call) and isinstance(s.func, ast.Name) and s.func.id in T]
print('blocking calls inside async def:', len(bad), bad)"
```

The event-loop assertions use a **100 ms ceiling** — far above scheduler jitter, far below the
~220 ms a regression would produce.

## Deferred with rationale — the body-size middleware

#322 also asks for one. Not in this PR:

- It needs a new settings field and a change to `_apps/server/bootstrap.py`, whose middleware
  ordering is **documented as load-bearing** — and audit cluster L (#324) rewires exactly that
  block. Landing both puts two PRs on the same lines.
- It is a different failure mode: memory and parse cost, not bcrypt cost.
- The collection bounds already close the bcrypt path, which is what made the finding BLOCKING.

Recorded on #322 and flagged to #324.

## Notes

Not governor-changing — `src/**` and `tests/**` match no Tier A/B/C glob in
`docs/ai/shared/governor-paths.md`, so no Governor Footer is required.

`tests/unit/user/interface/` is a new directory; `tests/unit/_core/common/` already existed.
