### PR TITLE
test(_core): resolve the enabled half of every optional-infra Selector

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ testpaths = ["tests"]
 pythonpath = [".agents/shared"]
 markers = [
     "slow: spawns a subprocess per test — container wiring probes that cannot\n           run in-process (see tests/support/container_env.py)",
-    "dynamodb: requires a dynamodb-local instance on DYNAMODB_ENDPOINT_URL",
+    "dynamodb: requires dynamodb-local at http://localhost:8000 (see make test-dynamo)",
 ]
 
 # === Ruff Configuration ===

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,10 @@ asyncio_default_fixture_loop_scope = "session"
 asyncio_default_test_loop_scope = "session"
 testpaths = ["tests"]
 pythonpath = [".agents/shared"]
+markers = [
+    "slow: spawns a subprocess per test — container wiring probes that cannot\n           run in-process (see tests/support/container_env.py)",
+    "dynamodb: requires a dynamodb-local instance on DYNAMODB_ENDPOINT_URL",
+]
 
 # === Ruff Configuration ===
 [tool.ruff]

--- a/tests/integration/_core/infrastructure/persistence/nosql/dynamodb/test_dynamo_repository.py
+++ b/tests/integration/_core/infrastructure/persistence/nosql/dynamodb/test_dynamo_repository.py
@@ -31,6 +31,40 @@ DYNAMODB_ENDPOINT = "http://localhost:8000"
 TABLE_NAME = "test_integration_notes"
 
 
+def _dynamodb_local_is_up() -> bool:
+    """Is a dynamodb-local instance listening?
+
+    Without this, all 10 tests in this module ERROR rather than skip whenever the
+    container is not running — which is the default for anyone running the
+    documented `pytest tests/ -v`. An error reads as "the suite is broken"; a skip
+    reads as "this needs infra", which is the truth. See `make test-dynamo`.
+    """
+    import socket
+    from urllib.parse import urlparse
+
+    parsed = urlparse(DYNAMODB_ENDPOINT)
+    try:
+        with socket.create_connection(
+            (parsed.hostname, parsed.port or 8000), timeout=0.5
+        ):
+            return True
+    except OSError:
+        return False
+
+
+pytestmark = [
+    pytest.mark.dynamodb,
+    pytest.mark.skipif(
+        not _dynamodb_local_is_up(),
+        reason=(
+            f"dynamodb-local not reachable at {DYNAMODB_ENDPOINT} — "
+            "start it with `make test-dynamo` or "
+            "`docker run -d -p 8000:8000 amazon/dynamodb-local`"
+        ),
+    ),
+]
+
+
 # ── Model / DTO / Repository ──────────────────────────────────
 
 

--- a/tests/integration/_core/infrastructure/test_optional_infra_enabled.py
+++ b/tests/integration/_core/infrastructure/test_optional_infra_enabled.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import pytest
 
-from tests.support.container_env import boot_fails, resolve_in_env
+from tests.support.container_env import REPO_ROOT, boot_fails, resolve_in_env
 
 pytestmark = pytest.mark.slow
 
@@ -213,3 +213,39 @@ class TestTheHarnessItself:
         assert out["t"] == "NoopNotificationClient", (
             "the parent process env leaked into the probe"
         )
+
+    def test_probe_runs_where_no_dotenv_can_be_found(self):
+        """Scrubbing the environment is only half the isolation.
+
+        `Settings` sets ``env_file=".env"`` (`config.py:66`), and
+        pydantic-settings resolves that **relative to the working directory**.
+        An earlier revision ran the probe with ``cwd=REPO_ROOT``, so a
+        developer's untracked `.env` reached a probe called with `{}` — verified
+        at the time: an empty-env probe returned `DiscordNotificationAdapter`
+        with the URL from that file instead of the Noop client. The suite passed
+        only because CI checkouts have no `.env`, which is the worst kind of
+        green.
+
+        Asserting on the working directory rather than planting a real `.env`
+        keeps the check honest without a test that can litter the repo root if
+        it dies. Found by the cross-tool review of PR #338, not by this file.
+        """
+        out = resolve_in_env(
+            {},
+            """
+import os, pathlib
+cwd = pathlib.Path(os.getcwd())
+result = {
+    "cwd": str(cwd),
+    "has_dotenv": (cwd / ".env").exists(),
+    "is_repo_root": (cwd / "pyproject.toml").exists(),
+    "client": type(container.notification_client()).__name__,
+}
+""",
+        )
+        assert not out["has_dotenv"], f"probe cwd contains a .env: {out['cwd']}"
+        assert not out["is_repo_root"], (
+            f"probe ran in the repo root ({out['cwd']}) — a developer's .env "
+            "would be read by Settings and silently change the result"
+        )
+        assert out["client"] == "NoopNotificationClient"

--- a/tests/integration/_core/infrastructure/test_optional_infra_enabled.py
+++ b/tests/integration/_core/infrastructure/test_optional_infra_enabled.py
@@ -1,0 +1,215 @@
+"""The *enabled* half of every optional-infra Selector (#330).
+
+`test_optional_infra.py` covers the disabled half. Nothing covered the enabled
+half, because the only technique available — monkeypatching `settings` after
+import — cannot set provider kwargs: they are captured when the class body runs.
+Worse, it *can* flip the branch, so a test written that way returns the right
+adapter type wired with `None` and passes.
+
+Every assertion here therefore checks the **configured value reached the object**,
+not just its type. See `tests/support/container_env.py`.
+
+These spawn a subprocess each. That is the cost of asking a question the
+in-process suite structurally cannot answer, and it is why this file is scoped to
+wiring contracts rather than behaviour.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.support.container_env import boot_fails, resolve_in_env
+
+pytestmark = pytest.mark.slow
+
+SLACK = "https://hooks.slack.com/services/T/B/BASE"
+ALERTS = "https://hooks.slack.com/services/T/B/ALERTS"
+MONITORING = "https://hooks.slack.com/services/T/B/MONITORING"
+DISCORD = "https://discord.com/api/webhooks/123456789012345678/abcdefgh"
+
+_ADAPTER_URL = """
+client = container.notification_client()
+result = {"type": type(client).__name__, "url": getattr(client, "_webhook_url", None)}
+"""
+
+
+class TestNotificationClientEnabled:
+    def test_slack_adapter_receives_the_configured_url(self):
+        out = resolve_in_env(
+            {"NOTIFICATION_PROVIDER": "slack", "SLACK_WEBHOOK_URL": SLACK},
+            _ADAPTER_URL,
+        )
+        assert out["type"] == "SlackNotificationAdapter"
+        # The assertion that a monkeypatch-based test cannot make: the *value*.
+        assert out["url"] == SLACK
+
+    def test_discord_adapter_receives_the_configured_url(self):
+        out = resolve_in_env(
+            {"NOTIFICATION_PROVIDER": "discord", "DISCORD_WEBHOOK_URL": DISCORD},
+            _ADAPTER_URL,
+        )
+        assert out["type"] == "DiscordNotificationAdapter"
+        assert out["url"] == DISCORD
+
+
+class TestNotificationRoutingEnabled:
+    """#286's routing graph, resolved for real for the first time."""
+
+    def test_router_is_none_without_the_threshold(self):
+        out = resolve_in_env(
+            {"NOTIFICATION_PROVIDER": "slack", "SLACK_WEBHOOK_URL": SLACK},
+            'result = {"router": repr(container.notification_router())}',
+        )
+        assert out["router"] == "None"
+
+    def test_each_tier_receives_its_own_url(self):
+        out = resolve_in_env(
+            {
+                "NOTIFICATION_PROVIDER": "slack",
+                "SLACK_WEBHOOK_URL": SLACK,
+                "NOTIFICATION_WARNING_THRESHOLD": "400",
+                "NOTIFICATION_CRITICAL_WEBHOOK_URL": ALERTS,
+                "NOTIFICATION_WARNING_WEBHOOK_URL": MONITORING,
+            },
+            """
+router = container.notification_router()
+result = {
+    "critical": getattr(router.resolve(500), "_webhook_url", None),
+    "warning": getattr(router.resolve(404), "_webhook_url", None),
+    "below": router.resolve(399),
+}
+""",
+        )
+        assert out["critical"] == ALERTS
+        assert out["warning"] == MONITORING
+        assert out["below"] is None, "below the warning band must not dispatch"
+
+    def test_unset_tier_url_falls_back_to_the_single_target(self):
+        out = resolve_in_env(
+            {
+                "NOTIFICATION_PROVIDER": "slack",
+                "SLACK_WEBHOOK_URL": SLACK,
+                "NOTIFICATION_WARNING_THRESHOLD": "400",
+                "NOTIFICATION_CRITICAL_WEBHOOK_URL": ALERTS,
+            },
+            """
+router = container.notification_router()
+result = {
+    "critical": getattr(router.resolve(500), "_webhook_url", None),
+    "warning": getattr(router.resolve(404), "_webhook_url", None),
+}
+""",
+        )
+        assert out["critical"] == ALERTS
+        assert out["warning"] == SLACK, "an unset tier degrades to the single target"
+
+    def test_disabled_path_emits_one_disabled_warning(self):
+        """Three client Selectors share one Noop Singleton, so the warning is
+        logged once regardless of tier count. Pinned in-process elsewhere; pinned
+        here against a real container resolve."""
+        out = resolve_in_env(
+            {},
+            """
+from structlog.testing import capture_logs
+import structlog
+structlog.reset_defaults()
+with capture_logs() as logs:
+    container.error_notifier()
+result = {"warnings": sum(
+    1 for r in logs if r.get("event") == "notification_client_disabled")}
+""",
+        )
+        assert out["warnings"] == 1
+
+
+class TestBootValidationRunsForReal:
+    """`model_validator` fires at construction, so a post-import monkeypatch never
+    re-runs it. These are the rejections `config.py` promises."""
+
+    @pytest.mark.parametrize(
+        "env,expected",
+        [
+            (
+                {"NOTIFICATION_PROVIDER": "slack"},
+                "slack_webhook_url",
+            ),
+            (
+                {"NOTIFICATION_PROVIDER": "nope", "SLACK_WEBHOOK_URL": SLACK},
+                "notification_provider",
+            ),
+            (
+                {
+                    "NOTIFICATION_PROVIDER": "slack",
+                    "SLACK_WEBHOOK_URL": SLACK,
+                    "NOTIFICATION_WARNING_THRESHOLD": "500",
+                },
+                "NOTIFICATION_WARNING_THRESHOLD",
+            ),
+            (
+                {
+                    "NOTIFICATION_PROVIDER": "slack",
+                    "SLACK_WEBHOOK_URL": SLACK,
+                    "NOTIFICATION_CRITICAL_WEBHOOK_URL": ALERTS,
+                },
+                "NOTIFICATION_WARNING_THRESHOLD",
+            ),
+            (
+                {"NOTIFICATION_CRITICAL_WEBHOOK_URL": ALERTS},
+                "NOTIFICATION_PROVIDER",
+            ),
+        ],
+        ids=[
+            "provider-without-url",
+            "unknown-provider",
+            "threshold-overlap",
+            "tier-url-without-threshold",
+            "tier-url-without-provider",
+        ],
+    )
+    def test_rejected_at_boot(self, env, expected):
+        err = boot_fails(env)
+        assert err is not None, f"expected boot to fail for {env}"
+        assert expected in err, f"error did not mention {expected}:\n{err}"
+
+    def test_a_complete_routing_config_boots(self):
+        assert (
+            boot_fails(
+                {
+                    "NOTIFICATION_PROVIDER": "slack",
+                    "SLACK_WEBHOOK_URL": SLACK,
+                    "NOTIFICATION_WARNING_THRESHOLD": "400",
+                    "NOTIFICATION_CRITICAL_WEBHOOK_URL": ALERTS,
+                    "NOTIFICATION_WARNING_WEBHOOK_URL": MONITORING,
+                }
+            )
+            is None
+        )
+
+
+class TestTheHarnessItself:
+    """If this regresses, every assertion above silently becomes a type check."""
+
+    def test_kwargs_track_the_environment(self):
+        """The exact false-green the harness exists to prevent: a post-import
+        monkeypatch yields the right adapter type with a None URL."""
+        a = resolve_in_env(
+            {"NOTIFICATION_PROVIDER": "slack", "SLACK_WEBHOOK_URL": ALERTS},
+            _ADAPTER_URL,
+        )
+        b = resolve_in_env(
+            {"NOTIFICATION_PROVIDER": "slack", "SLACK_WEBHOOK_URL": MONITORING},
+            _ADAPTER_URL,
+        )
+        assert a["url"] == ALERTS
+        assert b["url"] == MONITORING
+        assert a["url"] != b["url"], "kwargs are not tracking the environment"
+
+    def test_parent_environment_does_not_leak(self, monkeypatch):
+        monkeypatch.setenv("NOTIFICATION_PROVIDER", "discord")
+        monkeypatch.setenv("DISCORD_WEBHOOK_URL", DISCORD)
+        out = resolve_in_env(
+            {}, 'result = {"t": type(container.notification_client()).__name__}'
+        )
+        assert out["t"] == "NoopNotificationClient", (
+            "the parent process env leaked into the probe"
+        )

--- a/tests/support/container_env.py
+++ b/tests/support/container_env.py
@@ -26,6 +26,10 @@ module graph the rest of the suite already holds references to, so this runs in
 a subprocess instead: cheap enough for the handful of wiring assertions that
 need it, and it cannot leak state into any other test.
 
+The child runs in an empty temporary directory, not the repo root — `Settings`
+reads `env_file=".env"` relative to the working directory, so a developer's
+untracked `.env` would otherwise reach a probe called with `{}`.
+
 `tests/unit/_core/test_config.py::_create_settings` uses the same
 patch-then-import idea for `Settings` alone; this generalises it to the
 container graph.
@@ -37,6 +41,7 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 import textwrap
 from pathlib import Path
 
@@ -58,13 +63,46 @@ BASE_ENV: dict[str, str] = {
 
 # Anything the parent process exports would otherwise bleed into the child and
 # silently change what a probe resolves. The child starts from BASE_ENV plus the
-# caller's overrides only — never the developer's shell or `_env/.env`.
+# caller's overrides only.
 _PASSTHROUGH = ("PATH", "HOME", "LANG", "LC_ALL", "VIRTUAL_ENV", "PYTHONHASHSEED")
 
 
 class ContainerProbeError(RuntimeError):
     """The probe process failed. Carries the child's stderr, which is where the
     real cause (a boot-validation rejection, an import error) actually is."""
+
+
+def _run_probe(
+    env: dict[str, str], argv: list[str]
+) -> subprocess.CompletedProcess[str]:
+    """Run a probe with `env` and nothing else reaching `Settings`.
+
+    Scrubbing the environment is only half the isolation. `Settings` declares
+    ``env_file=".env"`` (`config.py:66`), which pydantic-settings resolves
+    **relative to the working directory** — so running the child in the repo root
+    lets a developer's untracked `.env` back in, and a probe called with `{}`
+    silently resolves whatever that file configures. Verified: with a repo-root
+    `.env` naming a Discord webhook, an empty-env probe returned
+    `DiscordNotificationAdapter` instead of the Noop client.
+
+    So the child runs in an empty temporary directory and finds the project via
+    `PYTHONPATH` instead. `cwd` is not where the code is; it is only where
+    `.env` would be looked for.
+    """
+    child_env = {k: os.environ[k] for k in _PASSTHROUGH if k in os.environ}
+    child_env["PYTHONPATH"] = str(REPO_ROOT)
+    child_env.update(BASE_ENV)
+    child_env.update(env)
+
+    with tempfile.TemporaryDirectory(prefix="container-probe-") as sandbox:
+        return subprocess.run(
+            argv,
+            cwd=sandbox,
+            env=child_env,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
 
 
 def resolve_in_env(env: dict[str, str], body: str) -> dict:
@@ -100,19 +138,7 @@ def resolve_in_env(env: dict[str, str], body: str) -> dict:
     """)
     )
 
-    child_env = {k: os.environ[k] for k in _PASSTHROUGH if k in os.environ}
-    child_env["PYTHONPATH"] = str(REPO_ROOT)
-    child_env.update(BASE_ENV)
-    child_env.update(env)
-
-    proc = subprocess.run(
-        [sys.executable, "-c", script],
-        cwd=REPO_ROOT,
-        env=child_env,
-        capture_output=True,
-        text=True,
-        timeout=120,
-    )
+    proc = _run_probe(env, [sys.executable, "-c", script])
     if proc.returncode != 0:
         raise ContainerProbeError(
             f"probe exited {proc.returncode}\n--- stderr ---\n{proc.stderr}"
@@ -133,17 +159,5 @@ def boot_fails(env: dict[str, str]) -> str | None:
     exercise: `model_validator` runs at construction, so patching attributes
     afterwards never re-runs it.
     """
-    child_env = {k: os.environ[k] for k in _PASSTHROUGH if k in os.environ}
-    child_env["PYTHONPATH"] = str(REPO_ROOT)
-    child_env.update(BASE_ENV)
-    child_env.update(env)
-
-    proc = subprocess.run(
-        [sys.executable, "-c", "import src._core.config"],
-        cwd=REPO_ROOT,
-        env=child_env,
-        capture_output=True,
-        text=True,
-        timeout=120,
-    )
+    proc = _run_probe(env, [sys.executable, "-c", "import src._core.config"])
     return None if proc.returncode == 0 else proc.stderr

--- a/tests/support/container_env.py
+++ b/tests/support/container_env.py
@@ -1,0 +1,149 @@
+"""Resolve a `CoreContainer` under an arbitrary environment (#330).
+
+`CoreContainer` is a `DeclarativeContainer`, so every provider's kwargs are
+evaluated **once, when the class body runs at import time**. A selector
+*function* re-reads `settings` on each resolve, but the values already baked
+into the `enabled` branch never change again.
+
+That split is the trap this module exists to close. Monkeypatching `settings`
+after import flips the branch but not the kwargs:
+
+    settings.notification_provider = "slack"
+    settings.slack_webhook_url     = "https://hooks.slack.com/services/T/B/REAL"
+
+    CoreContainer().notification_client()
+      -> SlackNotificationAdapter      # the branch moved
+      -> webhook_url is None           # the kwarg did not
+
+A test written that way asserts `isinstance(..., SlackNotificationAdapter)`,
+passes, and has verified nothing about the configuration. A green test proving
+the wrong thing is worse than a missing one — which is why no test in this repo
+had ever resolved the enabled half of an optional-infra Selector before now.
+
+The only way to get a truthful answer is to set the environment **before**
+`src._core.config` is imported. Doing that in-process would mean reimporting a
+module graph the rest of the suite already holds references to, so this runs in
+a subprocess instead: cheap enough for the handful of wiring assertions that
+need it, and it cannot leak state into any other test.
+
+`tests/unit/_core/test_config.py::_create_settings` uses the same
+patch-then-import idea for `Settings` alone; this generalises it to the
+container graph.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# The minimum an arbitrary env needs to satisfy Settings validation. Individual
+# probes override these freely; they exist so callers only have to name the
+# variables their own scenario is about.
+BASE_ENV: dict[str, str] = {
+    "ENV": "local",
+    "ADMIN_STORAGE_SECRET": "a-real-admin-storage-secret-value-x",
+    "DATABASE_ENGINE": "sqlite",
+    "DATABASE_USER": "app",
+    "DATABASE_PASSWORD": "db-s3cure-value",
+    "DATABASE_HOST": "localhost",
+    "DATABASE_PORT": "5432",
+    "DATABASE_NAME": ":memory:",
+}
+
+# Anything the parent process exports would otherwise bleed into the child and
+# silently change what a probe resolves. The child starts from BASE_ENV plus the
+# caller's overrides only — never the developer's shell or `_env/.env`.
+_PASSTHROUGH = ("PATH", "HOME", "LANG", "LC_ALL", "VIRTUAL_ENV", "PYTHONHASHSEED")
+
+
+class ContainerProbeError(RuntimeError):
+    """The probe process failed. Carries the child's stderr, which is where the
+    real cause (a boot-validation rejection, an import error) actually is."""
+
+
+def resolve_in_env(env: dict[str, str], body: str) -> dict:
+    """Run `body` in a fresh process with `env` applied before any project import.
+
+    `body` is Python source. It receives a module-level name `container`
+    (a freshly built `CoreContainer`) and must assign a JSON-serialisable dict
+    to `result`. Whatever it assigns is returned.
+
+    Example — prove the *value* reached the adapter, not just its type::
+
+        out = resolve_in_env(
+            {"NOTIFICATION_PROVIDER": "slack",
+             "SLACK_WEBHOOK_URL": "https://hooks.slack.com/services/T/B/REAL"},
+            '''
+            client = container.notification_client()
+            result = {"type": type(client).__name__,
+                      "url": getattr(client, "_webhook_url", None)}
+            ''',
+        )
+        assert out["url"].endswith("/REAL")   # the assertion that actually matters
+    """
+    script = (
+        textwrap.dedent("""
+        import json, sys
+        from src._core.infrastructure.di.core_container import CoreContainer
+        container = CoreContainer()
+        result = None
+    """)
+        + textwrap.dedent(body)
+        + textwrap.dedent("""
+        sys.stdout.write("---PROBE---" + json.dumps(result))
+    """)
+    )
+
+    child_env = {k: os.environ[k] for k in _PASSTHROUGH if k in os.environ}
+    child_env["PYTHONPATH"] = str(REPO_ROOT)
+    child_env.update(BASE_ENV)
+    child_env.update(env)
+
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=REPO_ROOT,
+        env=child_env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    if proc.returncode != 0:
+        raise ContainerProbeError(
+            f"probe exited {proc.returncode}\n--- stderr ---\n{proc.stderr}"
+        )
+    marker = "---PROBE---"
+    if marker not in proc.stdout:
+        raise ContainerProbeError(
+            f"probe produced no result\n--- stdout ---\n{proc.stdout}"
+            f"\n--- stderr ---\n{proc.stderr}"
+        )
+    return json.loads(proc.stdout.split(marker, 1)[1])
+
+
+def boot_fails(env: dict[str, str]) -> str | None:
+    """Return the boot-validation error for `env`, or None if it boots.
+
+    Settings validation is the other thing a post-import monkeypatch cannot
+    exercise: `model_validator` runs at construction, so patching attributes
+    afterwards never re-runs it.
+    """
+    child_env = {k: os.environ[k] for k in _PASSTHROUGH if k in os.environ}
+    child_env["PYTHONPATH"] = str(REPO_ROOT)
+    child_env.update(BASE_ENV)
+    child_env.update(env)
+
+    proc = subprocess.run(
+        [sys.executable, "-c", "import src._core.config"],
+        cwd=REPO_ROOT,
+        env=child_env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    return None if proc.returncode == 0 else proc.stderr

--- a/tests/unit/_core/infrastructure/di/test_core_container_selectors.py
+++ b/tests/unit/_core/infrastructure/di/test_core_container_selectors.py
@@ -146,8 +146,13 @@ class TestNotificationCriticalSelector:
         assert _notification_critical_selector() == "enabled"
 
     def test_enabled_via_explicit_override(self, monkeypatch: pytest.MonkeyPatch):
+        # A real deployment always has the base webhook set — boot validation
+        # rejects a provider without one. Modelling a bootable config here keeps
+        # the fixture honest; the override is still what the assertion is about.
         monkeypatch.setattr(settings, "notification_provider", "slack")
-        monkeypatch.setattr(settings, "slack_webhook_url", None)
+        monkeypatch.setattr(
+            settings, "slack_webhook_url", "https://hooks.slack.com/services/T/B/BASE"
+        )
         monkeypatch.setattr(
             settings,
             "notification_critical_webhook_url",
@@ -173,8 +178,13 @@ class TestNotificationWarningSelector:
         assert _notification_warning_selector() == "enabled"
 
     def test_enabled_via_explicit_override(self, monkeypatch: pytest.MonkeyPatch):
+        # A real deployment always has the base webhook set — boot validation
+        # rejects a provider without one. Modelling a bootable config here keeps
+        # the fixture honest; the override is still what the assertion is about.
         monkeypatch.setattr(settings, "notification_provider", "slack")
-        monkeypatch.setattr(settings, "slack_webhook_url", None)
+        monkeypatch.setattr(
+            settings, "slack_webhook_url", "https://hooks.slack.com/services/T/B/BASE"
+        )
         monkeypatch.setattr(
             settings,
             "notification_warning_webhook_url",


### PR DESCRIPTION
## Related Issue
- Refs #330 (audit cluster A) · Part of #336

> `Refs`, not a linking keyword — see the note at the bottom about what stays open.

## Change Summary

No test in this repo had ever resolved an optional-infra Selector with the infra **enabled**.
This adds the harness that makes it possible, and uses it.

### The issue's stated cause was wrong, and the truth is worse

#330 says post-import `monkeypatch` "cannot flip a Selector branch". Probed at `751c4c7`:

```text
settings.notification_provider = "slack"
settings.slack_webhook_url     = "https://hooks.slack.com/services/T/B/REAL"

CoreContainer().notification_client()
  adapter type : SlackNotificationAdapter     <- the branch DID flip
  adapter URL  : None                         <- the kwarg did not
```

The selector *function* re-reads `settings` on every resolve, so the branch moves. What cannot
move are the **kwargs**, captured when the `DeclarativeContainer` class body was evaluated:

```text
CoreContainer.notification_client.providers["enabled"].kwargs["webhook_url"]  ->  None
settings.notification_webhook_url                                            ->  ".../REAL"
```

So a test written the obvious way asserts `isinstance(..., SlackNotificationAdapter)`, passes, and
has verified **nothing about the configuration**. A green test proving the wrong thing is worse
than a missing one — and it is why both round-1 defects of PR #313 had to be caught by a human
reading the container rather than by CI.

A correction has been posted to #330 so the next reader does not inherit the wrong model.

### The harness

`tests/support/container_env.py`:

- **`resolve_in_env(env, body)`** applies an environment **before** `src._core.config` is imported,
  by running the probe in a subprocess. The kwargs are therefore real.
- **`boot_fails(env)`** does the same for `model_validator`, which runs at construction and which a
  post-import patch also never re-runs.
- The parent process's environment is deliberately **not** inherited — only an explicit passthrough
  list — so a developer's `_env/.env` cannot silently change what a probe sees.

It generalises `tests/unit/_core/test_config.py::_create_settings`, which already does
patch-then-import for `Settings` alone.

### What it pins

`tests/integration/_core/infrastructure/test_optional_infra_enabled.py`, 14 cases. **Every
assertion checks that the configured value reached the object, not just its type.**

- Slack and Discord adapters carrying their configured URL
- The #286 routing graph resolved for real: per-tier targets, unset-tier fallback to the single
  target, below-band returning `None`
- The single `notification_client_disabled` warning, against a real container resolve
- All five boot rejections `config.py` promises, including the two `[Notification/Routing]` ones
  added by #315
- **`TestTheHarnessItself`** — if the harness regresses, every assertion above silently degrades to
  a type check, so it is pinned too

### Three fold-ins from the same issue

| | before | after |
|---|---|---|
| DynamoDB integration tests | **10 ERROR** whenever `dynamodb-local` is not running — the default for anyone running the documented `pytest tests/ -v` | **10 skipped**, with `make test-dynamo` named in the reason |
| pytest markers | none registered; any marker raised `PytestUnknownMarkWarning` | `slow` and `dynamodb` registered |
| Two selector tests | asserted `slack_webhook_url=None` alongside a per-tier URL — a state boot validation rejects. They passed only because selector tests patch attributes directly and never re-run the validator | given a bootable config |

An error reads as "the suite is broken"; a skip reads as "this needs infra". Only one of those is
true, and this session spent time explaining the difference on every full run.

## Type of Change
- [x] test: Test-only change (plus pytest marker registration)

## Checklist
- [x] Architecture rules followed (no `src/` change at all)
- [x] Tests pass — see below
- [x] Linting passes (`ruff check`, `ruff format --check` on `src/` + `tests/`)

## How to Test

```bash
uv run pytest tests/integration/_core/infrastructure/test_optional_infra_enabled.py -v
uv run pytest tests/unit/_core/infrastructure/di/test_core_container_selectors.py -q
uv run pytest tests/integration/_core/infrastructure/persistence/nosql/dynamodb/ -q   # 10 skipped
```

Reproduce the false-green the harness exists to prevent:

```bash
uv run python -c "
from src._core.config import settings
from src._core.infrastructure.di.core_container import CoreContainer
settings.notification_provider = 'slack'
settings.slack_webhook_url = 'https://hooks.slack.com/services/T/B/REAL'
a = CoreContainer().notification_client()
print('type:', type(a).__name__)
print('url :', getattr(a, '_webhook_url', None))   # None — the kwarg never moved
"
```

### Suite comparison

```text
main     1570 passed, 32 skipped, 10 errors, 108s
this PR  1584 passed, 42 skipped,  0 errors,  68s
```

First run this cycle with no errors to explain away.

## What this unblocks

#327 (B, notification collapse), #324 (L, inline broker) and #328 (M, vector integrity) all needed
this to be regression-pinnable. None of them could be before.

## Notes

**Governor-changing — I got this wrong first, and the reason is worth recording.**

The original description here claimed this PR was not governor-changing, on the grounds that
`pyproject.toml`'s `markers` key is not one of the policy sections
[`governor-paths.md:41`](docs/ai/shared/governor-paths.md) names (`[tool.ruff]`, `[tool.mypy]`,
"or other linting/typing/policy sections"). CI disagreed, and CI is right:

```text
$ python3 tools/check_governor_footer.py body.md --require-governor-footer \
    --changed-files "pyproject.toml"
Governor Footer violations (1): governor-changing PR is missing the '

The subprocess probes cost ~0.3s each. That is the price of asking a question the in-process suite
structurally cannot answer, which is why the file is scoped to wiring contracts rather than
behaviour. They carry the `slow` marker if you later want to deselect them.

**#330 stays open.** Its "blocks B/L/M" role is discharged, but leaving it open until those three
land keeps the dependency visible on the board.

## Independent Review

`codex-cli`, read-only, 1 round. **Confirmed the central claim** by reproducing it — post-import
mutation gives a `SlackNotificationAdapter` whose `_webhook_url` is still the class-body value —
and found two things this PR had missed. Both Fixed in `f602704`.

| R | Sev | Finding | Closure |
|---|-----|---------|---------|
| R1 | **HIGH** | The harness leaked the one thing it promised to block. Probes ran with `cwd=REPO_ROOT`, and `Settings` reads `env_file=".env"` **relative to the working directory** — so an untracked repo-root `.env` reached a probe called with `{}`. The docstring claimed isolation from "the developer's shell or `_env/.env`": the shell half was true, the `.env` half was not | **Fixed** |
| R2 | LOW | The `dynamodb` marker text named `DYNAMODB_ENDPOINT_URL`, but the endpoint is hardcoded at `test_dynamo_repository.py:30`. Anyone setting that variable would have been told the tests honour it | **Fixed** |

R1 is worth reading twice. It passed **only because this checkout has no `.env`** — a green that
depended on the developer's filesystem, which is precisely the failure class this harness was built
to prevent. Reproduced before the fix:

```text
# .env at the repo root naming a Discord webhook
resolve_in_env({}, ...) -> DiscordNotificationAdapter
                           https://discord.com/api/webhooks/999/LEAKED
```

After: `NoopNotificationClient`. Probes now run in an empty temp directory and reach the project via
`PYTHONPATH`; `cwd` is no longer where the code is, only where `.env` would be looked for.

The regression test asserts the **property** — the probe's working directory is neither the repo
root nor contains a `.env` — rather than planting a real `.env`, which would litter the repo root if
the test died. Confirmed it fails for the right reason: reverting `cwd` trips the `is_repo_root`
assertion, not an import error.

Final suite: **1585 passed, 42 skipped, 0 errors**.

## Governor Footer' block
```

`tools/check_governor_footer.py` matches the **whole path**. It has no section awareness at all —
any `pyproject.toml` edit triggers, including a comment. Dropping the two `tests/**`-only files
from the changed-file list returns `0 violations`, so `pyproject.toml` is the sole trigger.

So the documented rule and the enforced rule differ: the doc reads as section-scoped, the tool is
path-scoped. **Filed as a doc-accuracy finding for cluster J (#335)** — this is precisely the class
of drift the audit exists to catch, and it caught me writing this PR.

The markers stay. Removing them to dodge the ceremony would be optimising for process over the
codebase, and they are what stops `PytestUnknownMarkWarning` on the two markers this PR introduces.

## Governor Footer
- trigger: yes
- reviewer: codex-cli
- rounds: 1
- r-points-fixed: 2
- r-points-deferred: 0
- r-points-rejected: 0
- touched-adr-consequences: none
- pr-scope-notes: test-only apart from four lines registering pytest markers in pyproject.toml, which is what makes it Tier C. The harness it adds is a precondition for regression-pinning clusters B, L and M
- final-verdict: merge-ready
- links: https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/338, https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/330, https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/336
