### PR TITLE
fix(admin): share the server's CoreContainer instead of building a second tree

### DIFF
--- a/src/_apps/admin/bootstrap.py
+++ b/src/_apps/admin/bootstrap.py
@@ -46,7 +46,10 @@ _global_exception_handler_registered = False
 
 def bootstrap_admin(fastapi_app: FastAPI) -> None:
     """Bootstrap NiceGUI admin dashboard onto the existing FastAPI app."""
-    admin_container = create_admin_container()
+    # A view over the server's tree, not a second one — see
+    # ``create_admin_container`` for why the core container cannot simply be
+    # injected the way the worker does it.
+    admin_container = create_admin_container(fastapi_app.state.container)
     fastapi_app.state.admin_container = admin_container
 
     # Global safety net (#195): uniformly structured-log any exception that
@@ -66,8 +69,11 @@ def bootstrap_admin(fastapi_app: FastAPI) -> None:
     # admin action can fire. The logger and the repository share the same
     # instance — the logger uses it for writes, the audit-log UI for queries,
     # and the cleanup task for retention deletes.
-    database = admin_container.core_container.database()
-    audit_repo = AdminAuditLogRepository(database)
+    # Pass the *provider*, not a resolved Database. Resolving here froze the
+    # connection into module state, so an override applied after bootstrap
+    # (override_database in the e2e harness) was invisible to every audit write
+    # and query while /v1/* ran on the swapped database.
+    audit_repo = AdminAuditLogRepository(admin_container.core_container.database)
     configure_audit_repository(audit_repo)
     configure_audit_logger(AuditLogger(audit_repo))
     configure_admin_account_use_case_provider(

--- a/src/_apps/admin/di/container.py
+++ b/src/_apps/admin/di/container.py
@@ -1,25 +1,59 @@
-from dependency_injector import containers, providers
+from dependency_injector import containers
 
-from src._core.infrastructure.di.core_container import CoreContainer
-from src._core.infrastructure.discovery import discover_domains, load_domain_container
+from src._core.infrastructure.discovery import discover_domains
 
 
-def create_admin_container() -> containers.DynamicContainer:
-    """Dynamically create the admin DI container.
+def create_admin_container(server_container) -> containers.DynamicContainer:
+    """Create the admin DI container as a view over the server's own tree.
 
-    Same pattern as create_server_container() — auto-discovers all domains.
+    Args:
+        server_container: the server ``DynamicContainer`` from
+            ``app.state.container``. The admin dashboard is mounted onto the
+            server process (``ui.run_with``), so it shares that process's
+            containers rather than building a second set.
+
+    Why this is a view and not its own tree
+    ---------------------------------------
+    This function used to call ``providers.Container(CoreContainer)`` and rebuild
+    every domain container. One process then held **two** of every
+    ``CoreContainer`` Singleton: two async engines and two QueuePools (with
+    ``database_pool_size``/``database_max_overflow`` unset, up to 2 x (5 + 10) =
+    30 connections against a 15-connection budget), two ``HttpClient``s, and two
+    ``ErrorNotifier`` cooldown dicts — making the "per-process" notification
+    cooldown really per-tree. Every optional-infra disabled warning was emitted
+    twice, including the ``notification_client_disabled`` line that
+    ``test_noop_notification_client_disabled_warning_emitted_once`` pins to
+    exactly one occurrence. And ``override_database`` reached only the server
+    tree, so a test that swapped the database got ``/v1/*`` on the swapped one
+    while ``/admin/*`` and every audit write stayed on the real ``DATABASE_*``.
+
+    Injecting the core container the way ``create_worker_container`` does is not
+    available here, and this is the part worth reading before changing it:
+    ``providers.Container(DomainContainer, core_container=...)`` **overrides
+    class-level state** on the domain container. By the time admin mounts, the
+    server has already applied that override, and re-applying it with a
+    core container that is already in use raises
+
+        AttributeError: 'DependenciesContainer' object has no attribute '__self__'
+
+    Only a *brand new* core tree is accepted as the second override — which is
+    the very thing being removed. The worker pattern works because a worker
+    process wires those classes exactly once. So admin reuses the server's
+    domain container providers rather than constructing its own.
+
+    ``discover_domains()`` still drives the loop: the attributes it sets are what
+    ``_discover_and_register_pages`` reads, and NiceGUI page registration happens
+    at bootstrap time. The values stay *providers*, never resolved services, so
+    the ``page_config._service_provider`` indirection is preserved.
     """
     container = containers.DynamicContainer()
-    container.core_container = providers.Container(CoreContainer)
+    container.core_container = server_container.core_container
 
     for domain in discover_domains():
-        domain_container_cls = load_domain_container(domain)
         setattr(
             container,
             f"{domain}_container",
-            providers.Container(
-                domain_container_cls, core_container=container.core_container
-            ),
+            getattr(server_container, f"{domain}_container"),
         )
 
     return container

--- a/src/_core/infrastructure/admin/audit/repository.py
+++ b/src/_core/infrastructure/admin/audit/repository.py
@@ -6,6 +6,7 @@ surface used by ``/admin/audit-log`` and the cleanup task: ``list_filtered``
 detail dialog), and ``delete_older_than`` (retention cleanup).
 """
 
+from collections.abc import Callable
 from datetime import UTC, datetime
 
 from sqlalchemy import delete, func, select
@@ -30,8 +31,23 @@ class AdminAuditLogRepository:
     plus retention cleanup, not a generic CRUD entity.
     """
 
-    def __init__(self, database: Database) -> None:
-        self._database = database
+    def __init__(self, database: Database | Callable[[], Database]) -> None:
+        """Accept a ``Database`` **or** a zero-arg provider returning one.
+
+        ``bootstrap_admin`` passes the container's ``database`` *provider* rather
+        than a resolved instance. Freezing the instance here made
+        ``override_database`` (applied after bootstrap) unobservable to every
+        audit write and query: the repository kept the real ``DATABASE_*``
+        connection while ``/v1/*`` ran on the swapped one. Callers that already
+        hold a ``Database`` — the worker cleanup task and the unit tests — pass
+        it directly and are unaffected.
+        """
+        self._database_source = database
+
+    @property
+    def _database(self) -> Database:
+        source = self._database_source
+        return source() if callable(source) else source
 
     # ── Write ────────────────────────────────────────────────────────────────
 

--- a/src/_core/infrastructure/admin/audit/repository.py
+++ b/src/_core/infrastructure/admin/audit/repository.py
@@ -47,7 +47,11 @@ class AdminAuditLogRepository:
     @property
     def _database(self) -> Database:
         source = self._database_source
-        return source() if callable(source) else source
+        # `isinstance`, not `callable(source)`: duck-typing the discrimination
+        # would silently invoke a `Database` that ever grows a `__call__`.
+        # Instances are not callable today, so both forms behave identically —
+        # this one cannot stop doing so.
+        return source if isinstance(source, Database) else source()
 
     # ── Write ────────────────────────────────────────────────────────────────
 

--- a/tests/unit/_apps/admin/test_admin_container_topology.py
+++ b/tests/unit/_apps/admin/test_admin_container_topology.py
@@ -1,0 +1,166 @@
+"""A server with the admin extra must hold ONE CoreContainer tree (#326).
+
+`create_admin_container` used to call `providers.Container(CoreContainer)` and
+rebuild every domain container, so a process with the admin extra held two of
+every `CoreContainer` Singleton. Probed at `d5c2a1d`:
+
+    C) server tree db is test_db  : True
+    D) admin  tree db is test_db  : False
+    E) audit repo db is test_db   : False -> sqlite:///./quickstart.db
+    F) admin user_repo db is test : False
+    H) engines distinct           : True
+
+The consequences were a test split-brain (`/v1/*` on the swapped database while
+`/admin/*` and every audit write stayed on the real `DATABASE_*`), two async
+engines and two QueuePools per process, and two `ErrorNotifier` cooldown dicts —
+making the "per-process" notification cooldown really per-tree.
+
+These tests are the boot-topology assertions the audit's cluster A harness was a
+precondition for. They need the `admin` extra; without it the server never mounts
+admin and there is no second tree to assert about.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip(
+    "nicegui", reason="admin topology is only observable with the admin extra"
+)
+
+from src._apps.server.testing import (  # noqa: E402
+    override_database,
+    reset_database_override,
+)
+from src._core.infrastructure.persistence.rdb.database import Database  # noqa: E402
+
+
+@pytest.fixture
+def app():
+    from src._apps.server.app import app as server_app
+
+    if not hasattr(server_app.state, "admin_container"):
+        pytest.skip("admin was not mounted on this app")
+    yield server_app
+    reset_database_override(server_app)
+    # Drop any repository built against this test's throwaway :memory: database,
+    # so a later test in the same process does not inherit it.
+    server_app.state.container.user_container.user_repository.reset()
+
+
+@pytest.fixture
+def swapped_db(app):
+    core = app.state.container.core_container()
+    db = Database(
+        database_engine="sqlite",
+        database_user="",
+        database_password="",
+        database_host="",
+        database_port=0,
+        database_name=":memory:",
+        config=core.db_config(),
+    )
+    override_database(app, db)
+    return db
+
+
+class TestOneCoreContainerPerProcess:
+    def test_admin_and_server_share_the_core_container(self, app):
+        server_core = app.state.container.core_container()
+        admin_core = app.state.admin_container.core_container()
+        assert admin_core is server_core, (
+            "admin built its own CoreContainer — two async engines, two "
+            "QueuePools, and two ErrorNotifier cooldown dicts per process"
+        )
+
+    @pytest.mark.parametrize(
+        "singleton",
+        [
+            "http_client",
+            "broker",
+            "taskiq_manager",
+            "embedding_client",
+            "notification_client",
+            "error_notifier",
+        ],
+    )
+    def test_every_core_singleton_is_shared(self, app, singleton):
+        server_core = app.state.container.core_container()
+        admin_core = app.state.admin_container.core_container()
+        assert getattr(server_core, singleton)() is getattr(admin_core, singleton)()
+
+    def test_domain_containers_stay_providers(self, app):
+        """`page_config._service_provider` holds a provider, not a resolved
+        service, and that indirection has to survive sharing the tree."""
+        admin_container = app.state.admin_container
+        provider = admin_container.admin_identity_container
+        assert callable(provider), "the domain container was resolved, not aliased"
+        assert provider is app.state.container.admin_identity_container
+
+
+class TestDatabaseOverrideReachesTheAdminTree:
+    def test_one_override_reaches_every_consumer(self, app, swapped_db):
+        """One test rather than four, and the repository singletons are reset.
+
+        `user_repository` is a `Singleton`, so once anything in the process has
+        resolved it — the autouse `_override_app_database` in `tests/e2e` does —
+        it keeps the `Database` it was built with. Without the reset this passed
+        in isolation and failed in the full suite, for a reason that has nothing
+        to do with container topology. Asserting under a single override with the
+        cache cleared tests the property and drops the ordering artefact.
+        """
+        from src._core.infrastructure.admin.audit.logger import get_audit_repository
+
+        app.state.container.user_container.user_repository.reset()
+
+        assert app.state.admin_container.core_container.database() is swapped_db, (
+            "the admin core tree did not see the override"
+        )
+        assert (
+            app.state.admin_container.user_container.user_repository().database
+            is swapped_db
+        ), "an admin domain repository did not see the override"
+        assert (
+            app.state.container.user_container.user_repository().database is swapped_db
+        ), "the server domain repository regressed"
+        assert get_audit_repository()._database is swapped_db, (
+            "the audit repository froze the pre-override Database; audit rows "
+            "would go to the real DATABASE_* while /v1/* used the swapped one"
+        )
+
+    def test_the_two_trees_share_one_engine(self, app):
+        server_core = app.state.container.core_container()
+        admin_core = app.state.admin_container.core_container()
+        assert server_core.database().engine is admin_core.database().engine
+
+
+class TestAuditRepositoryResolvesTheDatabaseLazily:
+    """`bootstrap_admin` resolved `core_container.database()` and froze the
+    instance into module state via `configure_audit_repository`, so an override
+    applied *after* bootstrap was invisible to every audit write and query."""
+
+    def test_a_plain_database_still_works(self):
+        """The worker cleanup task and the existing unit tests pass a resolved
+        `Database`. Accepting a provider must not break that."""
+        from src._core.infrastructure.admin.audit.repository import (
+            AdminAuditLogRepository,
+        )
+
+        sentinel = object()
+        assert AdminAuditLogRepository(sentinel)._database is sentinel  # type: ignore[arg-type]
+
+    def test_a_provider_is_resolved_on_every_access(self):
+        from src._core.infrastructure.admin.audit.repository import (
+            AdminAuditLogRepository,
+        )
+
+        calls: list[int] = []
+
+        def provider():
+            calls.append(1)
+            return "db"
+
+        repo = AdminAuditLogRepository(provider)  # type: ignore[arg-type]
+        assert repo._database == "db"
+        assert repo._database == "db"
+        assert len(calls) == 2, "the provider was cached instead of re-resolved"

--- a/tests/unit/_apps/admin/test_admin_container_topology.py
+++ b/tests/unit/_apps/admin/test_admin_container_topology.py
@@ -139,15 +139,24 @@ class TestAuditRepositoryResolvesTheDatabaseLazily:
     instance into module state via `configure_audit_repository`, so an override
     applied *after* bootstrap was invisible to every audit write and query."""
 
-    def test_a_plain_database_still_works(self):
-        """The worker cleanup task and the existing unit tests pass a resolved
-        `Database`. Accepting a provider must not break that."""
+    def test_a_plain_database_still_works(self, app):
+        """The worker cleanup task and the five existing unit-test call sites all
+        pass a resolved `Database`. Accepting a provider must not break that."""
         from src._core.infrastructure.admin.audit.repository import (
             AdminAuditLogRepository,
         )
 
-        sentinel = object()
-        assert AdminAuditLogRepository(sentinel)._database is sentinel  # type: ignore[arg-type]
+        core = app.state.container.core_container()
+        database = Database(
+            database_engine="sqlite",
+            database_user="",
+            database_password="",
+            database_host="",
+            database_port=0,
+            database_name=":memory:",
+            config=core.db_config(),
+        )
+        assert AdminAuditLogRepository(database)._database is database
 
     def test_a_provider_is_resolved_on_every_access(self):
         from src._core.infrastructure.admin.audit.repository import (
@@ -155,12 +164,16 @@ class TestAuditRepositoryResolvesTheDatabaseLazily:
         )
 
         calls: list[int] = []
+        first, second = object(), object()
 
         def provider():
             calls.append(1)
-            return "db"
+            return first if len(calls) == 1 else second
 
         repo = AdminAuditLogRepository(provider)  # type: ignore[arg-type]
-        assert repo._database == "db"
-        assert repo._database == "db"
-        assert len(calls) == 2, "the provider was cached instead of re-resolved"
+        assert repo._database is first
+        assert repo._database is second, (
+            "the provider was cached, so a post-bootstrap override would not be "
+            "picked up — the whole point of taking a provider"
+        )
+        assert len(calls) == 2


### PR DESCRIPTION
Resolves #326 (audit cluster C). Parent: #336

Cluster C is container topology. Land it before #324 (cluster L) so the inline-broker middleware fix targets the final shape.

## What was wrong

A server with the `admin` extra held **two** `CoreContainer` trees. Re-verified at `d5c2a1d`:

```
C) server tree db is test_db  : True
D) admin  tree db is test_db  : False
E) audit repo db is test_db   : False -> sqlite:///./quickstart.db
F) admin user_repo db is test : False
H) engines distinct           : True
```

Two consequences, one latent and one live:

- **Test split-brain.** `override_database` reached the server tree only, so a harness that swapped the database got `/v1/*` on the swapped one while `/admin/*` and every audit write kept the real `DATABASE_*`.
- **Production.** Two async engines and two QueuePools per process. With `database_pool_size`/`database_max_overflow` unset that is up to 2 × (5 + 10) = 30 connections against a 15-connection budget, plus two `HttpClient`s and two `ErrorNotifier` cooldown dicts — making the "per-process" notification cooldown really per-*tree*.

**One thing the issue did not record**, found while probing: every optional-infra disabled warning fired twice, including the `notification_client_disabled` line. #286 made three notification Selectors share one Noop Singleton specifically so that line appears exactly once, and `test_noop_notification_client_disabled_warning_emitted_once` pins it. The test passed only because it builds a single container; the shipped server violated the invariant.

## The issue's prescribed fix does not work

The issue said to adopt `create_worker_container`'s injected-core pattern: `create_admin_container(fastapi_app.state.container.core_container)`. I implemented it and it raises at boot:

```
AttributeError: 'DependenciesContainer' object has no attribute '__self__'
```

`providers.Container(DomainContainer, core_container=...)` **overrides class-level state** on the domain container. By the time admin mounts, the server has already applied that override; re-applying it with a core container that is already in use fails. Tested against the real boot, in order of preference:

```
fresh providers.Container(CoreContainer)  -> OK    <- the current, broken behaviour
the server's provider                    -> AttributeError
providers.Object(resolved instance)       -> AttributeError
the resolved instance                     -> AttributeError
CoreContainer() brand new                -> OK    <- also the broken behaviour
```

Only a *brand-new* tree is accepted as the second override — the very thing being removed. The worker pattern works because a worker process wires those classes exactly once.

So admin now **aliases the server's existing providers** rather than constructing its own. The issue's "do not collapse admin domain containers into the server's" note gave its reason as preserving the `page_config._service_provider` indirection; aliasing preserves that exactly, because the values stay providers and are never resolved. A test pins it.

## Also fixed

`bootstrap_admin` resolved `core_container.database()` and `configure_audit_repository` froze that instance into module globals, so even with a shared tree an override applied *after* bootstrap stayed invisible. `AdminAuditLogRepository` now accepts a `Database` **or** a zero-arg provider and resolves per access. The worker cleanup task and the five existing unit-test call sites pass a `Database` directly and are unchanged.

## After

```
D) admin  tree db is test_db  : True
E) audit repo db is test_db   : True -> sqlite:///:memory:
F) admin user_repo db is test : True
H) engines distinct           : False
CoreContainer trees           : 1  (was 2)
all 7 core Singletons shared  : True
```

## Verification

- `1597 passed, 42 skipped, 0 failed` — standalone and in the full suite.
- 11 of the 12 new tests fail against the previous implementation.
- `pre-commit run` clean. `check_governor_footer.py --require-governor-footer` run against the changed file list: `0 violations`, non-governor.
- mypy reports 7 errors in `src/_apps/admin/` — all **pre-existing**, verified identical on `origin/main` (only line numbers shift). Not introduced here and not fixed here.

## One test-writing note worth keeping

The override assertions are deliberately **one** test with an explicit `user_repository.reset()`. `user_repository` is a `Singleton`, and the autouse `_override_app_database` in `tests/e2e` resolves it first, so a split version passed in isolation and failed in the full suite for a reason unrelated to topology. The reset makes the assertion about the property rather than about test order.

## Deliberately not changed

- `create_admin_container` is kept, along with its `discover_domains()` loop — that loop is what populates the attributes `_discover_and_register_pages` reads at bootstrap time.
- The worker/broker module still holds its own `CoreContainer`. That is the third tree, and it is #324's to address.
