### PR TITLE
fix: run the task middleware and domain DI wiring the inline broker never had

### DIFF
--- a/src/_apps/server/bootstrap.py
+++ b/src/_apps/server/bootstrap.py
@@ -43,6 +43,7 @@ def bootstrap_app(app: FastAPI) -> None:
     _bootstrap_quickstart_schema_if_applicable(container)
     _install_core_routes(app, container)
     _bootstrap_domains(app, container)
+    _install_inline_task_runtime(container)
     _mount_admin_if_available(app)
 
 
@@ -133,6 +134,71 @@ def _bootstrap_domains(app: FastAPI, container) -> None:
             app=app,
             **{f"{name}_container": domain_container},
         )
+
+
+def _install_inline_task_runtime(container) -> None:
+    """Give the inline broker the task runtime the worker process would give it (#324).
+
+    Under ``BROKER_TYPE=inmemory`` — the shipped default, and a value that passes
+    stg/prod validation — ``.kiq()`` executes the task **in this process**. But the
+    middleware stack and the domain task wiring are installed by
+    ``src/_apps/worker/bootstrap.py``, reached only through ``worker/app.py``,
+    which the server never imports. Measured at HEAD in a server process:
+
+        server-process broker : InMemoryBroker
+        middlewares           : []
+        registered tasks      : ['my-project.docs.ingest_document']
+
+    So a task failure produced no retry, no ``task_error`` record, no #310 alert
+    and no correlation-id binding — and the absence of the error-logging
+    middleware is itself what hid the failure.
+
+    Three things here are deliberate and each was measured:
+
+    1. **The provider comes from the server's own core tree.** Passing the worker
+       module's ``container.error_notifier`` would give this process two
+       ``ErrorNotifier`` singletons, hence two ``NoopNotificationClient``s — two
+       ``notification_client_disabled`` lines against the documented per-process
+       invariant — and two independent cooldown dicts, so an HTTP-path alert would
+       not suppress a duplicate task-path alert.
+
+    2. **The server passes its OWN container to the domain wiring**, not a fresh
+       ``create_worker_container(...)``. Building one would raise
+       ``AttributeError: 'DependenciesContainer' object has no attribute
+       '__self__'`` — the server has already overridden those class-level
+       dependency containers.
+
+    3. **Only the inline broker is touched.** With a cross-process broker the
+       tasks run in a real worker that installs its own stack, and installing it
+       here as well would double-register. The ``not middlewares`` guard also
+       keeps a repeated ``bootstrap_app`` call (test reloads) idempotent.
+
+    Not imported at module scope: ``src._apps.worker.broker`` constructs a
+    ``CoreContainer`` at import time, and keeping that inside the function leaves
+    the import graph as it was for anything that does not reach this step.
+    """
+    from taskiq import InMemoryBroker
+
+    from src._apps.worker.bootstrap import (
+        bootstrap_task_domains,
+        install_task_middleware,
+    )
+    from src._apps.worker.broker import broker as task_broker
+
+    if not isinstance(task_broker, InMemoryBroker):
+        return
+
+    core_container = container.core_container()
+    if not task_broker.middlewares:
+        install_task_middleware(
+            task_broker, error_notifier_provider=core_container.error_notifier
+        )
+    bootstrap_task_domains(container)
+    _logger.info(
+        "inline_task_runtime_installed",
+        middlewares=[type(m).__name__ for m in task_broker.middlewares],
+        tasks=sorted(task_broker.get_all_tasks()),
+    )
 
 
 def _maybe_configure_otel(service_name: str) -> None:

--- a/src/_apps/worker/bootstrap.py
+++ b/src/_apps/worker/bootstrap.py
@@ -1,7 +1,7 @@
 import importlib
 
 import structlog
-from taskiq import AsyncBroker, TaskiqState
+from taskiq import AsyncBroker
 
 from src._apps.worker.broker import container
 from src._apps.worker.di.container import create_worker_container
@@ -11,15 +11,6 @@ from src._apps.worker.di.container import create_worker_container
 # the ``@broker.task`` decorator registers them with the broker before the
 # worker starts pulling jobs (#206 audit retention cleanup).
 from src._apps.worker.tasks import audit_cleanup_task as _audit_cleanup  # noqa: F401
-
-# Wire ``Provide[CoreContainer.database]`` markers in the cross-cutting tasks
-# at module-import time so resolution works in BOTH process families:
-# - worker process (executes the task)
-# - scheduler process (introspects @broker.task schedule labels)
-# Without module-level wire, the wire call inside the startup event only runs
-# in the worker — scheduler-side direct invocation would hit an unresolved
-# Provide marker.
-container.wire(modules=[_audit_cleanup])
 from src._core.config import settings
 from src._core.infrastructure.discovery import discover_domains
 from src._core.infrastructure.logging.configure import configure_logging
@@ -38,8 +29,27 @@ _logger = structlog.stdlib.get_logger("src._apps.worker.bootstrap")
 def bootstrap_app(app: AsyncBroker) -> None:
     _configure_logging_pipeline()
     _maybe_configure_otel(service_name="fastapi-agent-blueprint-worker")
-    _install_middleware(app)
-    _register_startup_event(app)
+    # ORDER IS LOAD-BEARING, and not for a stylistic reason. ``wire()`` adds a
+    # ``__self__`` provider to the container it is called on. After that, handing
+    # that container to a domain container's ``DependenciesContainer`` raises
+    #
+    #     AttributeError: 'DependenciesContainer' object has no attribute '__self__'
+    #
+    # because the override walks the overriding container's provider names and
+    # looks each one up on the DependenciesContainer. Measured post-wire: all
+    # three construction forms fail — ``providers.Container(cls,
+    # core_container=cc)``, ``cls(core_container=cc)``, and ``cls()`` followed by
+    # ``core_container.override(cc)``. Building the domain containers first works.
+    #
+    # This is why the cross-cutting wire moved off module scope: it used to run at
+    # import, i.e. before any domain container could be built. That made
+    # ``create_worker_container`` unreachable-by-exception, which stayed invisible
+    # only because the call sat inside a startup event that never fired
+    # (see bootstrap_task_domains). Pinned by
+    # tests/unit/_apps/worker/test_task_bootstrap_order.py.
+    bootstrap_task_domains(create_worker_container(core_container=container))
+    container.wire(modules=[_audit_cleanup])
+    install_task_middleware(app, error_notifier_provider=container.error_notifier)
 
 
 # ---------------------------------------------------------------------------
@@ -55,8 +65,25 @@ def _configure_logging_pipeline() -> None:
     )
 
 
-def _install_middleware(app: AsyncBroker) -> None:
+def install_task_middleware(app: AsyncBroker, *, error_notifier_provider) -> None:
     """Bind task context, log failures, retry transient errors, and alert (#310).
+
+    Public because the server installs the same stack on the inline broker: under
+    ``BROKER_TYPE=inmemory`` (the shipped default) ``.kiq()`` executes the task in
+    the *server* process, and that process never imports ``worker/app.py`` — so
+    without this call the inline broker ran tasks through an empty middleware
+    list. No retry, no ``task_error`` record, no #310 alert, no correlation-id
+    binding, and the absence of the error-logging middleware is itself what hid
+    the failure (#324).
+
+    ``error_notifier_provider`` is a parameter rather than the module-level
+    ``container.error_notifier`` it used to close over, and callers must pass the
+    provider from *their own* core tree. Passing the worker module's provider from
+    the server gives that process two ``ErrorNotifier`` singletons: two
+    ``NoopNotificationClient``s (so the disabled warning is logged twice, against
+    the documented per-process invariant) and two independent cooldown dicts, so
+    an HTTP-path alert would not suppress a duplicate task-path alert. Measured
+    before this change: ``same ErrorNotifier: False / disabled warnings: 2``.
 
     Registration order is a behavioural contract, not a style choice. Taskiq
     runs ``on_error`` over ``reversed(broker.middlewares)``, and
@@ -78,17 +105,44 @@ def _install_middleware(app: AsyncBroker) -> None:
         retry_middleware,
         TaskErrorLoggingMiddleware(),
         TaskFailureNotificationMiddleware(
-            error_notifier_provider=container.error_notifier,
+            error_notifier_provider=error_notifier_provider,
             retry_middleware=retry_middleware,
         ),
     )
 
 
-def _register_startup_event(app: AsyncBroker) -> None:
-    @app.on_event("startup")
-    async def startup(state: TaskiqState):
-        worker_container = create_worker_container(core_container=container)
-        _bootstrap_domains(worker_container=worker_container)
+def bootstrap_task_domains(container_with_domains) -> None:
+    """Wire every domain's worker-task ``Provide`` markers. Call this directly.
+
+    This replaced an ``@app.on_event("startup")`` registration that **never
+    fired in any process**. ``AsyncBroker.on_event`` keys its handler dict by the
+    argument it is given, and taskiq dispatches ``TaskiqEvents.WORKER_STARTUP``
+    — an enum member that is not equal to the plain string ``"startup"``, since
+    ``TaskiqEvents`` is not a ``str`` subclass. Verified after a full worker boot:
+
+        broker.event_handlers keys -> ["'startup'"]      # nothing under the enum
+
+    So the wiring never ran even on the real worker path, and the consequence was
+    not the server-only gap #324 described. On the exact import the taskiq CLI
+    performs (``src._apps.worker.app``), dispatching a domain task gave:
+
+        AttributeError: 'Provide' object has no attribute 'ingest_existing_document'
+
+    Calling it directly is also what lets the server reuse it: a FastAPI process
+    never calls ``broker.startup()``, so no broker event can reach it. Nothing
+    here needs a running loop or a ``TaskiqState`` — the body is ``.wire()`` calls
+    only, which this module already performs at import time for the cross-cutting
+    task.
+
+    ``container_with_domains`` is anything exposing ``<domain>_container``
+    attributes: the worker passes ``create_worker_container(...)``, the server
+    passes its own ``app.state.container``. The server must NOT build a fresh
+    worker container — ``providers.Container(DomainContainer, core_container=...)``
+    overrides class-level state that the server has already overridden, and
+    re-applying it raises ``AttributeError: 'DependenciesContainer' object has no
+    attribute '__self__'``.
+    """
+    _bootstrap_domains(worker_container=container_with_domains)
 
 
 def _maybe_configure_otel(service_name: str) -> None:

--- a/tests/e2e/docs/test_docs_router.py
+++ b/tests/e2e/docs/test_docs_router.py
@@ -149,6 +149,28 @@ async def test_query_endpoint_returns_answer_with_citations():
     assert "excerpt" in cite
 
 
+async def _drain_inline_tasks(timeout: float = 10.0) -> None:
+    """Wait for the inline broker's detached tasks to finish.
+
+    `InMemoryBroker` is constructed with `await_inplace=False`, so `.kiq()` only
+    does `asyncio.create_task(...)` and returns. Anything asserting on a task's
+    *effect* has to wait for those tasks rather than for a wall-clock interval.
+    """
+    import asyncio
+
+    from src._apps.worker.broker import broker
+
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        running = [t for t in getattr(broker, "_running_tasks", set()) if not t.done()]
+        if not running:
+            return
+        await asyncio.wait(
+            running, timeout=deadline - asyncio.get_running_loop().time()
+        )
+    raise AssertionError(f"inline broker tasks did not finish within {timeout:.1f}s")
+
+
 @pytest.mark.asyncio
 async def test_create_large_document_defers_ingestion_to_worker():
     """Content beyond the sync threshold returns chunk_count=0 and leaves
@@ -165,13 +187,28 @@ async def test_create_large_document_defers_ingestion_to_worker():
         assert response.status_code == 200, response.text
         created = response.json()["data"]
         document_id = created["id"]
-        # Worker has not processed the queued task yet, so the row is
-        # persisted with chunk_count=0 and the client can still read it back.
+        # The response is returned before ingestion runs, so the row the caller
+        # sees is still chunk_count=0. `.kiq()` is fire-and-forget on the inline
+        # broker (await_inplace=False), so this is a property of the response, not
+        # a race: the task cannot have run before `create_without_ingestion`
+        # returned.
         assert created["chunkCount"] == 0
+
+        # ...but on the inline broker the task then runs IN THIS PROCESS, so
+        # ingestion does complete. Before #324 it could not: the task module's
+        # `Provide` marker was never wired, so every dispatch died with
+        # `AttributeError: 'Provide' object has no attribute
+        # 'ingest_existing_document'` and the row stayed at chunk_count=0 forever
+        # — invisible to /v1/docs/query, with no alert and no error record.
+        # Draining rather than sleeping a fixed interval keeps this deterministic.
+        await _drain_inline_tasks()
 
         fetch_resp = await client.get(f"/v1/docs/documents/{document_id}")
         assert fetch_resp.status_code == 200
-        assert fetch_resp.json()["data"]["chunkCount"] == 0
+        assert fetch_resp.json()["data"]["chunkCount"] > 0, (
+            "async ingestion did not complete in-process; the inline broker is "
+            "running the task without its domain DI wiring again (#324)"
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/_apps/worker/test_bootstrap.py
+++ b/tests/unit/_apps/worker/test_bootstrap.py
@@ -1,6 +1,7 @@
 from taskiq import InMemoryBroker, TaskiqMiddleware
 
-from src._apps.worker.bootstrap import _install_middleware
+from src._apps.worker.bootstrap import install_task_middleware
+from src._apps.worker.broker import container
 from src._core.infrastructure.logging.taskiq_middleware import (
     PermanentAwareSmartRetryMiddleware,
     StructlogContextMiddleware,
@@ -22,10 +23,10 @@ def _middleware_index(
     )
 
 
-def test_install_middleware_registers_taskiq_error_handling_order() -> None:
+def test_install_task_middleware_registers_taskiq_error_handling_order() -> None:
     broker = InMemoryBroker()
 
-    _install_middleware(broker)
+    install_task_middleware(broker, error_notifier_provider=container.error_notifier)
 
     structlog_index = _middleware_index(broker.middlewares, StructlogContextMiddleware)
     retry_index = _middleware_index(

--- a/tests/unit/_apps/worker/test_task_bootstrap_order.py
+++ b/tests/unit/_apps/worker/test_task_bootstrap_order.py
@@ -1,0 +1,193 @@
+"""The task runtime must be installed, and installed in the right order (#324).
+
+Two defects sat behind one symptom.
+
+**The startup event never fired, in any process.** `bootstrap_app` registered the
+domain wiring with `@app.on_event("startup")`, but `AsyncBroker.on_event` keys its
+handler dict by whatever it is given, and taskiq dispatches
+`TaskiqEvents.WORKER_STARTUP` — an enum member that is not equal to the plain
+string `"startup"`, because `TaskiqEvents` is not a `str` subclass. Measured after
+a full worker boot at `d5c2a1d`:
+
+    broker.event_handlers keys -> ["'startup'"]      # nothing under the enum
+
+So `_bootstrap_domains` never ran even on the real worker path. On the exact
+import the taskiq CLI performs, dispatching a domain task gave:
+
+    AttributeError: 'Provide' object has no attribute 'ingest_existing_document'
+
+The issue framed this as a server-only gap. It was not — the worker was equally
+broken, and the blueprint's async ingestion had never worked.
+
+**`wire()` poisons later domain-container construction.** `wire()` adds a
+`__self__` provider to the container it is called on, and overriding a domain
+container's `DependenciesContainer` with such a container then raises
+`AttributeError: 'DependenciesContainer' object has no attribute '__self__'`.
+Measured post-wire, all three construction forms fail:
+
+    providers.Container(cls, core_container=cc)        -> AttributeError
+    cls(core_container=cc)                             -> AttributeError
+    cls(); dc.core_container.override(cc)              -> AttributeError
+
+Building the domain containers *before* the wire works. This was invisible only
+because the one call to `create_worker_container` sat inside the event that never
+fired; making the call reachable surfaced it immediately.
+"""
+
+from __future__ import annotations
+
+import pytest
+from dependency_injector import containers, providers
+from taskiq import InMemoryBroker
+from taskiq.events import TaskiqEvents
+
+from src._core.infrastructure.di.core_container import CoreContainer
+from src._core.infrastructure.discovery import discover_domains, load_domain_container
+
+
+class TestTheStartupEventKeyWasWrong:
+    """Regression guards for the mechanism, not just the symptom. If someone
+    reintroduces an `on_event("startup")` registration, these say why it is dead
+    code rather than leaving the next reader to rediscover it."""
+
+    def test_taskiq_events_is_not_a_str_enum(self):
+        assert not issubclass(TaskiqEvents, str), (
+            "if TaskiqEvents became a str enum, on_event('startup') might start "
+            "matching and this whole finding would need rechecking"
+        )
+        assert TaskiqEvents.WORKER_STARTUP != "startup"
+
+    def test_a_string_and_the_enum_are_different_handler_keys(self):
+        broker = InMemoryBroker()
+
+        @broker.on_event("startup")
+        async def _by_string(state): ...
+
+        @broker.on_event(TaskiqEvents.WORKER_STARTUP)
+        async def _by_enum(state): ...
+
+        assert "startup" in broker.event_handlers
+        assert TaskiqEvents.WORKER_STARTUP in broker.event_handlers
+        assert (
+            broker.event_handlers["startup"]
+            != broker.event_handlers[TaskiqEvents.WORKER_STARTUP]
+        ), "the two registrations landed in the same bucket; recheck the fix"
+
+    def test_bootstrap_no_longer_defers_domain_wiring_to_an_event(self):
+        """Checked over the AST, not the source text.
+
+        The first version of this test grepped for `on_event("startup")` and
+        failed on the docstrings that *explain* the bug — prose is not code, and a
+        text scan cannot tell them apart.
+        """
+        import ast
+        import inspect
+
+        from src._apps.worker import bootstrap
+
+        tree = ast.parse(inspect.getsource(bootstrap))
+        decorators = [
+            ast.unparse(dec)
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef)
+            for dec in node.decorator_list
+        ]
+        assert not [d for d in decorators if "on_event" in d], (
+            f"domain wiring is back behind a broker event that taskiq never "
+            f"dispatches; it must be called directly. Found: {decorators}"
+        )
+        assert hasattr(bootstrap, "bootstrap_task_domains")
+
+
+class TestWireBeforeDomainContainersBreaksConstruction:
+    """The ordering constraint `bootstrap_app` now encodes. Asserted on the DI
+    library's real behaviour so the constraint is documented by a failing case
+    rather than by a comment alone."""
+
+    @pytest.fixture
+    def audit_task_module(self):
+        from src._apps.worker.tasks import audit_cleanup_task
+
+        return audit_cleanup_task
+
+    def _build_domain_container(self, core_container):
+        holder = containers.DynamicContainer()
+        holder.core_container = core_container
+        cls = load_domain_container(discover_domains()[0])
+        return providers.Container(cls, core_container=holder.core_container)
+
+    def test_building_before_the_wire_succeeds(self, audit_task_module):
+        core = CoreContainer()
+        self._build_domain_container(core)  # must not raise
+        core.wire(modules=[audit_task_module])
+
+    def test_building_after_the_wire_raises(self, audit_task_module):
+        core = CoreContainer()
+        core.wire(modules=[audit_task_module])
+        with pytest.raises(AttributeError, match="__self__"):
+            self._build_domain_container(core)
+
+    def test_wire_is_what_adds_the_self_provider(self, audit_task_module):
+        """Names the mechanism, so a future DI upgrade that changes it fails here
+        rather than silently making the ordering constraint unnecessary — or
+        silently making it insufficient."""
+        core = CoreContainer()
+        assert "__self__" not in core.providers
+        core.wire(modules=[audit_task_module])
+        assert "__self__" in core.providers
+
+
+class TestInstallTaskMiddlewareIsReusable:
+    def test_it_takes_the_notifier_provider_from_the_caller(self):
+        """The server must be able to pass its OWN tree's provider. Hardcoding the
+        worker module's gave a server process two ErrorNotifiers, hence two
+        NoopNotificationClients — two `notification_client_disabled` lines against
+        the documented per-process invariant — and two independent cooldown dicts.
+        """
+        from src._apps.worker.bootstrap import install_task_middleware
+
+        sentinel = object()
+        broker = InMemoryBroker()
+        install_task_middleware(broker, error_notifier_provider=sentinel)
+
+        notifier = next(
+            m
+            for m in broker.middlewares
+            if type(m).__name__ == "TaskFailureNotificationMiddleware"
+        )
+        assert notifier._error_notifier_provider is sentinel
+
+    def test_the_only_load_bearing_inequality_is_retry_before_notifier(self):
+        """taskiq runs `on_error` over `reversed(middlewares)`, so registered-last
+        runs first. The notifier must run before the retry middleware bumps
+        `_retries`, which means it must be registered after it.
+
+        Deliberately asserting one inequality rather than the full chain: a
+        cross-review order matrix showed the structlog and error-logging positions
+        are behaviourally free, so pinning them over-specifies the contract and
+        would fail a harmless reordering.
+        """
+        from src._apps.worker.bootstrap import install_task_middleware
+
+        broker = InMemoryBroker()
+        install_task_middleware(broker, error_notifier_provider=object())
+        names = [type(m).__name__ for m in broker.middlewares]
+
+        assert names.index("PermanentAwareSmartRetryMiddleware") < names.index(
+            "TaskFailureNotificationMiddleware"
+        )
+
+    def test_installing_twice_is_what_the_server_guard_prevents(self):
+        """`install_task_middleware` itself is not idempotent — it appends. The
+        server checks `not broker.middlewares` before calling it; this pins the
+        reason that check exists."""
+        from src._apps.worker.bootstrap import install_task_middleware
+
+        broker = InMemoryBroker()
+        install_task_middleware(broker, error_notifier_provider=object())
+        first = len(broker.middlewares)
+        install_task_middleware(broker, error_notifier_provider=object())
+        assert len(broker.middlewares) == first * 2, (
+            "install_task_middleware became idempotent — the server's "
+            "`not middlewares` guard may now be dead code worth removing"
+        )

--- a/tests/unit/_core/infrastructure/notification/test_task_failure_notification_middleware.py
+++ b/tests/unit/_core/infrastructure/notification/test_task_failure_notification_middleware.py
@@ -317,17 +317,20 @@ class TestMiddlewareOrderingContract:
 
     # The positional assertion (notifier registered last) lives in
     # tests/unit/_apps/worker/test_bootstrap.py, which already owns the
-    # "what does _install_middleware register, in what order" contract for the
+    # "what does install_task_middleware register, in what order" contract for the
     # whole chain. Kept there rather than duplicated so there is one canonical
     # order assertion. What follows is notifier-specific.
 
-    def test_install_middleware_shares_one_retry_middleware_instance(self):
+    def test_install_task_middleware_shares_one_retry_middleware_instance(self):
         """The notifier reads retry defaults off the registered instance, so a
         second instance would let the two disagree about max_retries."""
-        from src._apps.worker.bootstrap import _install_middleware
+        from src._apps.worker.bootstrap import install_task_middleware
+        from src._apps.worker.broker import container
 
         broker = InMemoryBroker()
-        _install_middleware(broker)
+        install_task_middleware(
+            broker, error_notifier_provider=container.error_notifier
+        )
 
         registered_retry = next(
             m
@@ -343,7 +346,7 @@ class TestMiddlewareOrderingContract:
         assert notifier_middleware._retry_middleware is registered_retry
 
     async def test_registered_order_alerts_once_on_the_final_attempt(self):
-        """End-to-end through the REAL ``_install_middleware`` wiring.
+        """End-to-end through the REAL ``install_task_middleware`` wiring.
 
         Drives three attempts the way taskiq's receiver does and asserts
         exactly one alert lands, on the last. This is the test that actually
@@ -352,11 +355,14 @@ class TestMiddlewareOrderingContract:
         middleware it reads an already-incremented ``_retries`` and fires on
         attempt 2 instead of 3.
         """
-        from src._apps.worker.bootstrap import _install_middleware
+        from src._apps.worker.bootstrap import install_task_middleware
+        from src._apps.worker.broker import container
 
         notifier = FakeErrorNotifier()
         broker = InMemoryBroker()
-        _install_middleware(broker)
+        install_task_middleware(
+            broker, error_notifier_provider=container.error_notifier
+        )
 
         retry = next(
             m


### PR DESCRIPTION
Resolves #324 (audit cluster L). Parent: #336

## The issue mis-scoped this. It is worse than server-only.

#324 says the *server* process runs tasks without middleware and without domain DI wiring. The middleware half is exactly right. The wiring half is not server-specific — **no process ever ran it.**

`bootstrap_app` registered the domain wiring with `@app.on_event("startup")`. `AsyncBroker.on_event` keys its handler dict by whatever it is given, and taskiq dispatches `TaskiqEvents.WORKER_STARTUP` — an enum member that is not equal to the plain string `"startup"`, because `TaskiqEvents` is not a `str` subclass. After a full worker boot:

```
broker.event_handlers keys -> ["'startup'"]      # nothing under the enum
```

On the exact import the taskiq CLI performs (`src._apps.worker.app`), dispatching a domain task gave:

```
AttributeError: 'Provide' object has no attribute 'ingest_existing_document'
```

So the blueprint's async ingestion had never worked, on any broker, in any process. The issue's own probe did not catch this because it called `bootstrap_docs_domain` by hand before re-dispatching.

## A second defect the dead event was hiding

Making the call reachable surfaced it immediately: `create_worker_container` raises.

`wire()` adds a `__self__` provider to the container it is called on, and overriding a domain container's `DependenciesContainer` with such a container then raises `AttributeError: 'DependenciesContainer' object has no attribute '__self__'`. Post-wire, **all three** construction forms fail:

```
providers.Container(cls, core_container=cc)    -> AttributeError
cls(core_container=cc)                         -> AttributeError
cls(); dc.core_container.override(cc)          -> AttributeError
```

Building the domain containers *before* the wire works. So `create_worker_container` had been broken since the cross-cutting `container.wire(...)` moved to module scope — invisible only because its one caller sat inside the dead event. That wire now runs inside `bootstrap_app`, after the domain containers exist, and the ordering constraint is pinned by a test that asserts the DI library's real behaviour rather than by a comment.

This is the same mechanism that made #326's prescribed fix impossible. Worth knowing as one fact rather than two coincidences.

## What changed

`_install_middleware` → public `install_task_middleware(broker, *, error_notifier_provider)`, and `bootstrap_task_domains(container)` accepting anything exposing `<domain>_container`. `bootstrap_app` calls both directly. The server adds `_install_inline_task_runtime`, guarded on the broker being an `InMemoryBroker` with an empty middleware list.

Before, in a server process:

```
broker      : InMemoryBroker
middlewares : []
```

After:

```
middlewares                   : all four
tasks                         : audit_cleanup, docs.ingest_document, user.test
taskiq_task_failed logged     : 1
notification_client_disabled  : 1     (not 2)
```

Three deliberate choices, each measured rather than assumed:

- **The notifier provider comes from the server's own core tree.** The worker module's would give this process two `ErrorNotifier`s → two `NoopNotificationClient`s (two disabled warnings, against the documented per-process invariant) and two independent cooldown dicts, so an HTTP-path alert would not suppress a duplicate task-path alert.
- **The server passes its own container to the domain wiring**, not a fresh `create_worker_container(...)` — that would hit the `__self__` error above.
- **Only the inline broker, only when empty.** A cross-process broker runs a real worker that installs its own stack; the guard also keeps a repeated bootstrap idempotent.

## Two corrections to the issue text worth not propagating

- The issue says `TaskFailureNotificationMiddleware` "reads retry state off the *same* retry-middleware instance". A cross-review order matrix showed it reads only **immutable** config (`PERMANENT_ERROR_TYPES`, `default_retry_count`, `is_retry_on_error`); per-attempt state lives in `message.labels`. Sharing the instance is a config-drift guard, not a state-sharing requirement.
- Only `index(retry) < index(notifier)` is load-bearing. The structlog and error-logging positions are behaviourally free — `StructlogContextMiddleware` does not even override `on_error`, so it is skipped in that fan-out. The existing test's four-way chain over-specifies by two inequalities; the new test asserts the one that matters.

Also checked and **not** a problem, contrary to the issue's worst case: retry does not block the HTTP response. `InMemoryBroker` runs with `await_inplace=False`, so `.kiq()` only creates a detached task. Measured POST latency is 0.0069s with and without middleware; the cost is ~180ms of background CPU for three failing attempts. Separately, the retry *delay* is never honoured under the inline broker — the announced backoff is ignored and all attempts fire within ~200ms.

## Verification

- `1594 passed, 42 skipped, 0 failed`.
- The docs e2e test now asserts the **restored** behaviour. It previously asserted `chunkCount == 0` on read-back with the comment "worker has not processed the queued task yet" — true only because the task always died. It now drains the inline broker and asserts `chunkCount > 0`, and **fails without this change**. Draining rather than sleeping keeps it deterministic.
- That also explains the `format_exc_info` structlog warning the suite has been carrying: it was the unresolved-`Provide` traceback from this very test. The suite now reports one warning instead of two.
- The 22 existing middleware-contract tests still pass; three call sites were updated for the rename and the new keyword argument.
- mypy reports 7 errors under `src/_apps/admin/` — all pre-existing, verified identical on `origin/main`.

## Left open deliberately

- **`BROKER_TYPE=inmemory` is still legal in stg/prod**, and a probe confirms `ENV=prod` + `inmemory` validates with zero warnings. This PR makes that configuration *work correctly* rather than *safe*. See the issue comment I am adding for the evidence — including that archived ADR 029:149 already states the intent ("preventing accidental deployment with an in-process broker") that requiring the variable to be merely *set* does not achieve, and that the shipped Docker topology currently cannot run any other broker. That is a product decision with a real migration cost, so it is yours, not mine.
- The third `CoreContainer` (`src/_apps/worker/broker.py`) is untouched. Passing the server's own provider is what makes that harmless here.
