### PR TITLE
fix: close four post-merge review findings on the inline task runtime

### DIFF
--- a/src/_apps/server/bootstrap.py
+++ b/src/_apps/server/bootstrap.py
@@ -170,8 +170,15 @@ def _install_inline_task_runtime(container) -> None:
 
     3. **Only the inline broker is touched.** With a cross-process broker the
        tasks run in a real worker that installs its own stack, and installing it
-       here as well would double-register. The ``not middlewares`` guard also
-       keeps a repeated ``bootstrap_app`` call (test reloads) idempotent.
+       here as well would double-register.
+
+    A repeated ``bootstrap_app`` call is handled by ``install_task_middleware``
+    itself, which rebinds the notifier's provider rather than appending a second
+    stack. This used to be a ``not task_broker.middlewares`` guard here, which was
+    wrong in a way the comment claimed it was right: it skipped installation but
+    left the notifier holding the *first* container's ``error_notifier`` provider,
+    so a second bootstrap re-wired the domain tasks to the new container while
+    alert cooldowns kept keying off the discarded one.
 
     Not imported at module scope: ``src._apps.worker.broker`` constructs a
     ``CoreContainer`` at import time, and keeping that inside the function leaves
@@ -184,16 +191,27 @@ def _install_inline_task_runtime(container) -> None:
         install_task_middleware,
     )
     from src._apps.worker.broker import broker as task_broker
+    from src._apps.worker.tasks import audit_cleanup_task as _audit_cleanup
 
     if not isinstance(task_broker, InMemoryBroker):
         return
 
     core_container = container.core_container()
-    if not task_broker.middlewares:
-        install_task_middleware(
-            task_broker, error_notifier_provider=core_container.error_notifier
-        )
+    install_task_middleware(
+        task_broker, error_notifier_provider=core_container.error_notifier
+    )
     bootstrap_task_domains(container)
+    # `bootstrap_task_domains` covers `src/{domain}/` tasks only. The audit
+    # cleanup task lives under `_apps/worker/tasks/` and is wired by the worker
+    # bootstrap, which this process never calls — so without this line it ran with
+    # an unresolved `Provide[CoreContainer.database]` marker even though it *is*
+    # registered on this broker and therefore dispatchable from here. Probed after
+    # a server boot: `param database default_is_Provide=True`.
+    #
+    # Wiring against the server's core container is what makes the task use this
+    # process's database. Placed after the domain containers exist, per the
+    # ordering constraint `wire()` imposes (see worker/bootstrap.py).
+    core_container.wire(modules=[_audit_cleanup])
     _logger.info(
         "inline_task_runtime_installed",
         middlewares=[type(m).__name__ for m in task_broker.middlewares],

--- a/src/_apps/worker/bootstrap.py
+++ b/src/_apps/worker/bootstrap.py
@@ -98,7 +98,29 @@ def install_task_middleware(app: AsyncBroker, *, error_notifier_provider) -> Non
 
     The retry middleware is constructed once and shared: the notifier reads its
     retry defaults so the two cannot disagree about what "final attempt" means.
+    (It reads only *immutable* config off that instance — per-attempt state lives
+    in ``message.labels`` — so sharing is a config-drift guard, not a
+    state-sharing requirement.)
+
+    **Idempotent.** Called twice on one broker it rebinds the existing notifier's
+    provider instead of appending a second stack. The server calls this on the
+    module-level broker, and a process that bootstraps twice (test reloads, an
+    ASGI reloader) would otherwise end up with eight middlewares — and, worse,
+    with a notifier still holding the *first* container's ``error_notifier``
+    provider, so alert cooldowns would key off a discarded container.
     """
+    existing = next(
+        (
+            m
+            for m in app.middlewares
+            if isinstance(m, TaskFailureNotificationMiddleware)
+        ),
+        None,
+    )
+    if existing is not None:
+        existing._error_notifier_provider = error_notifier_provider
+        return
+
     retry_middleware = PermanentAwareSmartRetryMiddleware()
     app.add_middlewares(
         StructlogContextMiddleware(),

--- a/src/_core/infrastructure/logging/taskiq_middleware.py
+++ b/src/_core/infrastructure/logging/taskiq_middleware.py
@@ -38,12 +38,13 @@ Background: https://github.com/orgs/taskiq-python/discussions/273
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Iterable
 from typing import Any
 
 import structlog
 from pydantic import ValidationError
-from taskiq import TaskiqMessage, TaskiqMiddleware, TaskiqResult
+from taskiq import InMemoryBroker, TaskiqMessage, TaskiqMiddleware, TaskiqResult
 from taskiq.middlewares.smart_retry_middleware import SmartRetryMiddleware
 
 from src._core.exceptions.base_exception import BaseCustomException
@@ -138,7 +139,50 @@ class PermanentAwareSmartRetryMiddleware(SmartRetryMiddleware):
         result: TaskiqResult[Any],
         exception: BaseException,
     ) -> None:
+        # A cancelled task is not a transient failure. Taskiq's receiver catches
+        # `BaseException`, so `asyncio.CancelledError` arrives here like any other
+        # error and — being outside PERMANENT_ERROR_TYPES — used to schedule a
+        # retry. Probed: `CancelledError -> retry scheduled: True`.
+        #
+        # This was latent while the stack ran only in a worker, where cancellation
+        # means the process is going away anyway. It became reachable when #324
+        # installed the stack in the server process, where loop shutdown (uvicorn
+        # reload, test teardown) cancels the inline tasks: each cancellation
+        # spawned a fresh task on a loop that is closing, leaving orphaned
+        # pending tasks behind.
+        #
+        # Deliberately only suppressing the *retry*. Cancellation is still handed
+        # to the error-logging and notification middlewares, which decide for
+        # themselves whether it is worth reporting.
+        if isinstance(exception, asyncio.CancelledError):
+            return
+
         if isinstance(exception, self.PERMANENT_ERROR_TYPES):
             return
 
         await super().on_error(message, result, exception)
+
+    async def on_send(
+        self,
+        kicker: Any,
+        message: TaskiqMessage,
+        delay: float | None,
+    ) -> None:
+        """Honour the announced retry delay when the broker will not.
+
+        `SmartRetryMiddleware` computes a backoff, logs it ("Retrying 1/3 in 5.58
+        seconds") and writes it into `labels["delay"]`. Cross-process brokers
+        implement that label; `InMemoryBroker` does not — `kick()` ignores it and
+        goes straight to `asyncio.create_task`. Probed: three attempts completed
+        within 0.1s, at 0.033s and 0.018s intervals, against an announced 5.58s
+        and 11.37s.
+
+        That made "retry with backoff" mean "hammer three times immediately",
+        which is worse than useless for the transient failures retrying exists
+        for — a throttled LLM call gets three more requests inside 100ms. Sleeping
+        here is safe because this runs inside the detached task the inline broker
+        already created, not in the request path.
+        """
+        if delay is not None and isinstance(self.broker, InMemoryBroker):
+            await asyncio.sleep(delay)
+        await super().on_send(kicker, message, delay)

--- a/tests/e2e/_core/test_inline_task_runtime.py
+++ b/tests/e2e/_core/test_inline_task_runtime.py
@@ -1,0 +1,49 @@
+"""The cross-cutting audit task must be wired on the server's inline path.
+
+`bootstrap_task_domains` walks `discover_domains()`, so it covers `src/{domain}/`
+tasks only. The audit cleanup task lives under `_apps/worker/tasks/` and is wired
+by the worker bootstrap — which a server process never calls. It *is* registered
+on the broker the server executes tasks through, so it is dispatchable from here,
+and before this was fixed it ran with an unresolved marker:
+
+    AttributeError: 'Provide' object has no attribute 'session'
+
+Found by a post-merge review of #324, not by #324 itself. The domain half of the
+same bug was what #324 fixed; this is the piece its own fix did not cover.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# Import order matters: booting the server registers every domain model on
+# `Base.metadata`, and `admin_audit_log` carries a foreign key to `user`. Import
+# the task module first and collection dies on an unresolvable FK.
+from src._apps.server.app import app as _server_app  # noqa: F401
+from src._apps.worker.tasks.audit_cleanup_task import audit_cleanup_task
+
+
+@pytest.mark.asyncio
+async def test_the_audit_task_resolves_its_database_marker():
+    task = await audit_cleanup_task.kiq()
+    result = await task.wait_result(timeout=20)
+
+    rendered = str(result.error) if result.is_err else ""
+    assert "'Provide' object" not in rendered, (
+        "the audit task ran with an unresolved Provide marker — the server's "
+        "inline task runtime wired the domain tasks but not the cross-cutting one"
+    )
+    assert not result.is_err, (
+        f"audit cleanup failed: {type(result.error).__name__}: {rendered}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_audit_task_is_registered_on_the_broker_the_server_uses():
+    """Reachability is the reason the wiring matters. If this task were not
+    registered here, the finding above would be theoretical."""
+    from src._apps.worker.broker import broker
+    from src._core.config import settings
+
+    expected = f"{settings.task_name_prefix}._core.admin.audit_cleanup"
+    assert expected in broker.get_all_tasks()

--- a/tests/unit/_apps/worker/test_task_bootstrap_order.py
+++ b/tests/unit/_apps/worker/test_task_bootstrap_order.py
@@ -177,17 +177,41 @@ class TestInstallTaskMiddlewareIsReusable:
             "TaskFailureNotificationMiddleware"
         )
 
-    def test_installing_twice_is_what_the_server_guard_prevents(self):
-        """`install_task_middleware` itself is not idempotent — it appends. The
-        server checks `not broker.middlewares` before calling it; this pins the
-        reason that check exists."""
-        from src._apps.worker.bootstrap import install_task_middleware
+    def test_installing_twice_rebinds_rather_than_appending(self):
+        """Idempotent, and it rebinds the notifier's provider.
 
+        The first version of this test asserted the opposite — that a second call
+        appends — because the server guarded with `not broker.middlewares`. A
+        post-merge review showed that guard was wrong in the way its own comment
+        claimed it was right: it skipped installation but left the notifier
+        holding the *first* container's `error_notifier`, so a second bootstrap
+        re-wired the domain tasks to the new container while alert cooldowns kept
+        keying off the discarded one. The guard is gone; the installer is
+        idempotent instead.
+        """
+        from src._apps.worker.bootstrap import install_task_middleware
+        from src._core.infrastructure.notification.taskiq_middleware import (
+            TaskFailureNotificationMiddleware,
+        )
+
+        first_provider, second_provider = object(), object()
         broker = InMemoryBroker()
-        install_task_middleware(broker, error_notifier_provider=object())
-        first = len(broker.middlewares)
-        install_task_middleware(broker, error_notifier_provider=object())
-        assert len(broker.middlewares) == first * 2, (
-            "install_task_middleware became idempotent — the server's "
-            "`not middlewares` guard may now be dead code worth removing"
+
+        install_task_middleware(broker, error_notifier_provider=first_provider)
+        count = len(broker.middlewares)
+
+        install_task_middleware(broker, error_notifier_provider=second_provider)
+        assert len(broker.middlewares) == count, (
+            "a second install appended a duplicate stack; the server calls this "
+            "unconditionally, so a repeated bootstrap would double every hook"
+        )
+
+        notifier = next(
+            m
+            for m in broker.middlewares
+            if isinstance(m, TaskFailureNotificationMiddleware)
+        )
+        assert notifier._error_notifier_provider is second_provider, (
+            "the notifier kept the first container's provider, so alert cooldowns "
+            "would key off a discarded container"
         )

--- a/tests/unit/_core/infrastructure/logging/test_retry_middleware_inline_broker.py
+++ b/tests/unit/_core/infrastructure/logging/test_retry_middleware_inline_broker.py
@@ -1,0 +1,157 @@
+"""Retry behaviour that only matters once the stack runs in the server process.
+
+#324 installed `PermanentAwareSmartRetryMiddleware` on the inline broker, which
+runs tasks inside the server process. Two properties that were harmless in a
+worker became reachable there, and a post-merge review found both.
+
+**Cancellation spawned a retry.** Taskiq's receiver catches `BaseException`, so
+`asyncio.CancelledError` reaches `on_error` like any other error. Being outside
+`PERMANENT_ERROR_TYPES`, it scheduled a retry — on a loop that is shutting down.
+Probed before the fix:
+
+    CancelledError       retry scheduled: True
+    RuntimeError         retry scheduled: True
+    BaseCustomException  retry scheduled: False
+
+**The announced backoff was never applied.** `SmartRetryMiddleware` computes a
+delay, logs it ("Retrying 1/3 in 5.58 seconds") and writes it to
+`labels["delay"]`. Cross-process brokers implement that label; `InMemoryBroker`
+ignores it and calls `asyncio.create_task` immediately. Probed: three attempts
+finished within 0.1s, at 0.033s and 0.018s intervals, against an announced 5.58s
+and 11.37s. So "retry with backoff" meant "hammer three times at once" — the
+opposite of what helps a throttled provider.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+import taskiq.middlewares.smart_retry_middleware as smart_retry
+from pydantic import ValidationError
+from taskiq import InMemoryBroker, TaskiqMessage, TaskiqResult
+
+from src._core.exceptions.base_exception import BaseCustomException
+from src._core.infrastructure.logging.taskiq_middleware import (
+    PermanentAwareSmartRetryMiddleware,
+)
+
+
+@pytest.fixture
+def message() -> TaskiqMessage:
+    return TaskiqMessage(
+        task_id="t1",
+        task_name="probe.task",
+        labels={"max_retries": 3, "_retries": 0},
+        args=[],
+        kwargs={},
+    )
+
+
+@pytest.fixture
+def result() -> TaskiqResult:
+    return TaskiqResult(is_err=True, return_value=None, execution_time=0.0, error=None)
+
+
+@pytest.fixture
+def middleware() -> PermanentAwareSmartRetryMiddleware:
+    mw = PermanentAwareSmartRetryMiddleware()
+    mw.set_broker(InMemoryBroker())
+    return mw
+
+
+@pytest.fixture
+def captured_sends(monkeypatch) -> list:
+    """Record `SmartRetryMiddleware.on_send` calls without re-kicking anything."""
+    sends: list = []
+
+    async def _record(self, kicker, msg, delay):  # noqa: ANN001
+        sends.append(delay)
+
+    monkeypatch.setattr(smart_retry.SmartRetryMiddleware, "on_send", _record)
+    return sends
+
+
+class TestCancellationDoesNotRetry:
+    async def test_cancelled_error_schedules_no_retry(
+        self, middleware, message, result, captured_sends
+    ):
+        await middleware.on_error(message, result, asyncio.CancelledError())
+        assert captured_sends == [], (
+            "a cancelled task scheduled a retry; during loop shutdown that leaves "
+            "an orphaned pending task behind"
+        )
+
+    async def test_a_transient_error_still_retries(
+        self, middleware, message, result, captured_sends
+    ):
+        """The half that must not regress — suppressing cancellation must not
+        suppress the retries the middleware exists for."""
+        await middleware.on_error(message, result, RuntimeError("connection reset"))
+        assert captured_sends, "a transient error no longer retries"
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            BaseCustomException(status_code=400, message="curated"),
+            ValueError("bad input"),
+            TypeError("bad type"),
+        ],
+        ids=["custom", "value", "type"],
+    )
+    async def test_permanent_errors_still_skip_retry(
+        self, middleware, message, result, captured_sends, exc
+    ):
+        await middleware.on_error(message, result, exc)
+        assert captured_sends == []
+
+    def test_cancelled_error_is_not_in_the_permanent_set(self):
+        """The fix is a separate branch on purpose. Adding `CancelledError` to
+        `PERMANENT_ERROR_TYPES` would also change what the notifier treats as a
+        terminal failure worth alerting on, which is a different decision.
+        """
+        assert (
+            asyncio.CancelledError
+            not in PermanentAwareSmartRetryMiddleware.PERMANENT_ERROR_TYPES
+        )
+        # Guard the set itself so a future addition is a deliberate act.
+        assert set(PermanentAwareSmartRetryMiddleware.PERMANENT_ERROR_TYPES) == {
+            BaseCustomException,
+            ValueError,
+            TypeError,
+            ValidationError,
+        }
+
+
+class TestTheAnnouncedDelayIsHonouredOnTheInlineBroker:
+    DELAY = 0.3
+
+    async def test_inline_broker_waits(self, middleware, captured_sends):
+        started = time.monotonic()
+        await middleware.on_send(None, None, self.DELAY)
+        elapsed = time.monotonic() - started
+        assert elapsed >= self.DELAY * 0.8, (
+            f"waited {elapsed:.3f}s for an announced {self.DELAY}s backoff; the "
+            "inline broker ignores the delay label, so retries fire immediately"
+        )
+        assert captured_sends == [self.DELAY], "the re-kick was dropped, not delayed"
+
+    async def test_a_cross_process_broker_is_not_slept_on(self, captured_sends):
+        """Those brokers implement the delay label themselves. Sleeping here too
+        would double every backoff in production."""
+        from taskiq.brokers.shared_broker import AsyncSharedBroker
+
+        mw = PermanentAwareSmartRetryMiddleware()
+        mw.set_broker(AsyncSharedBroker())
+
+        started = time.monotonic()
+        await mw.on_send(None, None, self.DELAY)
+        assert time.monotonic() - started < self.DELAY / 2
+        assert captured_sends == [self.DELAY]
+
+    async def test_no_delay_means_no_sleep(self, middleware, captured_sends):
+        started = time.monotonic()
+        await middleware.on_send(None, None, None)
+        assert time.monotonic() - started < 0.05
+        assert captured_sends == [None]


### PR DESCRIPTION
Follow-up to #342 (issue #324). A post-merge cross review found four defects. **No revert is needed** — the core DI fix in #342 is sound; these are forward fixes. Each was re-verified by probe before and after, and two of the four are things #342 introduced.

## 1. The cross-cutting audit task was left unwired on the server path  [MEDIUM][CORR]

`bootstrap_task_domains` walks `discover_domains()`, so it covers `src/{domain}/` tasks only. The audit cleanup task lives under `_apps/worker/tasks/` and was wired by the worker bootstrap, which a server process never calls — while still being **registered on the broker the server executes tasks through**, so it is dispatchable from there.

Dispatched in a server-only process:

```
before: AttributeError: 'Provide' object has no attribute 'session'
after : DatabaseException          (reached the database layer)
```

This is the same class of bug #324 fixed for domain tasks. Its own fix did not cover the one task that is not under `src/{domain}/`, and I moved the module-level wire that had been covering it incidentally. The server now wires it against its **own** core container, after the domain containers exist, per the ordering constraint `wire()` imposes.

## 2. Cancellation scheduled a retry  [MEDIUM][STAB]

Taskiq's receiver catches `BaseException`, so `asyncio.CancelledError` reaches `on_error` like any other error and — being outside `PERMANENT_ERROR_TYPES` — scheduled a retry, on a loop that is shutting down.

```
before: CancelledError -> retry scheduled: True
after : CancelledError -> retry scheduled: False     (RuntimeError still True)
```

This was a latent property of the middleware, not something #342 wrote. What #342 changed is exposure: installing the stack in the server process is what made loop shutdown — uvicorn reload, test teardown — able to cancel inline tasks.

Deliberately a separate branch rather than adding `CancelledError` to `PERMANENT_ERROR_TYPES`: that set also governs what the notifier treats as a terminal failure worth alerting on, which is a different decision. A test pins the set's contents so a future addition is deliberate.

## 3. The announced retry backoff was never applied on the inline broker  [MEDIUM][STAB]

`SmartRetryMiddleware` computes a delay, logs it ("Retrying 1/3 in 5.58 seconds") and writes it to `labels["delay"]`. Cross-process brokers implement that label; `InMemoryBroker` ignores it and calls `asyncio.create_task` immediately. Measured: three attempts within 0.1s, at 0.033s and 0.018s intervals, against an announced 5.58s and 11.37s.

So "retry with backoff" meant "hammer three times at once" — the opposite of what helps a throttled provider. `on_send` now sleeps the announced delay when the broker is an `InMemoryBroker`, and only then. Safe because it runs inside the detached task the inline broker already created, not in the request path.

A test verifies a cross-process broker is **not** slept on — doing that would double every production backoff.

## 4. The `not middlewares` guard was wrong in the way its comment claimed it was right  [LOW][REG]

It skipped installation on a second `bootstrap_app()` but left the notifier holding the **first** container's `error_notifier` provider. So a repeated bootstrap re-wired the domain tasks to the new container while alert cooldowns kept keying off the discarded one — the opposite of the "test reloads idempotent" the comment asserted.

`install_task_middleware` is now genuinely idempotent: it rebinds the provider instead of appending a second stack, and the guard is gone.

The test I wrote in #342 asserting the installer is NOT idempotent has been inverted. Its own failure message had already named this outcome — *"install_task_middleware became idempotent — the server's `not middlewares` guard may now be dead code worth removing"* — which is how the change surfaced rather than slipping through.

## Verification

- `1704 passed, 42 skipped, 0 failed`.
- The two behavioural tests (audit-task wiring, cancellation, inline backoff) **fail against the pre-fix tree**; the remaining assertions are regression guards that pass either way, and are labelled as such.
- Runtime unchanged: 66s vs 63s. The backoff sleeps only on an actual retry, which the suite has few of.
- mypy reports the same 7 pre-existing errors under `src/_apps/admin/` and `src/_core/infrastructure/admin/` — verified identical on `origin/main`, not introduced here.
- `check_governor_footer.py --require-governor-footer` against the changed file list: `0 violations`, non-governor. Run, not assumed.

## One thing I got wrong while fixing this, worth recording

My first probe for finding 1 inspected the task function's **signature defaults** and reported `default_is_Provide=True` even after the fix — which briefly looked like the fix had failed. `dependency_injector.wire()` does not rewrite signature defaults; it patches the callable and injects at call time. The signature is simply the wrong instrument. Dispatching the task is the valid probe, which is what both the verification above and the shipped test use.

## Still open from #324, unchanged by this PR

`BROKER_TYPE=inmemory` remains legal in stg/prod. This PR makes the inline path *safer*; it does not make that configuration *safe*. The evidence and the migration cost are recorded in the #324 comment — it is a product decision.
