### PR TITLE
fix(core): exception translation — log 5xx, gate the LLM mapper, curate provider errors

### DIFF
--- a/src/_core/exceptions/exception_handlers.py
+++ b/src/_core/exceptions/exception_handlers.py
@@ -13,6 +13,11 @@ from src._core.exceptions.base_exception import BaseCustomException
 
 _logger = structlog.stdlib.get_logger("src._core.exceptions")
 
+# Status at or above which a curated exception is also an operational event worth
+# an exception-level log record. Named rather than inlined so the worker path can
+# share the same boundary (see taskiq_middleware._synthetic_status_code).
+_SERVER_ERROR_FLOOR = 500
+
 
 def _dispatch_error_notification(
     request: Request, *, status_code: int, error_code: str, message: str
@@ -81,6 +86,19 @@ async def custom_exception_handler(
             error_details=exc.details,
         )
     )
+    # A curated 5xx still means something broke. Without this record the wrapped
+    # cause exists nowhere in stg/prod: the response is curated by design, the
+    # notification receives that same curated text, and ``details`` carries the
+    # original only when ``settings.is_dev``. Curated 4xx are normal traffic and
+    # stay unlogged — logging them at error level would bury this signal.
+    if exc.status_code >= _SERVER_ERROR_FLOOR:
+        _logger.exception(
+            "custom_exception",
+            exc_info=exc,
+            exception_type=type(exc).__name__,
+            error_code=exc.error_code,
+            status_code=exc.status_code,
+        )
     _dispatch_error_notification(
         request,
         status_code=exc.status_code,
@@ -97,6 +115,19 @@ async def generic_exception_handler(request: Request, exc: Exception) -> JSONRes
 
     mapped = try_map_llm_error(exc)
     if mapped is not None:
+        # Log before the early return. This branch used to bypass
+        # ``_logger.exception`` below, so a provider error — or, before the
+        # mapper was gated on provider modules, a *misclassified* ordinary
+        # exception — produced a 4xx with no trace anywhere. The original ``exc``
+        # is what matters here; ``mapped`` is a translation of it.
+        _logger.exception(
+            "mapped_provider_exception",
+            exc_info=exc,
+            exception_type=type(exc).__name__,
+            exception_module=type(exc).__module__,
+            mapped_error_code=mapped.error_code,
+            mapped_status_code=mapped.status_code,
+        )
         content = jsonable_encoder(
             ErrorResponse(
                 message=mapped.message,

--- a/src/_core/infrastructure/http/http_client.py
+++ b/src/_core/infrastructure/http/http_client.py
@@ -3,11 +3,72 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 import aiohttp
+import structlog
 
 from src._core.infrastructure.http.exceptions import (
     ExternalServiceException,
     ExternalServiceTimeoutException,
 )
+
+_logger = structlog.stdlib.get_logger(__name__)
+
+_DEFAULT_PORTS = frozenset({80, 443})
+
+
+def _safe_origin(exc: aiohttp.ClientError) -> str | None:
+    """``scheme://host[:port]`` for the failed request — path and query dropped.
+
+    The path is the secret half of a webhook URL (a Slack token lives in
+    ``/services/T/B/X``); the origin is not. Keeping the origin makes the log
+    actionable without re-introducing the leak that ``error_notifier.py`` avoids
+    deliberately: both webhook adapters POST through this client, so anything
+    logged here can be a credential.
+
+    Returns ``None`` for the errors that carry no request context at all
+    (``ClientPayloadError`` has neither ``request_info`` nor ``host``).
+    """
+    request_info = getattr(exc, "request_info", None)
+    url = getattr(request_info, "url", None)
+    if url is not None:
+        suffix = f":{url.port}" if url.port not in _DEFAULT_PORTS else ""
+        return f"{url.scheme}://{url.host}{suffix}"
+
+    # ClientConnectorError never got a response, so it exposes host/port instead.
+    host = getattr(exc, "host", None)
+    if host is not None:
+        port = getattr(exc, "port", None)
+        if port is None or port in _DEFAULT_PORTS:
+            return str(host)
+        return f"{host}:{port}"
+
+    return None
+
+
+def _curate_client_error(exc: aiohttp.ClientError) -> ExternalServiceException:
+    """Build the 502 for an aiohttp failure without copying its message.
+
+    ``f"External service error: {exc}"`` published request detail to the caller:
+    ``ClientResponseError`` renders the **full URL** and ``ClientConnectorError``
+    the internal ``host:port``. Verified on aiohttp 3.13.5::
+
+        403, message='Forbidden', url='https://hooks.slack.com/services/T/B/X'
+        Cannot connect to host internal-svc.prod:8443 ssl:default [None]
+
+    ``security-checklist.md`` §13 records that property for the log stream; it
+    applies just as much to a response body. The client now gets the failure
+    class and the upstream status; the origin goes to the log only.
+    """
+    status = getattr(exc, "status", None)
+    _logger.error(
+        "external_service_error",
+        exc_type=type(exc).__name__,
+        upstream_status=status,
+        origin=_safe_origin(exc),
+    )
+    detail = f"{type(exc).__name__}"
+    if status is not None:
+        detail = f"{detail} {status}"
+    return ExternalServiceException(message=f"External service error [{detail}]")
 
 
 def get_http_client_config(env: str):
@@ -70,10 +131,20 @@ class HttpClient:
         try:
             session = await self._ensure_session()
             yield session
+        # Order is load-bearing: on aiohttp 3.13.5 every timeout class
+        # (ServerTimeoutError, SocketTimeoutError, ConnectionTimeoutError)
+        # subclasses *both* TimeoutError and aiohttp.ClientError, so catching
+        # ClientError first made the 504 branch unreachable for all three — a
+        # timed-out upstream was reported as a 502.
+        except TimeoutError as e:
+            _logger.error(
+                "external_service_timeout",
+                exc_type=type(e).__name__,
+                origin=_safe_origin(e) if isinstance(e, aiohttp.ClientError) else None,
+            )
+            raise ExternalServiceTimeoutException() from e
         except aiohttp.ClientError as e:
-            raise ExternalServiceException(message=f"External service error: {e}")
-        except TimeoutError:
-            raise ExternalServiceTimeoutException()
+            raise _curate_client_error(e) from e
 
     async def dispose(self) -> None:
         if self._client_session and not self._client_session.closed:

--- a/src/_core/infrastructure/llm/error_mapper.py
+++ b/src/_core/infrastructure/llm/error_mapper.py
@@ -58,12 +58,51 @@ _NOT_FOUND_NAMES = frozenset(
 )
 
 
+_PROVIDER_MODULE_PREFIXES: tuple[str, ...] = (
+    "openai",
+    "anthropic",
+    "botocore",  # Bedrock — see _is_provider_exception
+    "boto3",
+    "pydantic_ai",
+    "google.api_core",
+    "google.genai",
+    "google.generativeai",
+)
+
+
+def _is_provider_exception(exc: Exception) -> bool:
+    """Did this exception come out of an LLM provider SDK?
+
+    This gate exists because the heuristics below match on message *text*, and
+    ``generic_exception_handler`` hands this function **every** unhandled
+    application exception. Ungated, that mapped ordinary failures to LLM 4xx:
+    ``KeyError("unauthorized")`` became a 401, ``RuntimeError("S3 bucket
+    model-artifacts not found")`` a 404. Both are genuine 5xx, and being 4xx
+    they also skipped the exception log and the error notification — so the
+    misclassification left no trace anywhere.
+
+    Bedrock is the case that shapes this. Its exceptions are generated at
+    runtime by botocore, so they are not importable and cannot be matched by
+    identity — but they do carry ``__module__ == "botocore.errorfactory"`` and
+    ``botocore.exceptions.ClientError`` in their MRO. Module prefix alone is
+    enough; the MRO is not consulted, which keeps this free of a botocore import.
+    """
+    module = type(exc).__module__ or ""
+    return any(
+        module == prefix or module.startswith(f"{prefix}.")
+        for prefix in _PROVIDER_MODULE_PREFIXES
+    )
+
+
 def _classify(exc: Exception) -> LLMException | None:
     """Classify an exception as a known LLM provider error.
 
     Returns a domain LLMException instance, or None if the exception is not
     a recognisable provider error (caller should treat it as a generic 500).
     """
+    if not _is_provider_exception(exc):
+        return None
+
     type_name = type(exc).__name__.lower().replace("_", "")
     error_str = str(exc).lower()
 

--- a/src/_core/infrastructure/llm/error_mapper.py
+++ b/src/_core/infrastructure/llm/error_mapper.py
@@ -61,12 +61,27 @@ _NOT_FOUND_NAMES = frozenset(
 _PROVIDER_MODULE_PREFIXES: tuple[str, ...] = (
     "openai",
     "anthropic",
-    "botocore",  # Bedrock — see _is_provider_exception
-    "boto3",
     "pydantic_ai",
     "google.api_core",
     "google.genai",
     "google.generativeai",
+)
+
+# Bedrock cannot be matched by module: botocore is shared by *every* AWS client,
+# so `botocore.*` would readmit exactly the misclassification this gate exists to
+# stop — a real S3 `GetObject` failure whose message contains "unauthorized"
+# became a 401 `LLM_AUTH_FAILED`, and a DynamoDB `Query` throttle became a 429.
+# `botocore.errorfactory` does not separate them either: `s3.exceptions.NoSuchKey`
+# and `bedrock-runtime`'s `ThrottlingException` are both generated into that same
+# module. What *does* separate them is the operation, which every `ClientError`
+# carries (dynamically generated subclasses included).
+_BEDROCK_MODEL_OPERATIONS = frozenset(
+    {
+        "InvokeModel",
+        "InvokeModelWithResponseStream",
+        "Converse",
+        "ConverseStream",
+    }
 )
 
 
@@ -81,13 +96,17 @@ def _is_provider_exception(exc: Exception) -> bool:
     they also skipped the exception log and the error notification — so the
     misclassification left no trace anywhere.
 
-    Bedrock is the case that shapes this. Its exceptions are generated at
-    runtime by botocore, so they are not importable and cannot be matched by
-    identity — but they do carry ``__module__ == "botocore.errorfactory"`` and
-    ``botocore.exceptions.ClientError`` in their MRO. Module prefix alone is
-    enough; the MRO is not consulted, which keeps this free of a botocore import.
+    Bedrock is the case that shapes this, and it is why the botocore branch is
+    keyed on the operation rather than the module. See
+    ``_BEDROCK_MODEL_OPERATIONS`` — a module test cannot tell a Bedrock
+    ``InvokeModel`` failure from an S3 or DynamoDB one.
     """
     module = type(exc).__module__ or ""
+    if module == "botocore" or module.startswith("botocore."):
+        # Only a model-invocation call is an LLM error. `operation_name` is set
+        # by `ClientError.__init__`, so it is present on the dynamic subclasses
+        # too; anything without it is not a `ClientError` and not ours.
+        return getattr(exc, "operation_name", None) in _BEDROCK_MODEL_OPERATIONS
     return any(
         module == prefix or module.startswith(f"{prefix}.")
         for prefix in _PROVIDER_MODULE_PREFIXES

--- a/src/_core/infrastructure/persistence/nosql/dynamodb/dynamodb_client.py
+++ b/src/_core/infrastructure/persistence/nosql/dynamodb/dynamodb_client.py
@@ -75,17 +75,23 @@ class DynamoDBClient:
                 yield dynamodb_client
         except ClientError as e:
             error_code = e.response.get("Error", {}).get("Code", "Unknown")
-            error_message = e.response.get("Error", {}).get("Message", str(e))
 
             if error_code == "ConditionalCheckFailedException":
                 raise DynamoDBConditionFailedException(error_code) from e
             if error_code in _THROTTLE_CODES:
                 raise DynamoDBThrottlingException() from e
 
+            # The provider message is deliberately NOT a structlog kwarg:
+            # security-checklist.md:194 requires kwargs carry no sensitive
+            # fields, and an AWS `Error.Message` names the calling IAM principal
+            # ARN (embedding the account id) plus the table/bucket/key. The
+            # `from e` chain below still carries the full text, which is where
+            # `custom_exception_handler` renders it via `exc_info` — the log is
+            # the one sink that is allowed to have it.
             _logger.error(
                 "dynamodb_operation_failed",
                 error_code=error_code,
-                error_message=error_message,
+                provider_exception_type=type(e).__name__,
             )
             raise DynamoDBException(
                 status_code=500,

--- a/src/_core/infrastructure/storage/object_storage.py
+++ b/src/_core/infrastructure/storage/object_storage.py
@@ -3,8 +3,12 @@ from __future__ import annotations
 from io import BytesIO
 from typing import TYPE_CHECKING, BinaryIO
 
+import structlog
+
 from src._core.exceptions.base_exception import BaseCustomException
 from src._core.infrastructure.storage.object_storage_client import ObjectStorageClient
+
+_logger = structlog.stdlib.get_logger(__name__)
 
 if TYPE_CHECKING:
     from botocore.exceptions import ClientError
@@ -20,6 +24,48 @@ else:
         # — so this fallback never actually catches an exception.
         class ClientError(Exception):
             pass
+
+
+def _error_code(exc: ClientError) -> str:
+    """``Error.Code`` off a botocore error, tolerating a malformed response.
+
+    ``.get()`` rather than ``e.response["Error"]["Code"]``: the subscript form
+    used here previously raises ``KeyError`` inside an ``except`` block for any
+    error whose response lacks the key, replacing the real storage failure with
+    an unrelated traceback. Mirrors ``dynamodb_client.py``.
+    """
+    response = getattr(exc, "response", None) or {}
+    return response.get("Error", {}).get("Code", "Unknown")
+
+
+def _storage_failure(operation: str, exc: ClientError) -> BaseCustomException:
+    """Curate a botocore storage error into a 500 that omits its message.
+
+    ``f"Storage {op} failed: {e}"`` copied the provider text into the response
+    body. A boto3 ``AccessDenied`` message names the calling IAM principal ARN
+    (which embeds the 12-digit AWS account id), the bucket and the key::
+
+        An error occurred (AccessDenied) when calling the PutObject operation:
+        User: arn:aws:sts::123456789012:assumed-role/app-runtime/session is not
+        authorized to perform: s3:PutObject on resource: arn:aws:s3:::bucket/key
+
+    The client now gets the operation and the error code; the provider message
+    goes to the log. Same split as ``dynamodb_client.py`` and
+    ``vectors/s3/client.py``, which are the house pattern for this.
+    """
+    code = _error_code(exc)
+    response = getattr(exc, "response", None) or {}
+    _logger.error(
+        "storage_operation_failed",
+        operation=operation,
+        error_code=code,
+        error_message=response.get("Error", {}).get("Message", str(exc)),
+    )
+    return BaseCustomException(
+        status_code=500,
+        message=f"Storage {operation} failed [{code}]",
+        error_code="STORAGE_OPERATION_FAILED",
+    )
 
 
 class ObjectStorage:
@@ -50,9 +96,7 @@ class ObjectStorage:
                 )
                 return key
         except ClientError as e:
-            raise BaseCustomException(
-                status_code=500, message=f"Storage upload failed: {e}"
-            )
+            raise _storage_failure("upload", e) from e
 
     async def download_file(self, key: str) -> bytes:
         """Download a file."""
@@ -62,13 +106,13 @@ class ObjectStorage:
                 async with response["Body"] as stream:
                     return await stream.read()
         except ClientError as e:
-            if e.response["Error"]["Code"] == "NoSuchKey":
+            if _error_code(e) == "NoSuchKey":
                 raise BaseCustomException(
-                    status_code=404, message=f"File not found: {key}"
-                )
-            raise BaseCustomException(
-                status_code=500, message=f"Storage download failed: {e}"
-            )
+                    status_code=404,
+                    message=f"File not found: {key}",
+                    error_code="STORAGE_FILE_NOT_FOUND",
+                ) from e
+            raise _storage_failure("download", e) from e
 
     async def delete_file(self, key: str) -> bool:
         """Delete a file."""
@@ -77,9 +121,7 @@ class ObjectStorage:
                 await client.delete_object(Bucket=self.bucket_name, Key=key)
                 return True
         except ClientError as e:
-            raise BaseCustomException(
-                status_code=500, message=f"Storage delete failed: {e}"
-            )
+            raise _storage_failure("delete", e) from e
 
     async def file_exists(self, key: str) -> bool:
         """Check whether a file exists."""
@@ -88,11 +130,12 @@ class ObjectStorage:
                 await client.head_object(Bucket=self.bucket_name, Key=key)
                 return True
         except ClientError as e:
-            if e.response["Error"]["Code"] == "404":
+            # "404" and not "NoSuchKey": HEAD has no response body, so botocore
+            # falls back to the HTTP status as the error code. Unchanged from
+            # before — only the extraction is now KeyError-safe.
+            if _error_code(e) == "404":
                 return False
-            raise BaseCustomException(
-                status_code=500, message=f"Storage check failed: {e}"
-            )
+            raise _storage_failure("check", e) from e
 
     async def get_file_url(self, key: str, expires_in: int = 3600) -> str:
         """Generate a presigned URL for a file."""
@@ -105,9 +148,7 @@ class ObjectStorage:
                 )
                 return url
         except ClientError as e:
-            raise BaseCustomException(
-                status_code=500, message=f"Storage presigned URL generation failed: {e}"
-            )
+            raise _storage_failure("presigned URL generation", e) from e
 
     async def list_files(self, prefix: str = "") -> list[str]:
         """List files."""
@@ -120,6 +161,4 @@ class ObjectStorage:
                     return []
                 return [obj["Key"] for obj in response["Contents"]]
         except ClientError as e:
-            raise BaseCustomException(
-                status_code=500, message=f"Storage list failed: {e}"
-            )
+            raise _storage_failure("list", e) from e

--- a/src/_core/infrastructure/storage/object_storage.py
+++ b/src/_core/infrastructure/storage/object_storage.py
@@ -54,12 +54,16 @@ def _storage_failure(operation: str, exc: ClientError) -> BaseCustomException:
     ``vectors/s3/client.py``, which are the house pattern for this.
     """
     code = _error_code(exc)
-    response = getattr(exc, "response", None) or {}
+    # The provider message is deliberately NOT a structlog kwarg — see the note
+    # in dynamodb_client.py. An S3 `Error.Message` is the worst case of the
+    # family: besides the IAM principal ARN and account id it names the object
+    # key, which for a user-uploaded file is often itself personal data. The
+    # `from e` chain still carries the text for `exc_info` rendering.
     _logger.error(
         "storage_operation_failed",
         operation=operation,
         error_code=code,
-        error_message=response.get("Error", {}).get("Message", str(exc)),
+        provider_exception_type=type(exc).__name__,
     )
     return BaseCustomException(
         status_code=500,

--- a/src/_core/infrastructure/vectors/s3/client.py
+++ b/src/_core/infrastructure/vectors/s3/client.py
@@ -70,17 +70,23 @@ class S3VectorClient:
                 yield s3v_client
         except ClientError as e:
             error_code = e.response.get("Error", {}).get("Code", "Unknown")
-            error_message = e.response.get("Error", {}).get("Message", str(e))
 
             if error_code == "NotFoundException":
                 raise S3VectorIndexNotFoundException() from e
             if error_code == "TooManyRequestsException":
                 raise S3VectorThrottlingException() from e
 
+            # The provider message is deliberately NOT a structlog kwarg:
+            # security-checklist.md:194 requires kwargs carry no sensitive
+            # fields, and an AWS `Error.Message` names the calling IAM principal
+            # ARN (embedding the account id) plus the table/bucket/key. The
+            # `from e` chain below still carries the full text, which is where
+            # `custom_exception_handler` renders it via `exc_info` — the log is
+            # the one sink that is allowed to have it.
             _logger.error(
                 "s3vectors_operation_failed",
                 error_code=error_code,
-                error_message=error_message,
+                provider_exception_type=type(e).__name__,
             )
             raise S3VectorException(
                 status_code=500,

--- a/tests/unit/_core/exceptions/test_exception_handler_logging.py
+++ b/tests/unit/_core/exceptions/test_exception_handler_logging.py
@@ -1,0 +1,161 @@
+"""A 5xx must leave an exception-level log record (#323).
+
+Probed at `d5c2a1d`: `custom_exception_handler` made no logger call at all, and
+`generic_exception_handler` logged only on the *unmapped* path — the
+`try_map_llm_error` branch returned first. Meanwhile `Database.session()` puts
+the original driver error into `details` only when `settings.is_dev`.
+
+So in stg/prod a 500 reached the client with the wrapped error in **none** of:
+the response body, `details`, any log record, or the Slack alert (which receives
+the curated `"500 [DB_INTERNAL_ERROR]: Internal database error"`). The only
+surviving record was `RequestLogMiddleware`'s `http_request` line, which carries
+status and duration but no exception identity.
+
+12 of the 14 `5xx` raise sites under `src/` do not log before raising. The two
+that do — `dynamodb_client` and `vectors/s3/client` — are the house pattern.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+from structlog.testing import capture_logs
+
+from src._core.exceptions.base_exception import BaseCustomException
+from src._core.exceptions.exception_handlers import (
+    custom_exception_handler,
+    generic_exception_handler,
+    http_exception_handler,
+)
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+    app.add_exception_handler(BaseCustomException, custom_exception_handler)
+    app.add_exception_handler(HTTPException, http_exception_handler)
+    app.add_exception_handler(Exception, generic_exception_handler)
+
+    @app.get("/custom/{status}")
+    async def _custom(status: int):
+        raise BaseCustomException(
+            status_code=status, message="curated text", error_code="DB_INTERNAL_ERROR"
+        )
+
+    @app.get("/mapped")
+    async def _mapped():
+        provider = type("APIStatusError", (Exception,), {})
+        provider.__module__ = "openai"
+        raise provider("Rate limit reached for gpt-4o")
+
+    @app.get("/raw")
+    async def _raw():
+        raise RuntimeError("deadlock detected on relation users")
+
+    return app
+
+
+def _exception_records(logs: list[dict]) -> list[dict]:
+    """Records that carry exception identity — the thing an operator greps for."""
+    return [
+        r
+        for r in logs
+        if r.get("log_level") in {"error", "critical"}
+        or r.get("exc_info")
+        or "exception" in str(r.get("event", ""))
+    ]
+
+
+class TestFiveHundredIsLogged:
+    @pytest.mark.parametrize("status", [500, 502, 503])
+    def test_custom_exception_5xx_produces_an_exception_record(self, status):
+        client = TestClient(_app(), raise_server_exceptions=False)
+        with capture_logs() as logs:
+            resp = client.get(f"/custom/{status}")
+        assert resp.status_code == status
+        records = _exception_records(logs)
+        assert records, (
+            f"a {status} left no exception-level log record — the wrapped driver "
+            "error exists nowhere in stg/prod"
+        )
+        assert any("DB_INTERNAL_ERROR" in str(r) for r in records), (
+            "the log record does not carry the error_code"
+        )
+
+    def test_mapped_provider_error_is_logged_before_the_early_return(self):
+        """The `try_map_llm_error` branch returned before `_logger.exception`, so a
+        misclassification was invisible. Even a correctly mapped 429 should leave
+        a record naming the original exception."""
+        client = TestClient(_app(), raise_server_exceptions=False)
+        with capture_logs() as logs:
+            resp = client.get("/mapped")
+        assert resp.status_code == 429
+        records = _exception_records(logs)
+        assert records, "a mapped provider error left no log record"
+        assert any("APIStatusError" in str(r) or "openai" in str(r) for r in records), (
+            "the record does not identify the original provider exception"
+        )
+
+    def test_unmapped_exception_still_logs(self):
+        client = TestClient(_app(), raise_server_exceptions=False)
+        with capture_logs() as logs:
+            resp = client.get("/raw")
+        assert resp.status_code == 500
+        assert _exception_records(logs)
+
+
+class TestFourXXIsNotLoggedAsAnException:
+    """Curated 4xx are normal traffic. Logging them at error level would drown the
+    signal this change exists to create."""
+
+    @pytest.mark.parametrize("status", [400, 401, 404, 409])
+    def test_custom_exception_4xx_produces_no_exception_record(self, status):
+        client = TestClient(_app(), raise_server_exceptions=False)
+        with capture_logs() as logs:
+            resp = client.get(f"/custom/{status}")
+        assert resp.status_code == status
+        assert not _exception_records(logs), (
+            f"a curated {status} was logged at exception level"
+        )
+
+
+class TestResponseBodyIsUnchanged:
+    """`security-checklist.md:181-185` mandates that prod responses stay curated.
+    This change adds a log record; it must not widen what the client sees."""
+
+    def test_error_details_stay_absent(self):
+        client = TestClient(_app(), raise_server_exceptions=False)
+        resp = client.get("/custom/500")
+        body = resp.json()
+        assert body["message"] == "curated text"
+        assert body["errorCode"] == "DB_INTERNAL_ERROR"
+        assert body.get("errorDetails") is None
+
+    def test_raw_exception_text_does_not_reach_the_client_outside_dev(
+        self, monkeypatch
+    ):
+        """`generic_exception_handler` puts `traceback.format_exc()` into
+        `errorDetails` when `settings.is_dev` — documented and deliberate
+        (ADR 017). Outside dev it must not, and adding the log record must not
+        change that in either direction.
+        """
+        from src._core import config
+
+        monkeypatch.setattr(type(config.settings), "is_dev", property(lambda _: False))
+        client = TestClient(_app(), raise_server_exceptions=False)
+        resp = client.get("/raw")
+        assert resp.status_code == 500
+        assert "deadlock" not in resp.text, (
+            "the raw driver message reached the response body outside dev"
+        )
+        assert resp.json()["errorDetails"] is None
+
+    def test_dev_still_gets_the_trace(self, monkeypatch):
+        """The other half of the same contract — this is why the assertion above
+        has to be environment-scoped rather than absolute."""
+        from src._core import config
+
+        monkeypatch.setattr(type(config.settings), "is_dev", property(lambda _: True))
+        client = TestClient(_app(), raise_server_exceptions=False)
+        resp = client.get("/raw")
+        assert "deadlock" in resp.text

--- a/tests/unit/_core/exceptions/test_exception_handler_logging.py
+++ b/tests/unit/_core/exceptions/test_exception_handler_logging.py
@@ -11,8 +11,11 @@ the curated `"500 [DB_INTERNAL_ERROR]: Internal database error"`). The only
 surviving record was `RequestLogMiddleware`'s `http_request` line, which carries
 status and duration but no exception identity.
 
-12 of the 14 `5xx` raise sites under `src/` do not log before raising. The two
-that do — `dynamodb_client` and `vectors/s3/client` — are the house pattern.
+Most `5xx` raise sites under `src/` do not log before raising. The audit counted
+15 of 17; a narrower AST sweep run while fixing this counted 12 of 14. The exact
+figure depends on how the sweep decides a `raise` is a 5xx, so treat it as "most
+of them". Either way the two that *do* log — `dynamodb_client` and
+`vectors/s3/client` — are the house pattern this change aligns with.
 """
 
 from __future__ import annotations

--- a/tests/unit/_core/infrastructure/llm/test_error_mapper.py
+++ b/tests/unit/_core/infrastructure/llm/test_error_mapper.py
@@ -124,7 +124,7 @@ class TestProviderExceptionsStillMap:
 
     @pytest.mark.parametrize(
         "module",
-        ["openai", "anthropic", "botocore.errorfactory", "pydantic_ai.exceptions"],
+        ["openai", "anthropic", "pydantic_ai.exceptions"],
     )
     def test_every_supported_provider_module_is_recognised(self, module):
         mapped = try_map_llm_error(
@@ -138,9 +138,11 @@ class TestProviderExceptionsStillMap:
         """Bedrock errors are generated at runtime by botocore, so they carry
         `__module__ == 'botocore.errorfactory'` and `ClientError` in their MRO.
 
-        This is the case that decided the fix's shape: an earlier probe read the
-        *metaclass* module and reported `builtins`, which would have made module
-        gating look unusable for the one provider that matters most here.
+        Two probes shaped this test. An earlier one read the *metaclass* module
+        and reported `builtins`, which made module gating look unusable here. A
+        cross-review then showed module gating is not merely awkward but wrong:
+        S3's dynamic exceptions land in the same `botocore.errorfactory`, so the
+        gate keys on `operation_name` instead — see the class below.
         """
         botocore = pytest.importorskip("botocore")
         from botocore.session import get_session
@@ -167,3 +169,58 @@ class TestUnrecognisedProviderErrorFallsThrough:
         """A provider error the mapper cannot classify must return None so the
         caller produces a logged, alerted 500 — not a guessed 4xx."""
         assert try_map_llm_error(_provider_exc("APIError", "internal error")) is None
+
+
+class TestBotocoreIsGatedOnTheOperationNotTheModule:
+    """A cross-review caught that `botocore` as a module prefix readmits the very
+    bug this gate exists to stop. Every AWS client raises
+    `botocore.exceptions.ClientError`, and the dynamic subclasses for S3 and
+    Bedrock are generated into the *same* `botocore.errorfactory` module — so
+    neither module test separates them. Verified:
+
+        s3.exceptions.NoSuchKey.__module__                 == 'botocore.errorfactory'
+        bedrock.exceptions.ThrottlingException.__module__  == 'botocore.errorfactory'
+
+    `operation_name` does separate them, and `ClientError.__init__` sets it on the
+    dynamically generated subclasses too.
+    """
+
+    @staticmethod
+    def _client_error(code: str, message: str, operation: str):
+        from botocore.exceptions import ClientError
+
+        return ClientError({"Error": {"Code": code, "Message": message}}, operation)
+
+    @pytest.mark.parametrize(
+        "code,message,operation",
+        [
+            ("AccessDenied", "unauthorized request to bucket", "GetObject"),
+            ("AccessDenied", "unauthorized", "PutObject"),
+            ("ThrottlingException", "Rate exceeded", "Query"),
+            ("ThrottlingException", "throttling, slow down", "PutItem"),
+            ("ValidationException", "model artifacts not found", "ListBuckets"),
+        ],
+        ids=["s3-get", "s3-put", "dynamo-query", "dynamo-put", "s3-list"],
+    )
+    def test_non_bedrock_aws_error_is_not_an_llm_error(self, code, message, operation):
+        exc = self._client_error(code, message, operation)
+        assert try_map_llm_error(exc) is None, (
+            f"a {operation} failure was classified as an LLM error — the same "
+            "misclassification this gate exists to stop, reopened for AWS"
+        )
+
+    @pytest.mark.parametrize(
+        "operation",
+        ["InvokeModel", "InvokeModelWithResponseStream", "Converse", "ConverseStream"],
+    )
+    def test_bedrock_model_operation_still_maps(self, operation):
+        exc = self._client_error("ThrottlingException", "Rate exceeded", operation)
+        assert isinstance(try_map_llm_error(exc), LLMRateLimitException)
+
+    def test_botocore_module_without_an_operation_name_is_not_mapped(self):
+        """A non-`ClientError` botocore exception has no `operation_name`, so it
+        must not slip through the botocore branch."""
+        exc = _provider_exc(
+            "EndpointConnectionError", "rate limit", module="botocore.exceptions"
+        )
+        assert try_map_llm_error(exc) is None

--- a/tests/unit/_core/infrastructure/llm/test_error_mapper.py
+++ b/tests/unit/_core/infrastructure/llm/test_error_mapper.py
@@ -1,0 +1,169 @@
+"""Contract tests for the LLM provider exception mapper (#323).
+
+This module had **no tests**, and it is reached from
+`generic_exception_handler` for *every* unhandled application exception. Its
+message-substring heuristics therefore classified exceptions that have nothing
+to do with an LLM provider. Probed at `d5c2a1d`:
+
+    KeyError("unauthorized")                        -> 401 LLM_AUTH_FAILED
+    RuntimeError("S3 bucket model-artifacts not found") -> 404 LLM_MODEL_NOT_FOUND
+    TimeoutError("... after rate limit backoff")     -> 429 LLM_RATE_LIMITED
+
+Each of those is a genuine 5xx returned to the client as a 4xx, which also
+skips both `_logger.exception` and the error notification — so the
+misclassification leaves no trace anywhere.
+
+The fix gates classification on the exception actually originating from a
+provider SDK. These tests pin both directions: provider errors still map, and
+nothing else does.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src._core.exceptions.llm_exceptions import (
+    LLMAuthenticationException,
+    LLMContextLengthExceededException,
+    LLMModelNotFoundException,
+    LLMRateLimitException,
+)
+from src._core.infrastructure.llm.error_mapper import try_map_llm_error
+
+
+def _provider_exc(name: str, message: str, module: str = "openai"):
+    """Build an exception that looks like it came from a provider SDK.
+
+    Real provider classes are not importable here (`openai`, `anthropic` and
+    `pydantic_ai` are optional extras), so the module is set explicitly — which
+    is exactly the attribute the mapper gates on.
+    """
+    cls = type(name, (Exception,), {})
+    cls.__module__ = module
+    return cls(message)
+
+
+class TestNonProviderExceptionsAreNeverMapped:
+    """The regression this file exists for. Every case here reached a 4xx before."""
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            KeyError("unauthorized"),
+            RuntimeError("S3 bucket model-artifacts not found"),
+            TimeoutError("connection timed out after rate limit backoff"),
+            ValueError("throttling the ingest queue"),
+            OSError("authentication database unreachable"),
+            RuntimeError("context length of the audit log window exceeded"),
+        ],
+        ids=[
+            "keyerror-unauthorized",
+            "runtimeerror-model-not-found",
+            "timeouterror-rate-limit",
+            "valueerror-throttling",
+            "oserror-authentication",
+            "runtimeerror-context-length",
+        ],
+    )
+    def test_builtin_exception_is_not_an_llm_error(self, exc):
+        assert try_map_llm_error(exc) is None, (
+            f"{type(exc).__name__}({exc!r}) was classified as an LLM error — it "
+            "would be returned to the client as a 4xx, unlogged and unalerted"
+        )
+
+    def test_application_exception_is_not_mapped(self):
+        from src._core.exceptions.base_exception import BaseCustomException
+
+        exc = BaseCustomException(
+            status_code=500, message="rate limit on the audit writer"
+        )
+        assert try_map_llm_error(exc) is None
+
+
+class TestProviderExceptionsStillMap:
+    """Precision must not cost the coverage the mapper exists for."""
+
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            ("RateLimitError", LLMRateLimitException),
+            ("ThrottlingException", LLMRateLimitException),
+            ("AuthenticationError", LLMAuthenticationException),
+            ("PermissionDeniedError", LLMAuthenticationException),
+            ("ContextLengthExceeded", LLMContextLengthExceededException),
+            ("ModelNotFoundError", LLMModelNotFoundException),
+        ],
+    )
+    def test_provider_class_name_maps(self, name, expected):
+        mapped = try_map_llm_error(_provider_exc(name, "upstream said no"))
+        assert isinstance(mapped, expected)
+
+    @pytest.mark.parametrize(
+        "message,expected",
+        [
+            ("Rate limit reached for gpt-4o", LLMRateLimitException),
+            ("ThrottlingException: too fast", LLMRateLimitException),
+            ("invalid authentication credentials", LLMAuthenticationException),
+            ("unauthorized: bad key", LLMAuthenticationException),
+            (
+                "This model's maximum context length is 8192",
+                LLMContextLengthExceededException,
+            ),
+            (
+                "The model gpt-9 does not exist / model not found",
+                LLMModelNotFoundException,
+            ),
+        ],
+    )
+    def test_provider_message_still_maps(self, message, expected):
+        """A provider error whose class name is not in the known sets is still
+        classified from its message — that is the heuristic's purpose. It is now
+        scoped to provider exceptions instead of applying to everything."""
+        mapped = try_map_llm_error(_provider_exc("APIStatusError", message))
+        assert isinstance(mapped, expected)
+
+    @pytest.mark.parametrize(
+        "module",
+        ["openai", "anthropic", "botocore.errorfactory", "pydantic_ai.exceptions"],
+    )
+    def test_every_supported_provider_module_is_recognised(self, module):
+        mapped = try_map_llm_error(
+            _provider_exc("APIError", "Rate limit exceeded", module=module)
+        )
+        assert isinstance(mapped, LLMRateLimitException), (
+            f"exceptions from {module} are not recognised as provider errors"
+        )
+
+    def test_bedrock_dynamic_exception_is_recognised(self):
+        """Bedrock errors are generated at runtime by botocore, so they carry
+        `__module__ == 'botocore.errorfactory'` and `ClientError` in their MRO.
+
+        This is the case that decided the fix's shape: an earlier probe read the
+        *metaclass* module and reported `builtins`, which would have made module
+        gating look unusable for the one provider that matters most here.
+        """
+        botocore = pytest.importorskip("botocore")
+        from botocore.session import get_session
+
+        client = get_session().create_client(
+            "bedrock-runtime",
+            region_name="us-east-1",
+            aws_access_key_id="x",
+            aws_secret_access_key="y",
+        )
+        throttling = client.exceptions.ThrottlingException
+        assert throttling.__module__.startswith("botocore")
+        assert issubclass(throttling, botocore.exceptions.ClientError)
+
+        exc = throttling(
+            {"Error": {"Code": "ThrottlingException", "Message": "slow down"}},
+            "InvokeModel",
+        )
+        assert isinstance(try_map_llm_error(exc), LLMRateLimitException)
+
+
+class TestUnrecognisedProviderErrorFallsThrough:
+    def test_provider_exception_with_no_signal_returns_none(self):
+        """A provider error the mapper cannot classify must return None so the
+        caller produces a logged, alerted 500 — not a guessed 4xx."""
+        assert try_map_llm_error(_provider_exc("APIError", "internal error")) is None

--- a/tests/unit/_core/infrastructure/test_provider_error_curation.py
+++ b/tests/unit/_core/infrastructure/test_provider_error_curation.py
@@ -189,3 +189,71 @@ class TestTimeoutStillMapsTo504:
             "aiohttp timeout classes subclass ClientError too, so ClientError "
             "first makes ExternalServiceTimeoutException unreachable"
         )
+
+
+class TestProviderMessageStaysOutOfStructlogKwargs:
+    """`security-checklist.md:194` — "structlog kwargs / bind do not carry
+    sensitive fields".
+
+    A cross-review of the first version of this change proposed suppressing the
+    provider text from logs entirely, via `from None`. That conflicts with the
+    other half of #323: `custom_exception_handler` now logs a 5xx with
+    `exc_info`, and the whole point is that the wrapped cause has nowhere else to
+    live. So the split is deliberate — the **kwargs** stay clean, and the
+    exception chain keeps the text for the traceback.
+
+    These tests assert exactly that, and no more. An absolute "the ARN is not in
+    the log output" assertion would be false, because the chained
+    `__cause__` renders it.
+    """
+
+    def _kwargs_only(self, logs: list[dict]) -> str:
+        """Rendered structured fields, excluding the exception chain."""
+        return repr(
+            [
+                {k: v for k, v in rec.items() if k not in {"exc_info", "exception"}}
+                for rec in logs
+            ]
+        )
+
+    async def test_storage_failure_kwargs_carry_no_arn_key_or_account(self):
+        from structlog.testing import capture_logs
+
+        from src._core.infrastructure.storage.object_storage import ObjectStorage
+
+        class _FailingClient:
+            def client(self):
+                raise _access_denied()
+
+        storage = ObjectStorage(storage_client=_FailingClient(), bucket_name=BUCKET)
+        with capture_logs() as logs:
+            with pytest.raises(BaseCustomException):
+                await storage.upload_file(b"x", KEY, "text/plain")
+
+        rendered = self._kwargs_only(logs)
+        assert logs, "the storage failure produced no log record at all"
+        for secret, label in (
+            (ARN, "IAM ARN"),
+            (ACCOUNT, "account id"),
+            (KEY, "object key"),
+        ):
+            assert secret not in rendered, (
+                f"the {label} is a structlog kwarg: {rendered}"
+            )
+        assert "AccessDenied" in rendered, "the error code must still be logged"
+        assert "ClientError" in rendered, (
+            "the provider exception type must still be logged"
+        )
+
+    def test_the_exception_chain_still_carries_the_cause(self):
+        """The other half of the contract — deliberately asserting the text IS
+        reachable, so a future change cannot quietly drop the cause that F1
+        exists to surface."""
+        from src._core.infrastructure.storage.object_storage import _storage_failure
+
+        original = _access_denied()
+        try:
+            raise _storage_failure("upload", original) from original
+        except BaseCustomException as exc:
+            assert exc.__cause__ is original
+            assert ARN in str(exc.__cause__)

--- a/tests/unit/_core/infrastructure/test_provider_error_curation.py
+++ b/tests/unit/_core/infrastructure/test_provider_error_curation.py
@@ -1,0 +1,191 @@
+"""Raw provider exception text must not reach a response body (#323).
+
+`dynamodb_client.py:76-92` is the house pattern: pull `Error.Code` out, log the
+raw provider message via structlog, and raise a curated exception carrying the
+code but not the text. `vectors/s3/client.py` does the same.
+
+Two modules did not. Both interpolate the provider exception straight into the
+message a client receives:
+
+- `object_storage.py` — all **six** `except ClientError` blocks. A boto3
+  `AccessDenied` message names the calling IAM principal ARN (which embeds the
+  12-digit account id), the bucket and the key.
+- `http_client.py:73` — `f"External service error: {e}"`. Verified that
+  aiohttp puts the full URL in `ClientResponseError` and the host:port in
+  `ClientConnectorError`:
+
+      403, message='Forbidden', url='https://hooks.slack.com/services/T/B/SECRET'
+      Cannot connect to host internal-svc.prod:8443 ssl:default [None]
+
+  `security-checklist.md` §13 already records that property for the log stream —
+  it applies just as much to a response body, and for a notification webhook the
+  URL *is* the credential.
+"""
+
+from __future__ import annotations
+
+import aiohttp
+import pytest
+from botocore.exceptions import ClientError
+from yarl import URL
+
+from src._core.exceptions.base_exception import BaseCustomException
+
+ACCOUNT = "123456789012"
+ARN = f"arn:aws:sts::{ACCOUNT}:assumed-role/app-runtime/session"
+BUCKET = "prod-customer-uploads"
+KEY = "tenant-77/invoice-2026-08.pdf"
+WEBHOOK = "https://hooks.slack.com/services/T/B/SECRET"
+
+
+def _access_denied() -> ClientError:
+    return ClientError(
+        {
+            "Error": {
+                "Code": "AccessDenied",
+                "Message": (
+                    f"User: {ARN} is not authorized to perform: s3:PutObject "
+                    f"on resource: arn:aws:s3:::{BUCKET}/{KEY}"
+                ),
+            }
+        },
+        "PutObject",
+    )
+
+
+class TestObjectStorageDoesNotLeakProviderText:
+    """Every `except ClientError` in `object_storage.py`."""
+
+    @pytest.fixture
+    def storage(self):
+        from src._core.infrastructure.storage.object_storage import ObjectStorage
+
+        class _FailingClient:
+            def client(self):
+                raise _access_denied()
+
+        return ObjectStorage(storage_client=_FailingClient(), bucket_name=BUCKET)
+
+    @pytest.mark.parametrize(
+        "call",
+        [
+            lambda s: s.upload_file(b"x", "k", "text/plain"),
+            lambda s: s.download_file("k"),
+            lambda s: s.delete_file("k"),
+            lambda s: s.file_exists("k"),
+            lambda s: s.get_file_url("k"),
+            lambda s: s.list_files(),
+        ],
+        ids=["upload", "download", "delete", "exists", "presigned", "list"],
+    )
+    async def test_no_operation_leaks_the_arn_or_key(self, storage, call):
+        with pytest.raises(BaseCustomException) as info:
+            await call(storage)
+
+        rendered = str(info.value) + str(info.value.message)
+        for secret, label in (
+            (ARN, "IAM principal ARN"),
+            (ACCOUNT, "AWS account id"),
+            (KEY, "object key"),
+        ):
+            assert secret not in rendered, (
+                f"the {label} reached the client-visible message: {rendered!r}"
+            )
+
+    async def test_the_error_code_is_still_surfaced(self, storage):
+        """Curating must not mean saying nothing — the operator needs the code."""
+        with pytest.raises(BaseCustomException) as info:
+            await storage.upload_file(b"x", "k", "text/plain")
+        assert "AccessDenied" in str(info.value)
+
+    async def test_missing_key_still_maps_to_404(self):
+        """The pre-existing NoSuchKey branch must survive the curation change."""
+        from src._core.infrastructure.storage.object_storage import ObjectStorage
+
+        class _NoSuchKey:
+            def client(self):
+                raise ClientError(
+                    {
+                        "Error": {
+                            "Code": "NoSuchKey",
+                            "Message": "The key does not exist",
+                        }
+                    },
+                    "GetObject",
+                )
+
+        storage = ObjectStorage(storage_client=_NoSuchKey(), bucket_name=BUCKET)
+        with pytest.raises(BaseCustomException) as info:
+            await storage.download_file("k")
+        assert info.value.status_code == 404
+
+
+class TestHttpClientDoesNotLeakTheOutboundUrl:
+    def test_response_error_url_is_not_in_the_message(self):
+        from src._core.infrastructure.http.exceptions import ExternalServiceException
+        from src._core.infrastructure.http.http_client import _curate_client_error
+
+        exc = aiohttp.ClientResponseError(
+            request_info=aiohttp.RequestInfo(URL(WEBHOOK), "POST", {}, URL(WEBHOOK)),
+            history=(),
+            status=403,
+            message="Forbidden",
+        )
+        assert WEBHOOK in str(exc), "precondition: aiohttp embeds the URL"
+
+        curated = _curate_client_error(exc)
+        assert isinstance(curated, ExternalServiceException)
+        assert "hooks.slack.com" not in str(curated)
+        assert "SECRET" not in str(curated)
+
+    def test_connector_error_host_is_not_in_the_message(self):
+        from src._core.infrastructure.http.http_client import _curate_client_error
+
+        key = aiohttp.client_reqrep.ConnectionKey(
+            "internal-svc.prod", 8443, False, True, None, None, None
+        )
+        exc = aiohttp.ClientConnectorError(key, OSError("refused"))
+        assert "internal-svc" in str(exc), "precondition: aiohttp embeds the host"
+
+        assert "internal-svc" not in str(_curate_client_error(exc))
+
+    def test_the_exception_class_is_still_identifiable(self):
+        from src._core.infrastructure.http.http_client import _curate_client_error
+
+        curated = _curate_client_error(aiohttp.ClientPayloadError("truncated"))
+        assert "ClientPayloadError" in str(curated)
+
+
+class TestTimeoutStillMapsTo504:
+    """`except aiohttp.ClientError` preceded `except TimeoutError`, and in
+    aiohttp 3.13.5 **all three** timeout classes subclass both, so the 504 branch
+    was unreachable outright — every timed-out upstream was reported as a 502."""
+
+    @pytest.mark.parametrize(
+        "cls_name",
+        ["ServerTimeoutError", "SocketTimeoutError", "ConnectionTimeoutError"],
+    )
+    def test_timeout_classes_subclass_both(self, cls_name):
+        cls = getattr(aiohttp, cls_name, None)
+        if cls is None:
+            pytest.skip(f"{cls_name} absent in aiohttp {aiohttp.__version__}")
+        assert issubclass(cls, aiohttp.ClientError)
+        assert issubclass(cls, TimeoutError), (
+            "precondition for this finding no longer holds — recheck the "
+            "except ordering in http_client.session()"
+        )
+
+    def test_except_timeout_is_ordered_before_client_error(self):
+        """Asserted on the source because reaching the handler needs a live
+        session; the ordering *is* the contract."""
+        import inspect
+
+        from src._core.infrastructure.http import http_client
+
+        src = inspect.getsource(http_client.HttpClient.session)
+        assert src.index("except TimeoutError") < src.index(
+            "except aiohttp.ClientError"
+        ), (
+            "aiohttp timeout classes subclass ClientError too, so ClientError "
+            "first makes ExternalServiceTimeoutException unreachable"
+        )


### PR DESCRIPTION
Resolves #323 (audit cluster F). Parent: #336

Cluster F is the `raw exception → HTTP status → log → alert` path. All four issue
findings are fixed, plus one adjacent leak found while fixing them.

## What changed

**1. The LLM error mapper classified non-provider exceptions** (`error_mapper.py`)

`generic_exception_handler` hands `try_map_llm_error` *every* unhandled
application exception, and `_classify` matched on message substrings with no
check on origin. Re-probed at `d5c2a1d`:

```
KeyError("unauthorized")                            -> 401 LLM_AUTH_FAILED
RuntimeError("S3 bucket model-artifacts not found") -> 404 LLM_MODEL_NOT_FOUND
TimeoutError("... after rate limit backoff")        -> 429 LLM_RATE_LIMITED
```

Each is a genuine 5xx returned as a 4xx — and *because* it is a 4xx it also
skipped the exception log and the error notification, so the misclassification
left no trace anywhere. Now gated on `type(exc).__module__` matching a provider
SDK prefix.

Bedrock decided the shape. Its exceptions are generated at runtime by botocore,
so they are not importable and cannot be matched by identity — but they do carry
`__module__ == "botocore.errorfactory"`. Prefix matching alone suffices, which
keeps this module free of a botocore import. A test builds a real
`bedrock-runtime` `ThrottlingException` to pin that.

The module had **no tests**. Adds 25, covering both directions.

**2. A 5xx left no diagnostic** (`exception_handlers.py`) — F1

`custom_exception_handler` made no logger call; in `generic_exception_handler`
the `try_map_llm_error` branch returned before `_logger.exception`. For a curated
5xx the wrapped cause was in *none* of: the response body (curated by design),
`details` (only when `settings.is_dev`), any log record, or the notification
(same curated text). In stg/prod the sole survivor was `RequestLogMiddleware`'s
`http_request` line — status and duration, no exception identity.

Gated at `>= 500` as the issue specifies: curated 4xx are routine and logging
them at error level would bury the signal this adds. Tests pin that the response
body is unchanged **in both directions**, including the ADR 017 dev-only trace in
`errorDetails` — an absolute "no raw text reaches the client" assertion would be
wrong, and my first draft of that test was.

**3. Raw provider text reached response bodies** — F5 + one adjacent finding

`object_storage.py` — all six `except ClientError` blocks. A boto3 `AccessDenied`
message names the calling IAM principal ARN (embedding the 12-digit account id),
the bucket and the key. Routed through one `_storage_failure` helper following
the `dynamodb_client.py` / `vectors/s3/client.py` house pattern, plus a real
`STORAGE_OPERATION_FAILED` code (every storage failure was generic
`CUSTOM_ERROR`) and `from e`. `Error.Code` extraction also moves off
`e.response["Error"]["Code"]`, which raises `KeyError` *inside an except block*
for any error whose response lacks the key.

`http_client.py:73` — **not in the issue.** Same shape: `f"External service
error: {e}"`. Verified on aiohttp 3.13.5 that the message carries request detail:

```
403, message='Forbidden', url='https://hooks.slack.com/services/T/B/SECRET'
Cannot connect to host internal-svc.prod:8443 ssl:default [None]
```

`security-checklist.md` §13 records that property for the log stream; it applies
just as much to a response body, and for a notification webhook the URL *is* the
credential. The client now gets the failure class and upstream status.

The log side needed care: **both webhook adapters POST through this client**, and
`error_notifier.py` logs `exc_type` only precisely so the webhook URL never
reaches logs. Logging `str(exc)` here would have re-introduced the leak #17
deliberately avoided. So the log gets the origin only — `scheme://host[:port]`,
path and query dropped, since a Slack token lives in the path and the host is
not secret.

**4. The 504 branch was unreachable** (`http_client.py`) — except ordering

`except aiohttp.ClientError` preceded `except TimeoutError`. All three aiohttp
timeout classes subclass **both**, so every timed-out upstream was reported as a
502. The issue framed this as partial; the probe showed it is total:

```
ServerTimeoutError       ClientError / TimeoutError
SocketTimeoutError       ClientError / TimeoutError
ConnectionTimeoutError   ClientError / TimeoutError
```

## Verification

- `1637 passed, 42 skipped` (from `1585`; +52 tests). Zero failures, zero errors.
- The new tests were checked against the **unpatched** modules: 10 fail there,
  15 pass after. They catch the findings rather than describing the fix.
- `pre-commit run` clean; `mypy` (manual stage) clean — it caught a `str` /
  `Any | None` rebind in `_safe_origin` that I fixed.
- `check_governor_footer.py --require-governor-footer` run against the changed
  file list: `0 violations`, non-governor. Run, not assumed — asserting this
  without running it is what broke CI on #338.
- The pre-existing `format_exc_info` structlog warning in the docs e2e test was
  confirmed present *before* these changes, so it is not from this PR.

## Deliberately not changed

- The response is not widened — `errorDetails: null` in prod and the
  `settings.is_dev` gate stay as security-checklist:181-185 mandates.
- The log did not move into `_dispatch_error_notification`; that helper stays
  notifier-only and keeps swallowing everything.
- `raise ... from e` at `database.py:212` is not the fix — `__context__` is
  already set, so the traceback was already attached; only rendering was missing.
- `file_exists` still tests `"404"` and not `"NoSuchKey"`: HEAD has no response
  body, so botocore falls back to the HTTP status as the code. Only the
  extraction became KeyError-safe; the semantics are untouched.
