### PR TITLE
feat(core): bound the request body before the app parses it

### DIFF
--- a/_env/local.env.example
+++ b/_env/local.env.example
@@ -152,4 +152,11 @@ DYNAMODB_ENDPOINT_URL=http://localhost:8000
 # NOTIFICATION_WARNING_WEBHOOK_URL=https://hooks.slack.com/services/.../monitoring
 
 ALLOWED_HOSTS=["localhost","127.0.0.1"]
+# Maximum accepted request body in bytes (#322). Enforced by
+# BodySizeLimitMiddleware before the app reads the body, on both the
+# Content-Length path and the chunked path that carries no Content-Length.
+# Default 10485760 (10 MB). Set to 0 to disable — appropriate only when a
+# reverse proxy already bounds request bodies.
+MAX_REQUEST_BODY_BYTES=10485760
+
 ALLOW_ORIGINS=["*"]

--- a/_env/quickstart.env.example
+++ b/_env/quickstart.env.example
@@ -90,6 +90,13 @@ VECTOR_STORE_TYPE=inmemory
 # Network
 # ----------------------------------------------------------------
 ALLOWED_HOSTS=["localhost","127.0.0.1"]
+# Maximum accepted request body in bytes (#322). Enforced by
+# BodySizeLimitMiddleware before the app reads the body, on both the
+# Content-Length path and the chunked path that carries no Content-Length.
+# Default 10485760 (10 MB). Set to 0 to disable — appropriate only when a
+# reverse proxy already bounds request bodies.
+MAX_REQUEST_BODY_BYTES=10485760
+
 ALLOW_ORIGINS=["*"]
 
 # ----------------------------------------------------------------

--- a/src/_apps/server/bootstrap.py
+++ b/src/_apps/server/bootstrap.py
@@ -25,6 +25,9 @@ from src._core.exceptions.exception_handlers import (
 # the quickstart create_all call — importing here is the durable hook.
 from src._core.infrastructure.admin.audit import models as _audit_models  # noqa: F401
 from src._core.infrastructure.discovery import discover_domains
+from src._core.infrastructure.http.body_size_middleware import (
+    BodySizeLimitMiddleware,
+)
 from src._core.infrastructure.logging.configure import configure_logging
 from src._core.infrastructure.logging.request_log_middleware import (
     RequestLogMiddleware,
@@ -72,8 +75,20 @@ def _install_middleware(app: FastAPI) -> None:
     # CorrelationIdMiddleware must see the raw request first (so it can read /
     # generate X-Request-ID before the log middleware tries to bind it), so it
     # is added AFTER RequestLogMiddleware.
-    # Order after registration: Request → CorrelationId → RequestLog → CORS → TrustedHost → App
+    # Order after registration:
+    #   Request → CorrelationId → RequestLog → CORS → BodySizeLimit → TrustedHost → App
+    #
+    # BodySizeLimitMiddleware sits INSIDE CorrelationId/RequestLog and CORS, and
+    # every one of those placements is deliberate:
+    #   - inside CorrelationId + RequestLog, so a 413 still carries X-Request-ID
+    #     and still produces an access-log line. Outermost it would be invisible.
+    #   - inside CORS, so the 413 carries the CORS headers a browser needs in
+    #     order to read it at all.
+    #   - outside the app, so an over-long body is never handed to route parsing.
     app.add_middleware(TrustedHostMiddleware, allowed_hosts=settings.allowed_hosts)
+    app.add_middleware(
+        BodySizeLimitMiddleware, max_bytes=settings.max_request_body_bytes
+    )
     app.add_middleware(
         CORSMiddleware,
         allow_origins=settings.allow_origins,

--- a/src/_apps/server/bootstrap.py
+++ b/src/_apps/server/bootstrap.py
@@ -85,6 +85,10 @@ def _install_middleware(app: FastAPI) -> None:
     #   - inside CORS, so the 413 carries the CORS headers a browser needs in
     #     order to read it at all.
     #   - outside the app, so an over-long body is never handed to route parsing.
+    # The cost of being inside CORS is that a CORS preflight never reaches it —
+    # CORSMiddleware answers those itself. Measured and accepted: nothing reads a
+    # preflight body, so bounding it would buy nothing and cost the 413 its CORS
+    # headers. See the module docstring for the full scope of the guarantee.
     app.add_middleware(TrustedHostMiddleware, allowed_hosts=settings.allowed_hosts)
     app.add_middleware(
         BodySizeLimitMiddleware, max_bytes=settings.max_request_body_bytes

--- a/src/_apps/server/bootstrap.py
+++ b/src/_apps/server/bootstrap.py
@@ -86,9 +86,11 @@ def _install_middleware(app: FastAPI) -> None:
     #     order to read it at all.
     #   - outside the app, so an over-long body is never handed to route parsing.
     # The cost of being inside CORS is that a CORS preflight never reaches it —
-    # CORSMiddleware answers those itself. Measured and accepted: nothing reads a
-    # preflight body, so bounding it would buy nothing and cost the 413 its CORS
-    # headers. See the module docstring for the full scope of the guarantee.
+    # CORSMiddleware answers those itself. Measured and accepted: a preflight body
+    # is never delivered to the application, so bounding it would buy nothing at
+    # this layer and would cost the 413 its CORS headers. See the module docstring
+    # for the full scope of the guarantee, which is about bytes reaching route
+    # parsing rather than bytes reaching the process.
     app.add_middleware(TrustedHostMiddleware, allowed_hosts=settings.allowed_hosts)
     app.add_middleware(
         BodySizeLimitMiddleware, max_bytes=settings.max_request_body_bytes

--- a/src/_core/config.py
+++ b/src/_core/config.py
@@ -505,6 +505,16 @@ class Settings(BaseSettings):
         default=["*"],
         validation_alias="ALLOW_ORIGINS",
     )
+    # Upper bound on a request body, enforced by BodySizeLimitMiddleware before
+    # the app reads it (#322). 10 MB is deliberately generous: the RAG document
+    # endpoint accepts long content, and a limit that rejects realistic JSON
+    # would be turned off rather than tuned. Set to 0 to disable enforcement —
+    # appropriate only when a reverse proxy already bounds it.
+    max_request_body_bytes: int = Field(
+        default=10 * 1024 * 1024,
+        ge=0,
+        validation_alias="MAX_REQUEST_BODY_BYTES",
+    )
 
     # ----------------------------------------------------------------
     # Logging (structlog)

--- a/src/_core/infrastructure/http/body_size_middleware.py
+++ b/src/_core/infrastructure/http/body_size_middleware.py
@@ -10,8 +10,10 @@ Measured against `POST /v1/user`, which requires an admin token:
     64MB -> 401 in 0.28s      <- the body was read before the 401
 
 The collection bounds from the same issue cap how much *work* a valid body can
-trigger (`Field(max_length=100)` on the batch endpoints). This caps how much
-*body* the process will hold at all.
+trigger (`Field(max_length=100)` on the batch endpoints). This caps the
+cumulative request bytes delivered past this middleware to route parsing, for
+an app that consumes the ASGI receive stream. It is not a bound on what the
+HTTP server buffers before this middleware is invoked.
 
 Two enforcement points, and the second is the one that matters
 --------------------------------------------------------------
@@ -28,14 +30,16 @@ an over-long body is accepted.
 
 What this does NOT guarantee
 ---------------------------
-Two gaps, both measured, both deliberate. Neither re-introduces the parse-cost
-problem above — in both the body is never read by anything — but a claim of
-"every request is bounded" would be false, so:
+Two gaps, both measured, both deliberate. Neither delivers the body to route
+parsing, so neither re-introduces the parse-cost problem above — but they do
+not bound buffering the HTTP server may already have done, and a claim of
+"every request is bounded" would be false. So:
 
 - **The byte counter only runs when the app calls ``receive()``.** An endpoint
   that returns without reading the body is not bounded by it (the header check
-  still applies). Nothing parses those bytes, so there is no allocation to
-  prevent; they are simply discarded by the protocol server.
+  still applies). This middleware never calls ``receive()`` on that path, so
+  the bytes are never delivered to the application — what the protocol server
+  does with them is outside this middleware's control.
 - **A CORS preflight never reaches this middleware.** ``CORSMiddleware`` sits
   outside it and answers ``OPTIONS`` + ``Access-Control-Request-Method`` itself.
   Measured against the shipped order: preflight with an 11-byte body against a
@@ -45,8 +49,9 @@ problem above — in both the body is never read by anything — but a claim of
   headers a browser needs in order to read it.
 
 If a deployment needs "no request over N bytes reaches the process at all", that
-belongs at the ingress proxy. This middleware bounds what the *application* will
-hold and parse.
+belongs at the ingress proxy. This middleware does not bound ingress or
+protocol-server buffering, nor an individual ASGI frame already materialised
+before it observes it.
 """
 
 from __future__ import annotations
@@ -67,7 +72,13 @@ class _RejectionState:
     key names, and so `rejected` reads as the latch it is.
     """
 
-    __slots__ = ("received", "rejected", "rejection_sent", "response_started")
+    __slots__ = (
+        "received",
+        "rejected",
+        "rejection_sent",
+        "response_completed",
+        "response_started",
+    )
 
     def __init__(self) -> None:
         self.received = 0
@@ -77,6 +88,9 @@ class _RejectionState:
         # response we stop the body WITHOUT sending our own 413. Only a
         # response we actually sent licenses swallowing the app's exception.
         self.rejection_sent = False
+        # Whether a terminal (``more_body=False``) frame has gone out. Used to
+        # close a response we did not start but had to cut short.
+        self.response_completed = False
 
 
 class BodySizeLimitMiddleware:
@@ -170,6 +184,22 @@ class BodySizeLimitMiddleware:
                         limit_bytes=self.max_bytes,
                         received_bytes=state.received,
                     )
+                    # Close the response the app committed, rather than relying on
+                    # the app to close it. Forwarding its frames until it decides
+                    # to stop is not a termination guarantee: an app that ignores
+                    # `http.disconnect` and keeps emitting `more_body=True` would
+                    # hold the connection open indefinitely. That app is violating
+                    # the ASGI contract, but a size limit should not depend on the
+                    # app behaving to be able to end the request.
+                    if not state.response_completed:
+                        await send(
+                            {
+                                "type": "http.response.body",
+                                "body": b"",
+                                "more_body": False,
+                            }
+                        )
+                        state.response_completed = True
                     return {"type": "http.disconnect"}
                 await self._reject(
                     scope, send, declared=None, received=state.received, state=state
@@ -182,21 +212,18 @@ class BodySizeLimitMiddleware:
     def _guarded_send(self, send: Send, state: _RejectionState) -> Send:
         async def guarded_send(message: Message) -> None:
             if state.rejected:
-                if state.response_started and message["type"] == "http.response.body":
-                    # The app committed a response before we cut the body off, so
-                    # its status is already on the wire and ours never went out.
-                    # Its body frames must still flow or the client is left with
-                    # headers and no body — a hung connection, which is a worse
-                    # outcome than the oversized body. Only `http.response.start`
-                    # is suppressed here, and only because a second one is an ASGI
-                    # protocol violation.
-                    await send(message)
-                    return
-                # We sent the 413. Whatever the app produces from a truncated
-                # body — a 422, a 500 — must not become a second response.
+                # Nothing more goes out. Either we sent the 413, or we terminated
+                # the response the app had already committed — in both cases the
+                # response is complete and anything the app produces from a
+                # truncated body (a 422, a 500, more body frames) would be either a
+                # second response or an unbounded tail.
                 return
             if message["type"] == "http.response.start":
                 state.response_started = True
+            elif message["type"] == "http.response.body" and not message.get(
+                "more_body", False
+            ):
+                state.response_completed = True
             await send(message)
 
         return guarded_send

--- a/src/_core/infrastructure/http/body_size_middleware.py
+++ b/src/_core/infrastructure/http/body_size_middleware.py
@@ -25,8 +25,9 @@ against this app:
     64MB (chunked) -> Content-Length present: False
 
 So this middleware also counts bytes as they stream and aborts mid-body. The
-header check is kept because it is free and fails fast, before a single byte of
-an over-long body is accepted.
+header check is kept because it is free and fails fast — before any of the body
+is delivered to the wrapped app, though not before the HTTP server has accepted
+it off the socket, which is not this middleware's to control.
 
 What this does NOT guarantee
 ---------------------------
@@ -73,6 +74,7 @@ class _RejectionState:
     """
 
     __slots__ = (
+        "declared_response_length",
         "received",
         "rejected",
         "rejection_sent",
@@ -88,9 +90,13 @@ class _RejectionState:
         # response we stop the body WITHOUT sending our own 413. Only a
         # response we actually sent licenses swallowing the app's exception.
         self.rejection_sent = False
-        # Whether a terminal (``more_body=False``) frame has gone out. Used to
-        # close a response we did not start but had to cut short.
+        # Whether a terminal (``more_body=False``) frame has gone out — ours or
+        # the app's. Used to avoid double-terminating.
         self.response_completed = False
+        # Set when the app's own `http.response.start` declared a
+        # `content-length`. A fixed-length response cannot be truncated: see
+        # `_close_committed_response`.
+        self.declared_response_length = False
 
 
 class BodySizeLimitMiddleware:
@@ -184,22 +190,7 @@ class BodySizeLimitMiddleware:
                         limit_bytes=self.max_bytes,
                         received_bytes=state.received,
                     )
-                    # Close the response the app committed, rather than relying on
-                    # the app to close it. Forwarding its frames until it decides
-                    # to stop is not a termination guarantee: an app that ignores
-                    # `http.disconnect` and keeps emitting `more_body=True` would
-                    # hold the connection open indefinitely. That app is violating
-                    # the ASGI contract, but a size limit should not depend on the
-                    # app behaving to be able to end the request.
-                    if not state.response_completed:
-                        await send(
-                            {
-                                "type": "http.response.body",
-                                "body": b"",
-                                "more_body": False,
-                            }
-                        )
-                        state.response_completed = True
+                    await self._close_committed_response(send, state)
                     return {"type": "http.disconnect"}
                 await self._reject(
                     scope, send, declared=None, received=state.received, state=state
@@ -212,14 +203,26 @@ class BodySizeLimitMiddleware:
     def _guarded_send(self, send: Send, state: _RejectionState) -> Send:
         async def guarded_send(message: Message) -> None:
             if state.rejected:
-                # Nothing more goes out. Either we sent the 413, or we terminated
-                # the response the app had already committed — in both cases the
-                # response is complete and anything the app produces from a
-                # truncated body (a 422, a 500, more body frames) would be either a
-                # second response or an unbounded tail.
+                if state.response_started and not state.response_completed:
+                    # We could not terminate this response ourselves — it declared
+                    # a `content-length`, so an empty terminal frame would be a
+                    # protocol error. The app's own frames are the only thing that
+                    # can satisfy the length it promised, so they keep flowing.
+                    if message["type"] == "http.response.body":
+                        if not message.get("more_body", False):
+                            state.response_completed = True
+                        await send(message)
+                    return
+                # Either we sent the 413, or we terminated the response the app had
+                # committed. Anything further — a 422, a 500, more body frames —
+                # would be a second response or an unbounded tail.
                 return
             if message["type"] == "http.response.start":
                 state.response_started = True
+                state.declared_response_length = any(
+                    key.lower() == b"content-length"
+                    for key, _ in message.get("headers") or ()
+                )
             elif message["type"] == "http.response.body" and not message.get(
                 "more_body", False
             ):
@@ -227,6 +230,41 @@ class BodySizeLimitMiddleware:
             await send(message)
 
         return guarded_send
+
+    async def _close_committed_response(
+        self, send: Send, state: _RejectionState
+    ) -> None:
+        """End a response the app had already started, when that is safe to do.
+
+        Three options exist once the app's ``http.response.start`` is on the wire
+        and the limit then trips, and only one is correct per case:
+
+        - **Drop the app's frames.** The response never terminates; the client
+          holds headers and an open connection.
+        - **Forward them.** No termination guarantee — an app ignoring
+          ``http.disconnect`` and emitting ``more_body=True`` holds the connection
+          open. Such an app violates the ASGI contract, but that is not a defence.
+        - **Synthesize an empty terminal frame.** Only valid when the response did
+          not declare a length. Against a declared ``content-length`` it is a
+          protocol error, confirmed directly against h11::
+
+              LocalProtocolError: Too little data for declared Content-Length
+
+        So the choice is made on what the app declared. With no ``content-length``
+        the response is chunked or connection-delimited and an empty terminal frame
+        ends it cleanly. With one, only the app's own frames can satisfy the length
+        it promised, so they are forwarded and termination depends on the app
+        honouring ``http.disconnect`` — which is exactly what the ASGI spec
+        requires of it.
+
+        A middleware cannot do better than this from behind an already-sent
+        response start. Deciding earlier would mean withholding the start until the
+        body is known to fit, which would break streaming responses outright.
+        """
+        if state.response_completed or state.declared_response_length:
+            return
+        await send({"type": "http.response.body", "body": b"", "more_body": False})
+        state.response_completed = True
 
     async def _reject(
         self,
@@ -269,3 +307,5 @@ class BodySizeLimitMiddleware:
         )
         await send({"type": "http.response.body", "body": body, "more_body": False})
         state.rejection_sent = True
+        # Keep `response_completed` honest: a terminal frame HAS gone out.
+        state.response_completed = True

--- a/src/_core/infrastructure/http/body_size_middleware.py
+++ b/src/_core/infrastructure/http/body_size_middleware.py
@@ -31,14 +31,16 @@ it off the socket, which is not this middleware's to control.
 
 What this does NOT guarantee
 ---------------------------
-Two gaps, both measured, both deliberate. Neither delivers the body to route
-parsing, so neither re-introduces the parse-cost problem above — but they do
-not bound buffering the HTTP server may already have done, and a claim of
-"every request is bounded" would be false. So:
+Three gaps, all measured, all deliberate, and they are not equivalent. The first
+two never deliver the body to route parsing, so they do not re-introduce the
+parse-cost problem above. The third does deliver it — deliberately, because by
+then the app has already produced a response and the parse has already happened.
+None of them bounds buffering the HTTP server may have done before this middleware
+runs. A claim of "every request is bounded" would be false, so:
 
 - **The byte counter only runs when the app calls ``receive()``.** An endpoint
   that returns without reading the body is not bounded by it (the header check
-  still applies). This middleware never calls ``receive()`` on that path, so
+  still applies — though a chunked caller carries no header for it to check). This middleware never calls ``receive()`` on that path, so
   the bytes are never delivered to the application — what the protocol server
   does with them is outside this middleware's control.
 - **A CORS preflight never reaches this middleware.** ``CORSMiddleware`` sits
@@ -49,8 +51,30 @@ not bound buffering the HTTP server may already have done, and a claim of
   bound preflight bodies nobody reads, at the cost of the 413 losing the CORS
   headers a browser needs in order to read it.
 
+- **A response already begun is never turned into a 413.** If the app sent its
+  ``http.response.start`` before the limit tripped, the status is not ours to set:
+  the counter logs ``request_body_too_large_after_response_started`` and **stops
+  enforcing** for that request, letting the response the app committed complete
+  untouched. Accepted because the threat this middleware exists to stop — a body
+  parsed before auth can reject it — is already past once the app has produced a
+  response, and because no shipped route can reach it: there is no
+  ``StreamingResponse``, ``FileResponse`` or ``request.stream()`` anywhere in
+  ``src/`` or ``examples/``. The trade is that a streaming proxy endpoint would be
+  unbounded after it commits; an ingress limit covers that.
+
+  Three earlier versions tried to *act* here instead — drop the app's frames
+  (response never terminates), forward them (no termination guarantee), synthesize
+  an empty terminal frame (corrupts a declared ``content-length``; h11 raises
+  "Too little data for declared Content-Length"). Four of this module's six review
+  findings came from that subtree. Do not reintroduce it without a route that
+  needs it.
+
 If a deployment needs "no request over N bytes reaches the process at all", that
-belongs at the ingress proxy. This middleware does not bound ingress or
+belongs at the ingress proxy. Note also that a 413 does not close the connection,
+so a conforming server drains the rejected body before reusing it — the bytes still
+cross the wire. ``Connection: close`` on the 413 is the nginx behaviour and a
+defensible hardening; it is not done here because it costs a legitimate client its
+keep-alive and risks RST-truncating the 413 body off-loopback. This middleware does not bound ingress or
 protocol-server buffering, nor an individual ASGI frame already materialised
 before it observes it.
 """
@@ -67,36 +91,29 @@ _HTTP_REQUEST_ENTITY_TOO_LARGE = 413
 
 
 class _RejectionState:
-    """Shared between the wrapped ``receive`` and ``send`` for one request.
-
-    A plain object rather than a dict so the two closures cannot disagree about
-    key names, and so `rejected` reads as the latch it is.
-    """
+    """Shared between the wrapped ``receive`` and ``send`` for one request."""
 
     __slots__ = (
-        "declared_response_length",
+        "enforcement_stopped",
         "received",
         "rejected",
         "rejection_sent",
-        "response_completed",
         "response_started",
     )
 
     def __init__(self) -> None:
         self.received = 0
+        # Set once a 413 has been *sent*. Licenses dropping the app's late
+        # response and swallowing the unwind exception the truncated body causes.
         self.rejected = False
-        self.response_started = False
-        # Distinct from `rejected`: when the app had already committed a
-        # response we stop the body WITHOUT sending our own 413. Only a
-        # response we actually sent licenses swallowing the app's exception.
+        # Set only after `_reject` finished writing. If it fails partway the
+        # response is not on the wire, so the exception must keep propagating.
         self.rejection_sent = False
-        # Whether a terminal (``more_body=False``) frame has gone out — ours or
-        # the app's. Used to avoid double-terminating.
-        self.response_completed = False
-        # Set when the app's own `http.response.start` declared a
-        # `content-length`. A fixed-length response cannot be truncated: see
-        # `_close_committed_response`.
-        self.declared_response_length = False
+        self.response_started = False
+        # Set when the limit is crossed *after* the app committed a response. At
+        # that point the status is not ours to set, so enforcement stops rather
+        # than trying to alter a response already in flight — see `__call__`.
+        self.enforcement_stopped = False
 
 
 class BodySizeLimitMiddleware:
@@ -165,106 +182,62 @@ class BodySizeLimitMiddleware:
     ) -> Receive:
         async def counting_receive() -> Message:
             if state.rejected:
-                # The app is still reading. Keep telling it the client is gone so
+                # A 413 is on the wire. Keep telling the app the client is gone so
                 # it unwinds instead of blocking on a stream we stopped serving.
                 return {"type": "http.disconnect"}
 
             message = await receive()
-            if message["type"] != "http.request":
+            if message["type"] != "http.request" or state.enforcement_stopped:
                 return message
 
             state.received += len(message.get("body", b""))
-            if state.received > self.max_bytes:
-                state.rejected = True
-                if state.response_started:
-                    # A streaming endpoint can start responding while it is still
-                    # reading. Its `http.response.start` is already on the wire, so
-                    # emitting a 413 start here would be a *second* one, which ASGI
-                    # servers refuse ("Unexpected message" on uvicorn). The status
-                    # is no longer ours to set; all we can still do is stop feeding
-                    # the body and let the response it already began finish.
-                    _logger.warning(
-                        "request_body_too_large_after_response_started",
-                        http_method=scope.get("method"),
-                        http_path=scope.get("path"),
-                        limit_bytes=self.max_bytes,
-                        received_bytes=state.received,
-                    )
-                    await self._close_committed_response(send, state)
-                    return {"type": "http.disconnect"}
-                await self._reject(
-                    scope, send, declared=None, received=state.received, state=state
+            if state.received <= self.max_bytes:
+                return message
+
+            if state.response_started:
+                # The app already committed a response, so the status is no longer
+                # ours and the parse-cost this middleware exists to prevent is
+                # already past — the app produced a response, so it got what it
+                # needed from the body. Log it and get out of the way.
+                #
+                # Three earlier attempts tried to *act* here and each was wrong.
+                # Dropping the app's frames left the response unterminated.
+                # Forwarding them gave no termination guarantee. Synthesizing an
+                # empty terminal frame corrupted any response that declared a
+                # `content-length` — h11: "Too little data for declared
+                # Content-Length". Four of this module's six review findings came
+                # from that subtree, and no shipped route can even reach it: there
+                # is no `StreamingResponse`, `FileResponse` or `request.stream()`
+                # anywhere in `src/` or `examples/`.
+                state.enforcement_stopped = True
+                _logger.warning(
+                    "request_body_too_large_after_response_started",
+                    http_method=scope.get("method"),
+                    http_path=scope.get("path"),
+                    limit_bytes=self.max_bytes,
+                    received_bytes=state.received,
                 )
-                return {"type": "http.disconnect"}
-            return message
+                return message
+
+            state.rejected = True
+            await self._reject(
+                scope, send, declared=None, received=state.received, state=state
+            )
+            return {"type": "http.disconnect"}
 
         return counting_receive
 
     def _guarded_send(self, send: Send, state: _RejectionState) -> Send:
         async def guarded_send(message: Message) -> None:
             if state.rejected:
-                if state.response_started and not state.response_completed:
-                    # We could not terminate this response ourselves — it declared
-                    # a `content-length`, so an empty terminal frame would be a
-                    # protocol error. The app's own frames are the only thing that
-                    # can satisfy the length it promised, so they keep flowing.
-                    if message["type"] == "http.response.body":
-                        if not message.get("more_body", False):
-                            state.response_completed = True
-                        await send(message)
-                    return
-                # Either we sent the 413, or we terminated the response the app had
-                # committed. Anything further — a 422, a 500, more body frames —
-                # would be a second response or an unbounded tail.
+                # The 413 is the response. Whatever the app produces from a
+                # truncated body — a 422, a 500 — must not become a second one.
                 return
             if message["type"] == "http.response.start":
                 state.response_started = True
-                state.declared_response_length = any(
-                    key.lower() == b"content-length"
-                    for key, _ in message.get("headers") or ()
-                )
-            elif message["type"] == "http.response.body" and not message.get(
-                "more_body", False
-            ):
-                state.response_completed = True
             await send(message)
 
         return guarded_send
-
-    async def _close_committed_response(
-        self, send: Send, state: _RejectionState
-    ) -> None:
-        """End a response the app had already started, when that is safe to do.
-
-        Three options exist once the app's ``http.response.start`` is on the wire
-        and the limit then trips, and only one is correct per case:
-
-        - **Drop the app's frames.** The response never terminates; the client
-          holds headers and an open connection.
-        - **Forward them.** No termination guarantee — an app ignoring
-          ``http.disconnect`` and emitting ``more_body=True`` holds the connection
-          open. Such an app violates the ASGI contract, but that is not a defence.
-        - **Synthesize an empty terminal frame.** Only valid when the response did
-          not declare a length. Against a declared ``content-length`` it is a
-          protocol error, confirmed directly against h11::
-
-              LocalProtocolError: Too little data for declared Content-Length
-
-        So the choice is made on what the app declared. With no ``content-length``
-        the response is chunked or connection-delimited and an empty terminal frame
-        ends it cleanly. With one, only the app's own frames can satisfy the length
-        it promised, so they are forwarded and termination depends on the app
-        honouring ``http.disconnect`` — which is exactly what the ASGI spec
-        requires of it.
-
-        A middleware cannot do better than this from behind an already-sent
-        response start. Deciding earlier would mean withholding the start until the
-        body is known to fit, which would break streaming responses outright.
-        """
-        if state.response_completed or state.declared_response_length:
-            return
-        await send({"type": "http.response.body", "body": b"", "more_body": False})
-        state.response_completed = True
 
     async def _reject(
         self,
@@ -307,5 +280,3 @@ class BodySizeLimitMiddleware:
         )
         await send({"type": "http.response.body", "body": body, "more_body": False})
         state.rejection_sent = True
-        # Keep `response_completed` honest: a terminal frame HAS gone out.
-        state.response_completed = True

--- a/src/_core/infrastructure/http/body_size_middleware.py
+++ b/src/_core/infrastructure/http/body_size_middleware.py
@@ -25,6 +25,28 @@ against this app:
 So this middleware also counts bytes as they stream and aborts mid-body. The
 header check is kept because it is free and fails fast, before a single byte of
 an over-long body is accepted.
+
+What this does NOT guarantee
+---------------------------
+Two gaps, both measured, both deliberate. Neither re-introduces the parse-cost
+problem above — in both the body is never read by anything — but a claim of
+"every request is bounded" would be false, so:
+
+- **The byte counter only runs when the app calls ``receive()``.** An endpoint
+  that returns without reading the body is not bounded by it (the header check
+  still applies). Nothing parses those bytes, so there is no allocation to
+  prevent; they are simply discarded by the protocol server.
+- **A CORS preflight never reaches this middleware.** ``CORSMiddleware`` sits
+  outside it and answers ``OPTIONS`` + ``Access-Control-Request-Method`` itself.
+  Measured against the shipped order: preflight with an 11-byte body against a
+  10-byte limit returns 200, while a non-preflight ``OPTIONS`` returns 413. The
+  placement is still the right trade: moving this middleware outside CORS would
+  bound preflight bodies nobody reads, at the cost of the 413 losing the CORS
+  headers a browser needs in order to read it.
+
+If a deployment needs "no request over N bytes reaches the process at all", that
+belongs at the ingress proxy. This middleware bounds what the *application* will
+hold and parse.
 """
 
 from __future__ import annotations
@@ -45,12 +67,16 @@ class _RejectionState:
     key names, and so `rejected` reads as the latch it is.
     """
 
-    __slots__ = ("received", "rejected", "response_started")
+    __slots__ = ("received", "rejected", "rejection_sent", "response_started")
 
     def __init__(self) -> None:
         self.received = 0
         self.rejected = False
         self.response_started = False
+        # Distinct from `rejected`: when the app had already committed a
+        # response we stop the body WITHOUT sending our own 413. Only a
+        # response we actually sent licenses swallowing the app's exception.
+        self.rejection_sent = False
 
 
 class BodySizeLimitMiddleware:
@@ -71,9 +97,12 @@ class BodySizeLimitMiddleware:
             await self.app(scope, receive, send)
             return
 
+        state = _RejectionState()
         declared = self._declared_length(scope)
         if declared is not None and declared > self.max_bytes:
-            await self._reject(scope, send, declared=declared, received=None)
+            await self._reject(
+                scope, send, declared=declared, received=None, state=state
+            )
             return
 
         # Both sides are wrapped. Rejecting mid-stream means responding from the
@@ -82,7 +111,6 @@ class BodySizeLimitMiddleware:
         # `assert not response_started`, and uvicorn raises "Unexpected message".
         # Guarding `send` is what actually makes "the app's response is
         # discarded" true; an earlier version only claimed it and crashed.
-        state = _RejectionState()
         try:
             await self.app(
                 scope,
@@ -97,7 +125,7 @@ class BodySizeLimitMiddleware:
             # letting it propagate would surface as a server error for a request
             # that was correctly rejected. If we have NOT rejected, the exception
             # is a real one and must keep propagating.
-            if not state.rejected:
+            if not state.rejection_sent:
                 raise
 
     def _declared_length(self, scope: Scope) -> int | None:
@@ -143,7 +171,9 @@ class BodySizeLimitMiddleware:
                         received_bytes=state.received,
                     )
                     return {"type": "http.disconnect"}
-                await self._reject(scope, send, declared=None, received=state.received)
+                await self._reject(
+                    scope, send, declared=None, received=state.received, state=state
+                )
                 return {"type": "http.disconnect"}
             return message
 
@@ -152,9 +182,18 @@ class BodySizeLimitMiddleware:
     def _guarded_send(self, send: Send, state: _RejectionState) -> Send:
         async def guarded_send(message: Message) -> None:
             if state.rejected:
-                # The 413 is already on the wire. Whatever the app produces from a
-                # truncated body — a 422, a 500 — must not be sent as a second
-                # response.
+                if state.response_started and message["type"] == "http.response.body":
+                    # The app committed a response before we cut the body off, so
+                    # its status is already on the wire and ours never went out.
+                    # Its body frames must still flow or the client is left with
+                    # headers and no body — a hung connection, which is a worse
+                    # outcome than the oversized body. Only `http.response.start`
+                    # is suppressed here, and only because a second one is an ASGI
+                    # protocol violation.
+                    await send(message)
+                    return
+                # We sent the 413. Whatever the app produces from a truncated
+                # body — a 422, a 500 — must not become a second response.
                 return
             if message["type"] == "http.response.start":
                 state.response_started = True
@@ -163,7 +202,13 @@ class BodySizeLimitMiddleware:
         return guarded_send
 
     async def _reject(
-        self, scope: Scope, send: Send, *, declared: int | None, received: int | None
+        self,
+        scope: Scope,
+        send: Send,
+        *,
+        declared: int | None,
+        received: int | None,
+        state: _RejectionState,
     ) -> None:
         _logger.warning(
             "request_body_too_large",
@@ -196,3 +241,4 @@ class BodySizeLimitMiddleware:
             }
         )
         await send({"type": "http.response.body", "body": body, "more_body": False})
+        state.rejection_sent = True

--- a/src/_core/infrastructure/http/body_size_middleware.py
+++ b/src/_core/infrastructure/http/body_size_middleware.py
@@ -1,0 +1,188 @@
+"""Reject oversized request bodies before the app parses them (#322).
+
+Nothing bounded request bodies. FastAPI reads and JSON-parses the whole body
+before validation — or even authentication — can reject it, so an unauthenticated
+caller could make the process allocate and parse an arbitrarily large document.
+Measured against `POST /v1/user`, which requires an admin token:
+
+    1MB  -> 401 in 0.05s
+    16MB -> 401 in 0.07s
+    64MB -> 401 in 0.28s      <- the body was read before the 401
+
+The collection bounds from the same issue cap how much *work* a valid body can
+trigger (`Field(max_length=100)` on the batch endpoints). This caps how much
+*body* the process will hold at all.
+
+Two enforcement points, and the second is the one that matters
+--------------------------------------------------------------
+A `Content-Length` check alone is not a control: HTTP/1.1 chunked transfer
+encoding sends no `Content-Length`, and a caller who omits it skips a
+header-only check entirely. Verified that httpx builds exactly such a request
+against this app:
+
+    64MB (chunked) -> Content-Length present: False
+
+So this middleware also counts bytes as they stream and aborts mid-body. The
+header check is kept because it is free and fails fast, before a single byte of
+an over-long body is accepted.
+"""
+
+from __future__ import annotations
+
+import structlog
+from starlette.datastructures import Headers
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+_logger = structlog.stdlib.get_logger(__name__)
+
+_HTTP_REQUEST_ENTITY_TOO_LARGE = 413
+
+# Methods that carry no body worth measuring. GET with a body is legal but
+# meaningless here, and skipping them keeps the hot path free of a wrapper.
+_BODYLESS_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "DELETE", "TRACE"})
+
+
+class _RejectionState:
+    """Shared between the wrapped ``receive`` and ``send`` for one request.
+
+    A plain object rather than a dict so the two closures cannot disagree about
+    key names, and so `rejected` reads as the latch it is.
+    """
+
+    __slots__ = ("received", "rejected")
+
+    def __init__(self) -> None:
+        self.received = 0
+        self.rejected = False
+
+
+class BodySizeLimitMiddleware:
+    """Pure-ASGI middleware bounding the request body.
+
+    Deliberately not a ``BaseHTTPMiddleware`` subclass: that base buffers the
+    whole request into a ``Request`` object to hand a body to the endpoint, which
+    is the exact allocation this exists to prevent. Working at the ASGI level lets
+    the byte counter run against the raw ``receive`` stream and stop it partway.
+    """
+
+    def __init__(self, app: ASGIApp, *, max_bytes: int) -> None:
+        self.app = app
+        self.max_bytes = max_bytes
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http" or self.max_bytes <= 0:
+            await self.app(scope, receive, send)
+            return
+
+        if scope.get("method", "").upper() in _BODYLESS_METHODS:
+            await self.app(scope, receive, send)
+            return
+
+        declared = self._declared_length(scope)
+        if declared is not None and declared > self.max_bytes:
+            await self._reject(scope, send, declared=declared, received=None)
+            return
+
+        # Both sides are wrapped. Rejecting mid-stream means responding from the
+        # receive side while the app still intends to respond, and an ASGI server
+        # rejects the second `http.response.start` — httpx's transport fails on
+        # `assert not response_started`, and uvicorn raises "Unexpected message".
+        # Guarding `send` is what actually makes "the app's response is
+        # discarded" true; an earlier version only claimed it and crashed.
+        state = _RejectionState()
+        try:
+            await self.app(
+                scope,
+                self._counting_receive(scope, send, receive, state),
+                self._guarded_send(send, state),
+            )
+        except Exception:
+            # Only after we have already responded. Cutting the body off makes the
+            # app unwind — Starlette turns our `http.disconnect` into
+            # `ClientDisconnect` inside `await request.body()` — and that
+            # exception has nowhere useful to go: the 413 is on the wire, so
+            # letting it propagate would surface as a server error for a request
+            # that was correctly rejected. If we have NOT rejected, the exception
+            # is a real one and must keep propagating.
+            if not state.rejected:
+                raise
+
+    def _declared_length(self, scope: Scope) -> int | None:
+        raw = Headers(scope=scope).get("content-length")
+        if raw is None:
+            return None
+        try:
+            return int(raw)
+        except ValueError:
+            # A malformed Content-Length is not ours to adjudicate; the protocol
+            # layer or the app will reject it. Fall through to byte counting so a
+            # bogus header cannot be used to skip the limit.
+            return None
+
+    def _counting_receive(
+        self, scope: Scope, send: Send, receive: Receive, state: _RejectionState
+    ) -> Receive:
+        async def counting_receive() -> Message:
+            if state.rejected:
+                # The app is still reading. Keep telling it the client is gone so
+                # it unwinds instead of blocking on a stream we stopped serving.
+                return {"type": "http.disconnect"}
+
+            message = await receive()
+            if message["type"] != "http.request":
+                return message
+
+            state.received += len(message.get("body", b""))
+            if state.received > self.max_bytes:
+                state.rejected = True
+                await self._reject(scope, send, declared=None, received=state.received)
+                return {"type": "http.disconnect"}
+            return message
+
+        return counting_receive
+
+    def _guarded_send(self, send: Send, state: _RejectionState) -> Send:
+        async def guarded_send(message: Message) -> None:
+            if state.rejected:
+                # The 413 is already on the wire. Whatever the app produces from a
+                # truncated body — a 422, a 500 — must not be sent as a second
+                # response.
+                return
+            await send(message)
+
+        return guarded_send
+
+    async def _reject(
+        self, scope: Scope, send: Send, *, declared: int | None, received: int | None
+    ) -> None:
+        _logger.warning(
+            "request_body_too_large",
+            http_method=scope.get("method"),
+            http_path=scope.get("path"),
+            limit_bytes=self.max_bytes,
+            declared_bytes=declared,
+            received_bytes=received,
+        )
+        # Hand-rolled rather than a JSONResponse: this runs outside the exception
+        # handlers, and the payload deliberately mirrors ``ErrorResponse`` so a
+        # client parses a 413 the same way it parses every other error. The limit
+        # is included because it is configuration, not internal detail.
+        body = (
+            b'{"success":false,'
+            b'"message":"Request body exceeds the maximum of '
+            + str(self.max_bytes).encode()
+            + b' bytes",'
+            b'"errorCode":"REQUEST_BODY_TOO_LARGE",'
+            b'"errorDetails":null}'
+        )
+        await send(
+            {
+                "type": "http.response.start",
+                "status": _HTTP_REQUEST_ENTITY_TOO_LARGE,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"content-length", str(len(body)).encode()),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": body, "more_body": False})

--- a/src/_core/infrastructure/http/body_size_middleware.py
+++ b/src/_core/infrastructure/http/body_size_middleware.py
@@ -37,10 +37,6 @@ _logger = structlog.stdlib.get_logger(__name__)
 
 _HTTP_REQUEST_ENTITY_TOO_LARGE = 413
 
-# Methods that carry no body worth measuring. GET with a body is legal but
-# meaningless here, and skipping them keeps the hot path free of a wrapper.
-_BODYLESS_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "DELETE", "TRACE"})
-
 
 class _RejectionState:
     """Shared between the wrapped ``receive`` and ``send`` for one request.
@@ -49,11 +45,12 @@ class _RejectionState:
     key names, and so `rejected` reads as the latch it is.
     """
 
-    __slots__ = ("received", "rejected")
+    __slots__ = ("received", "rejected", "response_started")
 
     def __init__(self) -> None:
         self.received = 0
         self.rejected = False
+        self.response_started = False
 
 
 class BodySizeLimitMiddleware:
@@ -71,10 +68,6 @@ class BodySizeLimitMiddleware:
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http" or self.max_bytes <= 0:
-            await self.app(scope, receive, send)
-            return
-
-        if scope.get("method", "").upper() in _BODYLESS_METHODS:
             await self.app(scope, receive, send)
             return
 
@@ -135,6 +128,21 @@ class BodySizeLimitMiddleware:
             state.received += len(message.get("body", b""))
             if state.received > self.max_bytes:
                 state.rejected = True
+                if state.response_started:
+                    # A streaming endpoint can start responding while it is still
+                    # reading. Its `http.response.start` is already on the wire, so
+                    # emitting a 413 start here would be a *second* one, which ASGI
+                    # servers refuse ("Unexpected message" on uvicorn). The status
+                    # is no longer ours to set; all we can still do is stop feeding
+                    # the body and let the response it already began finish.
+                    _logger.warning(
+                        "request_body_too_large_after_response_started",
+                        http_method=scope.get("method"),
+                        http_path=scope.get("path"),
+                        limit_bytes=self.max_bytes,
+                        received_bytes=state.received,
+                    )
+                    return {"type": "http.disconnect"}
                 await self._reject(scope, send, declared=None, received=state.received)
                 return {"type": "http.disconnect"}
             return message
@@ -148,6 +156,8 @@ class BodySizeLimitMiddleware:
                 # truncated body — a 422, a 500 — must not be sent as a second
                 # response.
                 return
+            if message["type"] == "http.response.start":
+                state.response_started = True
             await send(message)
 
         return guarded_send

--- a/tests/e2e/test_middleware.py
+++ b/tests/e2e/test_middleware.py
@@ -80,10 +80,22 @@ async def test_request_id_echoed_when_valid_uuid():
 
 # --- Registration order ----------------------------------------------------
 def test_middleware_registration_order():
+    """`user_middleware` is in *registration* order; Starlette makes the LAST
+    added the OUTERMOST, so the runtime chain is this list reversed.
+
+    `BodySizeLimitMiddleware` (#322) sits between CORS and TrustedHost, which puts
+    it inside CorrelationId, RequestLog and CORS but outside the app. Each of
+    those is load-bearing: a 413 still gets an X-Request-ID and an access-log
+    line, it still carries the CORS headers a browser needs to read it, and an
+    over-long body never reaches route parsing.
+    """
     from asgi_correlation_id import CorrelationIdMiddleware
     from fastapi.middleware.cors import CORSMiddleware
     from fastapi.middleware.trustedhost import TrustedHostMiddleware
 
+    from src._core.infrastructure.http.body_size_middleware import (
+        BodySizeLimitMiddleware,
+    )
     from src._core.infrastructure.logging.request_log_middleware import (
         RequestLogMiddleware,
     )
@@ -92,6 +104,7 @@ def test_middleware_registration_order():
         CorrelationIdMiddleware,
         RequestLogMiddleware,
         CORSMiddleware,
+        BodySizeLimitMiddleware,
         TrustedHostMiddleware,
     ]
 

--- a/tests/unit/_core/infrastructure/http/test_body_size_middleware.py
+++ b/tests/unit/_core/infrastructure/http/test_body_size_middleware.py
@@ -1,0 +1,235 @@
+"""Request bodies are bounded, on both paths a caller can use (#322).
+
+Nothing bounded them before. FastAPI reads and JSON-parses the whole body before
+validation — or even authentication — can reject it. Measured against
+`POST /v1/user`, which requires an admin token:
+
+    1MB  -> 401 in 0.05s
+    16MB -> 401 in 0.07s
+    64MB -> 401 in 0.28s      <- the body was read before the 401
+
+The `Field(max_length=100)` bounds that shipped earlier in #322 cap how much
+*work* a valid body triggers. This caps how much *body* the process holds.
+
+Why the chunked case gets its own tests
+--------------------------------------
+A `Content-Length` check alone is not a control. HTTP/1.1 chunked encoding sends
+no `Content-Length`, so a header-only check is skipped entirely by a caller who
+omits it — verified against this app, `Content-Length present: False`. The
+middleware therefore also counts streamed bytes.
+
+Rejecting mid-stream is where the first implementation was wrong: responding from
+the receive side while the app still intends to respond produces two
+`http.response.start` messages. httpx's transport fails on
+`assert not response_started`; uvicorn raises "Unexpected message". `send` is
+wrapped so the app's late response is genuinely dropped, which the tests below
+pin from both directions.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from src._core.infrastructure.http.body_size_middleware import BodySizeLimitMiddleware
+
+LIMIT = 1024
+
+
+def _build_app(*, max_bytes: int = LIMIT) -> Starlette:
+    """A minimal app that reads the whole body, like a FastAPI route would."""
+
+    async def echo(request: Request) -> JSONResponse:
+        body = await request.body()
+        return JSONResponse({"read": len(body)})
+
+    app = Starlette(routes=[Route("/echo", echo, methods=["POST", "PUT", "GET"])])
+    app.add_middleware(BodySizeLimitMiddleware, max_bytes=max_bytes)
+    return app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(_build_app())
+
+
+class TestTheContentLengthPath:
+    def test_a_body_under_the_limit_passes_through(self, client):
+        resp = client.post("/echo", content=b"x" * (LIMIT - 1))
+        assert resp.status_code == 200
+        assert resp.json()["read"] == LIMIT - 1
+
+    def test_a_body_exactly_at_the_limit_passes(self, client):
+        """The limit is a maximum, not a strict bound. Pinned because an
+        off-by-one here silently rejects a documented-legal payload."""
+        resp = client.post("/echo", content=b"x" * LIMIT)
+        assert resp.status_code == 200
+
+    def test_a_body_over_the_limit_is_rejected(self, client):
+        resp = client.post("/echo", content=b"x" * (LIMIT + 1))
+        assert resp.status_code == 413
+
+    def test_the_rejection_body_matches_the_error_response_shape(self, client):
+        """Clients parse every other error through `ErrorResponse`. This runs
+        outside the exception handlers, so the shape is hand-rolled and worth
+        pinning."""
+        resp = client.post("/echo", content=b"x" * (LIMIT * 4))
+        payload = json.loads(resp.text)
+        assert payload["success"] is False
+        assert payload["errorCode"] == "REQUEST_BODY_TOO_LARGE"
+        assert payload["errorDetails"] is None
+        assert str(LIMIT) in payload["message"]
+        assert resp.headers["content-type"] == "application/json"
+
+    def test_the_app_never_sees_an_oversized_body(self):
+        """The point of the middleware: not just the status code, but that the
+        handler was never invoked with the payload."""
+        seen: list[int] = []
+
+        async def record(request: Request) -> JSONResponse:
+            body = await request.body()
+            seen.append(len(body))
+            return JSONResponse({"read": len(body)})
+
+        app = Starlette(routes=[Route("/r", record, methods=["POST"])])
+        app.add_middleware(BodySizeLimitMiddleware, max_bytes=LIMIT)
+
+        resp = TestClient(app).post("/r", content=b"x" * (LIMIT * 8))
+        assert resp.status_code == 413
+        assert seen == [], f"the handler read {seen} bytes of a rejected body"
+
+
+class TestTheChunkedPathWithNoContentLength:
+    """The bypass a header-only check would leave open."""
+
+    @staticmethod
+    def _chunks(total: int, size: int = 256):
+        sent = 0
+        while sent < total:
+            n = min(size, total - sent)
+            yield b"x" * n
+            sent += n
+
+    def test_a_streamed_oversized_body_is_rejected(self, client):
+        resp = client.post("/echo", content=self._chunks(LIMIT * 6))
+        assert resp.status_code == 413
+
+    def test_a_streamed_body_under_the_limit_passes(self, client):
+        resp = client.post("/echo", content=self._chunks(LIMIT // 2))
+        assert resp.status_code == 200
+        assert resp.json()["read"] == LIMIT // 2
+
+    def test_the_request_carried_no_content_length(self, client):
+        """Precondition for the two tests above. If httpx ever starts buffering
+        and setting Content-Length, they would silently stop covering the chunked
+        path and only re-test the header check."""
+        request = client.build_request("POST", "/echo", content=self._chunks(LIMIT * 6))
+        assert not any(k.lower() == "content-length" for k in request.headers)
+
+    def test_only_one_response_is_produced(self, client):
+        """A regression guard for the actual bug in the first implementation.
+
+        Rejecting from the receive side while the app is still going to respond
+        sent two `http.response.start` messages. Starlette does not discard the
+        second — httpx asserted `not response_started` and the request blew up
+        rather than returning 413. A single clean 413 here IS that assertion.
+        """
+        resp = client.post("/echo", content=self._chunks(LIMIT * 6))
+        assert resp.status_code == 413
+        assert json.loads(resp.text)["errorCode"] == "REQUEST_BODY_TOO_LARGE"
+
+
+class TestWhatIsDeliberatelyNotChecked:
+    def test_zero_disables_enforcement(self):
+        client = TestClient(_build_app(max_bytes=0))
+        resp = client.post("/echo", content=b"x" * (LIMIT * 100))
+        assert resp.status_code == 200, (
+            "max_bytes=0 must disable the limit — it is the documented escape "
+            "hatch for deployments where a reverse proxy already bounds bodies"
+        )
+
+    def test_bodyless_methods_skip_the_wrapper(self, client):
+        """GET may legally carry a body but never meaningfully does here, and
+        skipping those methods keeps the hot path free of two closures."""
+        assert client.get("/echo").status_code == 200
+
+    def test_a_malformed_content_length_falls_back_to_counting(self):
+        """A bogus header must not be usable to skip the limit. Sent at the raw
+        ASGI level because an HTTP client will not emit an invalid header."""
+        import anyio
+
+        app = _build_app()
+        stack = app.build_middleware_stack()
+        sent: list[dict] = []
+        chunks = [b"x" * 512, b"x" * 512, b"x" * 512]
+
+        async def receive():
+            if chunks:
+                return {
+                    "type": "http.request",
+                    "body": chunks.pop(0),
+                    "more_body": bool(chunks),
+                }
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        async def send(message):
+            sent.append(message)
+
+        scope = {
+            "type": "http",
+            "asgi": {"version": "3.0"},
+            "http_version": "1.1",
+            "method": "POST",
+            "path": "/echo",
+            "raw_path": b"/echo",
+            "query_string": b"",
+            "root_path": "",
+            "scheme": "http",
+            "headers": [(b"content-length", b"not-a-number")],
+            "client": ("127.0.0.1", 1234),
+            "server": ("testserver", 80),
+        }
+        anyio.run(stack, scope, receive, send)
+
+        start = next(m for m in sent if m["type"] == "http.response.start")
+        assert start["status"] == 413, (
+            "a malformed Content-Length let an oversized body through"
+        )
+
+
+class TestTheExceptionGuardIsNarrow:
+    """The reject path swallows the app's unwind exception. That suppression must
+    apply ONLY after a rejection, or the middleware would hide every real error
+    behind a 200-shaped silence."""
+
+    def test_an_app_error_still_propagates_when_nothing_was_rejected(self):
+        async def boom(request: Request) -> JSONResponse:
+            raise RuntimeError("deliberate")
+
+        app = Starlette(routes=[Route("/boom", boom, methods=["POST"])])
+        app.add_middleware(BodySizeLimitMiddleware, max_bytes=LIMIT)
+
+        with pytest.raises(RuntimeError, match="deliberate"):
+            TestClient(app, raise_server_exceptions=True).post("/boom", content=b"ok")
+
+    def test_an_app_error_on_a_small_body_is_not_turned_into_a_413(self):
+        async def boom(request: Request) -> JSONResponse:
+            await request.body()
+            raise RuntimeError("deliberate")
+
+        app = Starlette(routes=[Route("/boom", boom, methods=["POST"])])
+        app.add_middleware(BodySizeLimitMiddleware, max_bytes=LIMIT)
+
+        resp = TestClient(app, raise_server_exceptions=False).post(
+            "/boom", content=b"x" * (LIMIT - 1)
+        )
+        assert resp.status_code == 500, (
+            "a genuine handler error was masked; the exception guard is only "
+            "meant to apply once a 413 has already been sent"
+        )

--- a/tests/unit/_core/infrastructure/http/test_body_size_middleware.py
+++ b/tests/unit/_core/infrastructure/http/test_body_size_middleware.py
@@ -543,3 +543,122 @@ class TestTheDocumentedBoundariesOfTheGuarantee:
             "this is the documented boundary; if it now returns 413 the module "
             "docstring's scope section is out of date"
         )
+
+
+class TestTerminationRespectsADeclaredContentLength:
+    """A fixed-length response cannot be truncated.
+
+    The previous round made the middleware synthesize an empty terminal frame to
+    close a response the app had committed. That is only valid when the response
+    did not declare a length. Against a declared `content-length` it is a protocol
+    error — confirmed directly against h11, the parser uvicorn uses:
+
+        LocalProtocolError: Too little data for declared Content-Length
+
+    So the behaviour now splits on what the app declared. Both halves are asserted
+    here, because the failure mode of getting it wrong is invisible to a test that
+    only counts messages.
+    """
+
+    @staticmethod
+    def _app(*, declare_length: bool, body_frames: int = 3):
+        async def app(scope, receive, send):
+            headers = [(b"content-type", b"text/plain")]
+            if declare_length:
+                headers.append((b"content-length", str(4 * body_frames).encode()))
+            await send(
+                {"type": "http.response.start", "status": 200, "headers": headers}
+            )
+            # Read the request while responding — the case this class is about.
+            while True:
+                message = await receive()
+                if message["type"] == "http.disconnect":
+                    break
+                if not message.get("more_body", False):
+                    break
+            for index in range(body_frames):
+                await send(
+                    {
+                        "type": "http.response.body",
+                        "body": b"data",
+                        "more_body": index < body_frames - 1,
+                    }
+                )
+
+        return app
+
+    def _run(self, *, declare_length: bool) -> list[dict]:
+        import anyio
+
+        middleware = BodySizeLimitMiddleware(
+            self._app(declare_length=declare_length), max_bytes=LIMIT
+        )
+        sent: list[dict] = []
+        chunks = [b"x" * 600] * 5
+
+        async def receive():
+            if chunks:
+                return {
+                    "type": "http.request",
+                    "body": chunks.pop(0),
+                    "more_body": bool(chunks),
+                }
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        async def send(message):
+            sent.append(message)
+
+        anyio.run(middleware, _raw_scope(), receive, send)
+        return sent
+
+    def test_no_declared_length_is_closed_with_one_empty_frame(self):
+        sent = self._run(declare_length=False)
+        bodies = [m for m in sent if m["type"] == "http.response.body"]
+        assert len(bodies) == 1
+        assert bodies[0]["body"] == b""
+        assert bodies[0].get("more_body", False) is False
+
+    def test_a_declared_length_forwards_the_app_frames_instead(self):
+        """The app promised 12 bytes; only its own frames can satisfy that. An
+        empty terminal frame here would make h11 raise."""
+        sent = self._run(declare_length=True)
+        bodies = [m for m in sent if m["type"] == "http.response.body"]
+        assert b"".join(m["body"] for m in bodies) == b"data" * 3, (
+            "the declared length was not satisfied; the response is truncated and "
+            "the protocol server will raise"
+        )
+        assert bodies[-1].get("more_body", False) is False
+        assert not any(m["body"] == b"" for m in bodies), (
+            "an empty frame was synthesized despite the declared content-length"
+        )
+
+    def test_the_resulting_sequence_is_valid_to_h11(self):
+        """The assertion that actually matters: replay both outcomes through h11
+        and require no protocol error. Counting frames cannot catch a length
+        mismatch; h11 can."""
+        import h11
+
+        for declare_length in (False, True):
+            sent = self._run(declare_length=declare_length)
+            conn = h11.Connection(our_role=h11.SERVER)
+            conn.receive_data(
+                b"POST / HTTP/1.1\r\nHost: t\r\nContent-Length: 5\r\n\r\nhello"
+            )
+            conn.next_event()
+            conn.next_event()
+
+            start = next(m for m in sent if m["type"] == "http.response.start")
+            conn.send(
+                h11.Response(
+                    status_code=start["status"],
+                    headers=[(k, v) for k, v in start["headers"]],
+                )
+            )
+            for message in sent:
+                if message["type"] != "http.response.body":
+                    continue
+                if message["body"]:
+                    conn.send(h11.Data(data=message["body"]))
+                if not message.get("more_body", False):
+                    # Raises LocalProtocolError on a length mismatch.
+                    conn.send(h11.EndOfMessage())

--- a/tests/unit/_core/infrastructure/http/test_body_size_middleware.py
+++ b/tests/unit/_core/infrastructure/http/test_body_size_middleware.py
@@ -342,18 +342,28 @@ class TestItNeverEmitsASecondResponseStart:
         )
 
         # The half a start-count-only assertion misses, and a review caught:
-        # suppressing the app's messages after rejection also suppressed the
-        # frames that TERMINATE the response it had already committed, leaving the
-        # client with headers and no body. An incomplete response is a worse
-        # outcome than the oversized body.
+        # suppressing every app message after rejection also suppressed the frames
+        # that TERMINATE the response already committed, leaving the client with
+        # headers and an open connection.
+        #
+        # The response IS terminated — but by this middleware, not by forwarding
+        # the app's frames. A second review round showed why forwarding is not a
+        # termination guarantee: an app that ignores `http.disconnect` and keeps
+        # emitting `more_body=True` would hold the connection open indefinitely.
+        # So exactly one empty terminal frame goes out and the app's own body
+        # (`b"done"`) never does.
         bodies = [m for m in sent if m["type"] == "http.response.body"]
-        assert bodies, (
-            "the committed response was never terminated — the client is left "
-            "holding 200 headers and an open connection"
+        assert len(bodies) == 1, (
+            f"sent {len(bodies)} body frames; the response must be closed with "
+            "exactly one, not by forwarding however many the app decides to send"
         )
-        assert bodies[-1].get("more_body", False) is False
-        assert b"done" in b"".join(m.get("body", b"") for m in bodies), (
-            "the app's body frames were dropped after the limit tripped"
+        assert bodies[0].get("more_body", False) is False, (
+            "the terminal frame did not terminate — the client is left holding "
+            "200 headers and an open connection"
+        )
+        assert bodies[0]["body"] == b"", (
+            "the app's post-rejection body was forwarded; only an empty terminal "
+            "frame should close a response cut short by the limit"
         )
 
 
@@ -397,7 +407,15 @@ class TestCumulativeCountingAcrossMessages:
     """
 
     @staticmethod
-    def _run(chunk_sizes: list[int], *, max_bytes: int = LIMIT) -> list[dict]:
+    def _run(
+        chunk_sizes: list[int], *, max_bytes: int = LIMIT
+    ) -> tuple[list[dict], int]:
+        """Returns the sent messages and how many body frames were consumed.
+
+        The consumed count matters: asserting only the status lets an
+        implementation that drains the entire body and *then* rejects pass a test
+        named "cut off at the limit". A review caught exactly that.
+        """
         import anyio
 
         async def echo(request: Request) -> JSONResponse:
@@ -408,10 +426,13 @@ class TestCumulativeCountingAcrossMessages:
 
         sizes = list(chunk_sizes)
         sent: list[dict] = []
+        consumed = 0
 
         async def receive():
+            nonlocal consumed
             if sizes:
                 size = sizes.pop(0)
+                consumed += 1
                 return {
                     "type": "http.request",
                     "body": b"x" * size,
@@ -423,10 +444,10 @@ class TestCumulativeCountingAcrossMessages:
             sent.append(message)
 
         anyio.run(app.build_middleware_stack(), _raw_scope(), receive, send)
-        return sent
+        return sent, consumed
 
     def test_each_message_under_the_limit_but_the_total_over_is_rejected(self):
-        sent = self._run([400, 400, 400])
+        sent, _ = self._run([400, 400, 400])
         start = next(m for m in sent if m["type"] == "http.response.start")
         assert start["status"] == 413, (
             "three 400-byte messages against a 1024-byte limit were accepted; the "
@@ -434,17 +455,26 @@ class TestCumulativeCountingAcrossMessages:
         )
 
     def test_the_total_staying_under_the_limit_passes(self):
-        sent = self._run([300, 300])
+        sent, _ = self._run([300, 300])
         start = next(m for m in sent if m["type"] == "http.response.start")
         assert start["status"] == 200
 
     def test_the_body_is_cut_off_at_the_limit_not_after_the_last_message(self):
-        """Rejection happens on the message that crosses the line, so the process
-        never holds the whole oversized body — the point of streaming enforcement
-        rather than a post-hoc size check."""
-        sent = self._run([400] * 20)
+        """Rejection happens ON the message that crosses the line.
+
+        Asserting the consumed count, not just the status: with 20 frames of 400
+        bytes against a 1024-byte limit, the third frame is the one that crosses,
+        so exactly three must be read. An implementation that drained all 20 and
+        then rejected would satisfy a status-only assertion while defeating the
+        point of streaming enforcement.
+        """
+        sent, consumed = self._run([400] * 20)
         start = next(m for m in sent if m["type"] == "http.response.start")
         assert start["status"] == 413
+        assert consumed == 3, (
+            f"read {consumed} of 20 frames before rejecting; the limit is crossed "
+            "on the third, so anything more means the body was drained first"
+        )
 
 
 class TestTheDocumentedBoundariesOfTheGuarantee:

--- a/tests/unit/_core/infrastructure/http/test_body_size_middleware.py
+++ b/tests/unit/_core/infrastructure/http/test_body_size_middleware.py
@@ -124,8 +124,18 @@ class TestTheContentLengthPath:
         assert seen == [], f"the handler read {seen} bytes of a rejected body"
 
 
-class TestTheChunkedPathWithNoContentLength:
-    """The bypass a header-only check would leave open."""
+class TestTheNoContentLengthPath:
+    """The bypass a header-only check would leave open.
+
+    Scope note, and it is narrower than it first looks: Starlette's `TestClient`
+    **coalesces** a generator body into a single ASGI `http.request` message. A
+    3-byte + 4-byte generator arrives as one 7-byte message with no
+    Content-Length. So these tests cover "no Content-Length" — the property that
+    defeats a header-only check — but NOT multi-message accumulation. That is
+    covered separately at the raw ASGI level below, where the message boundaries
+    are ours to choose. Asserting the real HTTP/1.1 chunked wire format would take
+    a socket-level test against a live uvicorn, which this file does not attempt.
+    """
 
     @staticmethod
     def _chunks(total: int, size: int = 256):
@@ -135,19 +145,19 @@ class TestTheChunkedPathWithNoContentLength:
             yield b"x" * n
             sent += n
 
-    def test_a_streamed_oversized_body_is_rejected(self, client):
+    def test_an_oversized_body_with_no_content_length_is_rejected(self, client):
         resp = client.post("/echo", content=self._chunks(LIMIT * 6))
         assert resp.status_code == 413
 
-    def test_a_streamed_body_under_the_limit_passes(self, client):
+    def test_a_body_under_the_limit_with_no_content_length_passes(self, client):
         resp = client.post("/echo", content=self._chunks(LIMIT // 2))
         assert resp.status_code == 200
         assert resp.json()["read"] == LIMIT // 2
 
     def test_the_request_carried_no_content_length(self, client):
-        """Precondition for the two tests above. If httpx ever starts buffering
-        and setting Content-Length, they would silently stop covering the chunked
-        path and only re-test the header check."""
+        """Precondition for the two tests above. If the client ever starts setting
+        Content-Length, they would silently stop covering this path and merely
+        re-test the header check a second time."""
         request = client.build_request("POST", "/echo", content=self._chunks(LIMIT * 6))
         assert not any(k.lower() == "content-length" for k in request.headers)
 
@@ -331,6 +341,21 @@ class TestItNeverEmitsASecondResponseStart:
             "the status was overwritten after the response had already begun"
         )
 
+        # The half a start-count-only assertion misses, and a review caught:
+        # suppressing the app's messages after rejection also suppressed the
+        # frames that TERMINATE the response it had already committed, leaving the
+        # client with headers and no body. An incomplete response is a worse
+        # outcome than the oversized body.
+        bodies = [m for m in sent if m["type"] == "http.response.body"]
+        assert bodies, (
+            "the committed response was never terminated — the client is left "
+            "holding 200 headers and an open connection"
+        )
+        assert bodies[-1].get("more_body", False) is False
+        assert b"done" in b"".join(m.get("body", b"") for m in bodies), (
+            "the app's body frames were dropped after the limit tripped"
+        )
+
 
 class TestAnUnderstatedContentLengthIsStillCaught:
     def test_a_header_that_lies_does_not_bypass_the_counter(self):
@@ -360,3 +385,131 @@ class TestAnUnderstatedContentLengthIsStillCaught:
 
         start = next(m for m in sent if m["type"] == "http.response.start")
         assert start["status"] == 413
+
+
+class TestCumulativeCountingAcrossMessages:
+    """Multi-message accumulation with NO Content-Length at all.
+
+    Driven at the raw ASGI level because `TestClient` coalesces a generator into
+    one message, so no client-level test can produce these boundaries. Each
+    individual message here is under the limit; only the running total exceeds it,
+    which is the case a per-message check would miss.
+    """
+
+    @staticmethod
+    def _run(chunk_sizes: list[int], *, max_bytes: int = LIMIT) -> list[dict]:
+        import anyio
+
+        async def echo(request: Request) -> JSONResponse:
+            return JSONResponse({"read": len(await request.body())})
+
+        app = Starlette(routes=[Route("/echo", echo, methods=["POST"])])
+        app.add_middleware(BodySizeLimitMiddleware, max_bytes=max_bytes)
+
+        sizes = list(chunk_sizes)
+        sent: list[dict] = []
+
+        async def receive():
+            if sizes:
+                size = sizes.pop(0)
+                return {
+                    "type": "http.request",
+                    "body": b"x" * size,
+                    "more_body": bool(sizes),
+                }
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        async def send(message):
+            sent.append(message)
+
+        anyio.run(app.build_middleware_stack(), _raw_scope(), receive, send)
+        return sent
+
+    def test_each_message_under_the_limit_but_the_total_over_is_rejected(self):
+        sent = self._run([400, 400, 400])
+        start = next(m for m in sent if m["type"] == "http.response.start")
+        assert start["status"] == 413, (
+            "three 400-byte messages against a 1024-byte limit were accepted; the "
+            "counter is per-message rather than cumulative"
+        )
+
+    def test_the_total_staying_under_the_limit_passes(self):
+        sent = self._run([300, 300])
+        start = next(m for m in sent if m["type"] == "http.response.start")
+        assert start["status"] == 200
+
+    def test_the_body_is_cut_off_at_the_limit_not_after_the_last_message(self):
+        """Rejection happens on the message that crosses the line, so the process
+        never holds the whole oversized body — the point of streaming enforcement
+        rather than a post-hoc size check."""
+        sent = self._run([400] * 20)
+        start = next(m for m in sent if m["type"] == "http.response.start")
+        assert start["status"] == 413
+
+
+class TestTheDocumentedBoundariesOfTheGuarantee:
+    """Two gaps a review found. Pinned so they stay deliberate boundaries rather
+    than becoming unnoticed holes — and so a future reader sees they were measured
+    rather than overlooked."""
+
+    def test_a_cors_preflight_is_not_bounded(self):
+        """`CORSMiddleware` sits outside and answers preflights itself, so the
+        body never reaches this middleware. Accepted: nothing reads a preflight
+        body, and moving outside CORS would cost the 413 its CORS headers.
+        """
+        from starlette.middleware.cors import CORSMiddleware
+
+        async def echo(request: Request) -> JSONResponse:
+            return JSONResponse({"read": len(await request.body())})
+
+        app = Starlette(routes=[Route("/e", echo, methods=["POST", "OPTIONS"])])
+        app.add_middleware(BodySizeLimitMiddleware, max_bytes=10)
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=["*"],
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
+        client = TestClient(app)
+
+        preflight = client.request(
+            "OPTIONS",
+            "/e",
+            content=b"x" * 11,
+            headers={
+                "Origin": "http://x.com",
+                "Access-Control-Request-Method": "POST",
+            },
+        )
+        assert preflight.status_code == 200
+
+        # The same oversized body on a real request IS bounded, and so is an
+        # OPTIONS that is not a preflight.
+        assert client.post("/e", content=b"x" * 11).status_code == 413
+        assert client.request("OPTIONS", "/e", content=b"x" * 11).status_code == 413
+
+    def test_an_app_that_never_reads_the_body_is_not_bounded_by_the_counter(self):
+        """The counter runs on `receive()`. An endpoint that ignores the body is
+        bounded only by the header check — and nothing parses those bytes, so
+        there is no allocation to prevent."""
+        import anyio
+
+        async def ignores_body(scope, receive, send):
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": b"ok"})
+
+        middleware = BodySizeLimitMiddleware(ignores_body, max_bytes=10)
+        sent: list[dict] = []
+
+        async def receive():
+            return {"type": "http.request", "body": b"x" * 999, "more_body": False}
+
+        async def send(message):
+            sent.append(message)
+
+        anyio.run(middleware, _raw_scope(), receive, send)
+        start = next(m for m in sent if m["type"] == "http.response.start")
+        assert start["status"] == 200, (
+            "this is the documented boundary; if it now returns 413 the module "
+            "docstring's scope section is out of date"
+        )

--- a/tests/unit/_core/infrastructure/http/test_body_size_middleware.py
+++ b/tests/unit/_core/infrastructure/http/test_body_size_middleware.py
@@ -282,317 +282,74 @@ class TestTheExceptionGuardIsNarrow:
         )
 
 
-class TestItNeverEmitsASecondResponseStart:
-    """A streaming endpoint may start responding while it is still reading.
+class TestEnforcementStopsOnceTheAppHasCommittedAResponse:
+    """The design that replaced three failed attempts at acting mid-response.
 
-    At that point the status is no longer ours to set: emitting a 413
-    `http.response.start` would be the *second* one, which ASGI servers refuse
-    ("Unexpected message" on uvicorn). The middleware stops feeding the body and
-    logs instead. Asserted at the raw ASGI level because an HTTP client cannot
-    show how many start messages were produced.
+    An app may begin responding while still reading — legal ASGI. Three earlier
+    versions each tried to *do* something when the limit tripped after that point,
+    and each was wrong:
+
+      1. Drop the app's frames  -> response never terminates (headers, no body).
+      2. Forward them           -> no termination guarantee at all.
+      3. Synthesize an empty terminal frame -> corrupts any response that declared
+         a `content-length`. h11: "Too little data for declared Content-Length".
+
+    Four of this module's six review findings came out of that subtree, including
+    all three rounds where fixing one hole opened another. It is now deleted: once
+    `http.response.start` is on the wire the middleware logs and stops enforcing.
+
+    The reasoning, not just the retreat: the threat this middleware exists to stop
+    is FastAPI parsing a body before auth can reject it. Once the app has produced
+    a response it has already got what it needed from the body, so the threat is
+    past by definition. And no shipped route can reach this path — there is no
+    `StreamingResponse`, `FileResponse` or `request.stream()` anywhere in `src/` or
+    `examples/`, verified by grep.
+
+    The trade, stated rather than hidden: a streaming proxy endpoint would be
+    unbounded after it commits. That endpoint does not exist here, and an ingress
+    limit covers it if it ever does.
     """
 
     @staticmethod
-    async def _app_that_responds_then_reads(scope, receive, send):
-        await send(
-            {
-                "type": "http.response.start",
-                "status": 200,
-                "headers": [(b"content-type", b"text/plain")],
-            }
-        )
-        while True:
-            message = await receive()
-            if message["type"] == "http.disconnect" or not message.get(
-                "more_body", False
-            ):
-                break
-        await send({"type": "http.response.body", "body": b"done", "more_body": False})
-
-    def test_only_one_start_is_sent(self):
-        import anyio
-
-        middleware = BodySizeLimitMiddleware(
-            self._app_that_responds_then_reads, max_bytes=LIMIT
-        )
-        sent: list[dict] = []
-        chunks = [b"x" * 600] * 5
-
-        async def receive():
-            if chunks:
-                return {
-                    "type": "http.request",
-                    "body": chunks.pop(0),
-                    "more_body": bool(chunks),
-                }
-            return {"type": "http.request", "body": b"", "more_body": False}
-
-        async def send(message):
-            sent.append(message)
-
-        anyio.run(middleware, _raw_scope(), receive, send)
-
-        starts = [m for m in sent if m["type"] == "http.response.start"]
-        assert len(starts) == 1, (
-            f"emitted {len(starts)} http.response.start messages; an ASGI server "
-            "rejects the second and the request fails instead of being rejected"
-        )
-        assert starts[0]["status"] == 200, (
-            "the status was overwritten after the response had already begun"
-        )
-
-        # The half a start-count-only assertion misses, and a review caught:
-        # suppressing every app message after rejection also suppressed the frames
-        # that TERMINATE the response already committed, leaving the client with
-        # headers and an open connection.
-        #
-        # The response IS terminated — but by this middleware, not by forwarding
-        # the app's frames. A second review round showed why forwarding is not a
-        # termination guarantee: an app that ignores `http.disconnect` and keeps
-        # emitting `more_body=True` would hold the connection open indefinitely.
-        # So exactly one empty terminal frame goes out and the app's own body
-        # (`b"done"`) never does.
-        bodies = [m for m in sent if m["type"] == "http.response.body"]
-        assert len(bodies) == 1, (
-            f"sent {len(bodies)} body frames; the response must be closed with "
-            "exactly one, not by forwarding however many the app decides to send"
-        )
-        assert bodies[0].get("more_body", False) is False, (
-            "the terminal frame did not terminate — the client is left holding "
-            "200 headers and an open connection"
-        )
-        assert bodies[0]["body"] == b"", (
-            "the app's post-rejection body was forwarded; only an empty terminal "
-            "frame should close a response cut short by the limit"
-        )
-
-
-class TestAnUnderstatedContentLengthIsStillCaught:
-    def test_a_header_that_lies_does_not_bypass_the_counter(self):
-        """The header check is an optimisation, not the control. A caller who
-        declares 10 bytes and sends 1800 must still be rejected."""
-        import anyio
-
-        stack = _build_app().build_middleware_stack()
-        sent: list[dict] = []
-        chunks = [b"x" * 900, b"x" * 900]
-
-        async def receive():
-            if chunks:
-                return {
-                    "type": "http.request",
-                    "body": chunks.pop(0),
-                    "more_body": bool(chunks),
-                }
-            return {"type": "http.request", "body": b"", "more_body": False}
-
-        async def send(message):
-            sent.append(message)
-
-        anyio.run(
-            stack, _raw_scope(headers=[(b"content-length", b"10")]), receive, send
-        )
-
-        start = next(m for m in sent if m["type"] == "http.response.start")
-        assert start["status"] == 413
-
-
-class TestCumulativeCountingAcrossMessages:
-    """Multi-message accumulation with NO Content-Length at all.
-
-    Driven at the raw ASGI level because `TestClient` coalesces a generator into
-    one message, so no client-level test can produce these boundaries. Each
-    individual message here is under the limit; only the running total exceeds it,
-    which is the case a per-message check would miss.
-    """
-
-    @staticmethod
-    def _run(
-        chunk_sizes: list[int], *, max_bytes: int = LIMIT
-    ) -> tuple[list[dict], int]:
-        """Returns the sent messages and how many body frames were consumed.
-
-        The consumed count matters: asserting only the status lets an
-        implementation that drains the entire body and *then* rejects pass a test
-        named "cut off at the limit". A review caught exactly that.
-        """
-        import anyio
-
-        async def echo(request: Request) -> JSONResponse:
-            return JSONResponse({"read": len(await request.body())})
-
-        app = Starlette(routes=[Route("/echo", echo, methods=["POST"])])
-        app.add_middleware(BodySizeLimitMiddleware, max_bytes=max_bytes)
-
-        sizes = list(chunk_sizes)
-        sent: list[dict] = []
-        consumed = 0
-
-        async def receive():
-            nonlocal consumed
-            if sizes:
-                size = sizes.pop(0)
-                consumed += 1
-                return {
-                    "type": "http.request",
-                    "body": b"x" * size,
-                    "more_body": bool(sizes),
-                }
-            return {"type": "http.request", "body": b"", "more_body": False}
-
-        async def send(message):
-            sent.append(message)
-
-        anyio.run(app.build_middleware_stack(), _raw_scope(), receive, send)
-        return sent, consumed
-
-    def test_each_message_under_the_limit_but_the_total_over_is_rejected(self):
-        sent, _ = self._run([400, 400, 400])
-        start = next(m for m in sent if m["type"] == "http.response.start")
-        assert start["status"] == 413, (
-            "three 400-byte messages against a 1024-byte limit were accepted; the "
-            "counter is per-message rather than cumulative"
-        )
-
-    def test_the_total_staying_under_the_limit_passes(self):
-        sent, _ = self._run([300, 300])
-        start = next(m for m in sent if m["type"] == "http.response.start")
-        assert start["status"] == 200
-
-    def test_the_body_is_cut_off_at_the_limit_not_after_the_last_message(self):
-        """Rejection happens ON the message that crosses the line.
-
-        Asserting the consumed count, not just the status: with 20 frames of 400
-        bytes against a 1024-byte limit, the third frame is the one that crosses,
-        so exactly three must be read. An implementation that drained all 20 and
-        then rejected would satisfy a status-only assertion while defeating the
-        point of streaming enforcement.
-        """
-        sent, consumed = self._run([400] * 20)
-        start = next(m for m in sent if m["type"] == "http.response.start")
-        assert start["status"] == 413
-        assert consumed == 3, (
-            f"read {consumed} of 20 frames before rejecting; the limit is crossed "
-            "on the third, so anything more means the body was drained first"
-        )
-
-
-class TestTheDocumentedBoundariesOfTheGuarantee:
-    """Two gaps a review found. Pinned so they stay deliberate boundaries rather
-    than becoming unnoticed holes — and so a future reader sees they were measured
-    rather than overlooked."""
-
-    def test_a_cors_preflight_is_not_bounded(self):
-        """`CORSMiddleware` sits outside and answers preflights itself, so the
-        body never reaches this middleware. Accepted: nothing reads a preflight
-        body, and moving outside CORS would cost the 413 its CORS headers.
-        """
-        from starlette.middleware.cors import CORSMiddleware
-
-        async def echo(request: Request) -> JSONResponse:
-            return JSONResponse({"read": len(await request.body())})
-
-        app = Starlette(routes=[Route("/e", echo, methods=["POST", "OPTIONS"])])
-        app.add_middleware(BodySizeLimitMiddleware, max_bytes=10)
-        app.add_middleware(
-            CORSMiddleware,
-            allow_origins=["*"],
-            allow_methods=["*"],
-            allow_headers=["*"],
-        )
-        client = TestClient(app)
-
-        preflight = client.request(
-            "OPTIONS",
-            "/e",
-            content=b"x" * 11,
-            headers={
-                "Origin": "http://x.com",
-                "Access-Control-Request-Method": "POST",
-            },
-        )
-        assert preflight.status_code == 200
-
-        # The same oversized body on a real request IS bounded, and so is an
-        # OPTIONS that is not a preflight.
-        assert client.post("/e", content=b"x" * 11).status_code == 413
-        assert client.request("OPTIONS", "/e", content=b"x" * 11).status_code == 413
-
-    def test_an_app_that_never_reads_the_body_is_not_bounded_by_the_counter(self):
-        """The counter runs on `receive()`. An endpoint that ignores the body is
-        bounded only by the header check — and nothing parses those bytes, so
-        there is no allocation to prevent."""
-        import anyio
-
-        async def ignores_body(scope, receive, send):
-            await send({"type": "http.response.start", "status": 200, "headers": []})
-            await send({"type": "http.response.body", "body": b"ok"})
-
-        middleware = BodySizeLimitMiddleware(ignores_body, max_bytes=10)
-        sent: list[dict] = []
-
-        async def receive():
-            return {"type": "http.request", "body": b"x" * 999, "more_body": False}
-
-        async def send(message):
-            sent.append(message)
-
-        anyio.run(middleware, _raw_scope(), receive, send)
-        start = next(m for m in sent if m["type"] == "http.response.start")
-        assert start["status"] == 200, (
-            "this is the documented boundary; if it now returns 413 the module "
-            "docstring's scope section is out of date"
-        )
-
-
-class TestTerminationRespectsADeclaredContentLength:
-    """A fixed-length response cannot be truncated.
-
-    The previous round made the middleware synthesize an empty terminal frame to
-    close a response the app had committed. That is only valid when the response
-    did not declare a length. Against a declared `content-length` it is a protocol
-    error — confirmed directly against h11, the parser uvicorn uses:
-
-        LocalProtocolError: Too little data for declared Content-Length
-
-    So the behaviour now splits on what the app declared. Both halves are asserted
-    here, because the failure mode of getting it wrong is invisible to a test that
-    only counts messages.
-    """
-
-    @staticmethod
-    def _app(*, declare_length: bool, body_frames: int = 3):
+    def _app(*, declare_length: bool, raises_on_disconnect: bool):
         async def app(scope, receive, send):
             headers = [(b"content-type", b"text/plain")]
             if declare_length:
-                headers.append((b"content-length", str(4 * body_frames).encode()))
+                headers.append((b"content-length", b"12"))
             await send(
                 {"type": "http.response.start", "status": 200, "headers": headers}
             )
-            # Read the request while responding — the case this class is about.
             while True:
                 message = await receive()
                 if message["type"] == "http.disconnect":
+                    if raises_on_disconnect:
+                        # What a real Starlette streaming endpoint does:
+                        # `Request.stream()` turns the disconnect into
+                        # ClientDisconnect. Every disconnect-handling app in the
+                        # first five rounds of this file used `break` instead,
+                        # which is precisely why the exception-latch defect
+                        # survived all of them.
+                        from starlette.requests import ClientDisconnect
+
+                        raise ClientDisconnect()
                     break
                 if not message.get("more_body", False):
                     break
-            for index in range(body_frames):
+            for index in range(3):
                 await send(
                     {
                         "type": "http.response.body",
                         "body": b"data",
-                        "more_body": index < body_frames - 1,
+                        "more_body": index < 2,
                     }
                 )
 
         return app
 
-    def _run(self, *, declare_length: bool) -> list[dict]:
+    def _run(self, app) -> tuple[list[dict], str | None]:
         import anyio
 
-        middleware = BodySizeLimitMiddleware(
-            self._app(declare_length=declare_length), max_bytes=LIMIT
-        )
+        middleware = BodySizeLimitMiddleware(app, max_bytes=LIMIT)
         sent: list[dict] = []
         chunks = [b"x" * 600] * 5
 
@@ -608,45 +365,61 @@ class TestTerminationRespectsADeclaredContentLength:
         async def send(message):
             sent.append(message)
 
-        anyio.run(middleware, _raw_scope(), receive, send)
-        return sent
+        escaped: str | None = None
+        try:
+            anyio.run(middleware, _raw_scope(), receive, send)
+        except BaseException as exc:  # noqa: BLE001 - recorded, not handled
+            escaped = type(exc).__name__
+        return sent, escaped
 
-    def test_no_declared_length_is_closed_with_one_empty_frame(self):
-        sent = self._run(declare_length=False)
-        bodies = [m for m in sent if m["type"] == "http.response.body"]
-        assert len(bodies) == 1
-        assert bodies[0]["body"] == b""
-        assert bodies[0].get("more_body", False) is False
+    @pytest.mark.parametrize(
+        "declare_length", [False, True], ids=["no-length", "declared-length"]
+    )
+    @pytest.mark.parametrize(
+        "raises_on_disconnect", [False, True], ids=["breaks", "raises"]
+    )
+    def test_the_app_response_completes_untouched(
+        self, declare_length, raises_on_disconnect
+    ):
+        sent, escaped = self._run(
+            self._app(
+                declare_length=declare_length,
+                raises_on_disconnect=raises_on_disconnect,
+            )
+        )
 
-    def test_a_declared_length_forwards_the_app_frames_instead(self):
-        """The app promised 12 bytes; only its own frames can satisfy that. An
-        empty terminal frame here would make h11 raise."""
-        sent = self._run(declare_length=True)
+        starts = [m for m in sent if m["type"] == "http.response.start"]
+        assert len(starts) == 1, f"{len(starts)} response starts; ASGI allows one"
+        assert starts[0]["status"] == 200, "the app's status was overwritten"
+
         bodies = [m for m in sent if m["type"] == "http.response.body"]
         assert b"".join(m["body"] for m in bodies) == b"data" * 3, (
-            "the declared length was not satisfied; the response is truncated and "
-            "the protocol server will raise"
+            "the app's response was truncated; enforcement should have stopped, "
+            "not interfered with a response already in flight"
         )
         assert bodies[-1].get("more_body", False) is False
-        assert not any(m["body"] == b"" for m in bodies), (
-            "an empty frame was synthesized despite the declared content-length"
+
+        assert escaped is None, (
+            f"{escaped} escaped for a request the middleware chose not to reject. "
+            "Starlette's error middleware would turn that into an ERROR-level "
+            "unhandled_exception AND a false 500 notification dispatch"
         )
 
-    def test_the_resulting_sequence_is_valid_to_h11(self):
-        """The assertion that actually matters: replay both outcomes through h11
-        and require no protocol error. Counting frames cannot catch a length
-        mismatch; h11 can."""
+    def test_the_emitted_sequence_is_valid_to_h11(self):
+        """Counting frames cannot catch a length mismatch; h11 can. Replays both
+        length variants through the parser uvicorn uses."""
         import h11
 
         for declare_length in (False, True):
-            sent = self._run(declare_length=declare_length)
+            sent, _ = self._run(
+                self._app(declare_length=declare_length, raises_on_disconnect=True)
+            )
             conn = h11.Connection(our_role=h11.SERVER)
             conn.receive_data(
                 b"POST / HTTP/1.1\r\nHost: t\r\nContent-Length: 5\r\n\r\nhello"
             )
             conn.next_event()
             conn.next_event()
-
             start = next(m for m in sent if m["type"] == "http.response.start")
             conn.send(
                 h11.Response(
@@ -660,5 +433,22 @@ class TestTerminationRespectsADeclaredContentLength:
                 if message["body"]:
                     conn.send(h11.Data(data=message["body"]))
                 if not message.get("more_body", False):
-                    # Raises LocalProtocolError on a length mismatch.
                     conn.send(h11.EndOfMessage())
+
+    def test_the_decision_is_logged(self):
+        """Silently going unbounded would be the worst version of this. The
+        operator gets a record naming the limit and how much arrived."""
+        from structlog.testing import capture_logs
+
+        with capture_logs() as logs:
+            self._run(self._app(declare_length=False, raises_on_disconnect=False))
+        events = [r.get("event") for r in logs]
+        assert "request_body_too_large_after_response_started" in events, events
+
+
+class TestARealRejectionStillWorks:
+    """The path that matters, kept adjacent so the retreat above cannot quietly
+    widen into "never reject anything"."""
+
+    def test_a_body_over_the_limit_before_any_response_is_still_413(self, client):
+        assert client.post("/echo", content=b"x" * (LIMIT * 4)).status_code == 413

--- a/tests/unit/_core/infrastructure/http/test_body_size_middleware.py
+++ b/tests/unit/_core/infrastructure/http/test_body_size_middleware.py
@@ -54,6 +54,25 @@ def _build_app(*, max_bytes: int = LIMIT) -> Starlette:
     return app
 
 
+def _raw_scope(
+    *, headers: list | None = None, method: str = "POST", path: str = "/echo"
+) -> dict:
+    return {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": method,
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "root_path": "",
+        "scheme": "http",
+        "headers": headers or [],
+        "client": ("127.0.0.1", 1234),
+        "server": ("testserver", 80),
+    }
+
+
 @pytest.fixture
 def client() -> TestClient:
     return TestClient(_build_app())
@@ -154,10 +173,28 @@ class TestWhatIsDeliberatelyNotChecked:
             "hatch for deployments where a reverse proxy already bounds bodies"
         )
 
-    def test_bodyless_methods_skip_the_wrapper(self, client):
-        """GET may legally carry a body but never meaningfully does here, and
-        skipping those methods keeps the hot path free of two closures."""
+    def test_a_get_without_a_body_is_unaffected(self, client):
         assert client.get("/echo").status_code == 200
+
+    @pytest.mark.parametrize("method", ["POST", "PUT", "DELETE"])
+    def test_every_body_carrying_method_is_bounded(self, method):
+        """No method is exempt.
+
+        An earlier version skipped GET/HEAD/OPTIONS/DELETE/TRACE as "bodyless" to
+        keep two closures off the hot path. DELETE and OPTIONS may legally carry a
+        body, and a probe confirmed the hole: `DELETE` with an 8 KB body returned
+        200 and the handler read all 8192 bytes. The optimisation is gone; the
+        wrapper costs two closures per request.
+        """
+
+        async def echo(request: Request) -> JSONResponse:
+            return JSONResponse({"read": len(await request.body())})
+
+        app = Starlette(routes=[Route("/m", echo, methods=[method])])
+        app.add_middleware(BodySizeLimitMiddleware, max_bytes=LIMIT)
+
+        resp = TestClient(app).request(method, "/m", content=b"x" * (LIMIT * 8))
+        assert resp.status_code == 413
 
     def test_a_malformed_content_length_falls_back_to_counting(self):
         """A bogus header must not be usable to skip the limit. Sent at the raw
@@ -233,3 +270,93 @@ class TestTheExceptionGuardIsNarrow:
             "a genuine handler error was masked; the exception guard is only "
             "meant to apply once a 413 has already been sent"
         )
+
+
+class TestItNeverEmitsASecondResponseStart:
+    """A streaming endpoint may start responding while it is still reading.
+
+    At that point the status is no longer ours to set: emitting a 413
+    `http.response.start` would be the *second* one, which ASGI servers refuse
+    ("Unexpected message" on uvicorn). The middleware stops feeding the body and
+    logs instead. Asserted at the raw ASGI level because an HTTP client cannot
+    show how many start messages were produced.
+    """
+
+    @staticmethod
+    async def _app_that_responds_then_reads(scope, receive, send):
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"text/plain")],
+            }
+        )
+        while True:
+            message = await receive()
+            if message["type"] == "http.disconnect" or not message.get(
+                "more_body", False
+            ):
+                break
+        await send({"type": "http.response.body", "body": b"done", "more_body": False})
+
+    def test_only_one_start_is_sent(self):
+        import anyio
+
+        middleware = BodySizeLimitMiddleware(
+            self._app_that_responds_then_reads, max_bytes=LIMIT
+        )
+        sent: list[dict] = []
+        chunks = [b"x" * 600] * 5
+
+        async def receive():
+            if chunks:
+                return {
+                    "type": "http.request",
+                    "body": chunks.pop(0),
+                    "more_body": bool(chunks),
+                }
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        async def send(message):
+            sent.append(message)
+
+        anyio.run(middleware, _raw_scope(), receive, send)
+
+        starts = [m for m in sent if m["type"] == "http.response.start"]
+        assert len(starts) == 1, (
+            f"emitted {len(starts)} http.response.start messages; an ASGI server "
+            "rejects the second and the request fails instead of being rejected"
+        )
+        assert starts[0]["status"] == 200, (
+            "the status was overwritten after the response had already begun"
+        )
+
+
+class TestAnUnderstatedContentLengthIsStillCaught:
+    def test_a_header_that_lies_does_not_bypass_the_counter(self):
+        """The header check is an optimisation, not the control. A caller who
+        declares 10 bytes and sends 1800 must still be rejected."""
+        import anyio
+
+        stack = _build_app().build_middleware_stack()
+        sent: list[dict] = []
+        chunks = [b"x" * 900, b"x" * 900]
+
+        async def receive():
+            if chunks:
+                return {
+                    "type": "http.request",
+                    "body": chunks.pop(0),
+                    "more_body": bool(chunks),
+                }
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        async def send(message):
+            sent.append(message)
+
+        anyio.run(
+            stack, _raw_scope(headers=[(b"content-length", b"10")]), receive, send
+        )
+
+        start = next(m for m in sent if m["type"] == "http.response.start")
+        assert start["status"] == 413


### PR DESCRIPTION
Closes the last open item in #322. The `Field(max_length=100)` collection bounds shipped in PR #337; this is the body-size limit that was deferred until #324 landed, since both touch the middleware block.

## The exposure

Nothing bounded request bodies. FastAPI reads and JSON-parses the whole body before validation — or even authentication — can reject it. Measured against `POST /v1/user`, which requires an admin token:

```
1MB  -> 401 in 0.05s
16MB -> 401 in 0.07s
64MB -> 401 in 0.28s      <- the body was read before the 401
```

The collection bounds cap how much *work* a valid body triggers. This caps how much *body* the process holds.

## A Content-Length check alone would not have been a control

HTTP/1.1 chunked encoding sends no `Content-Length`, and a caller who omits it skips a header-only check entirely — verified against this app, `Content-Length present: False`. So the middleware also counts bytes as they stream and aborts mid-body. After:

```
1MB  (Content-Length) -> 401   (still reaches the app)
16MB (Content-Length) -> 413
64MB (Content-Length) -> 413
64MB (chunked)        -> 413
```

Pure-ASGI rather than a `BaseHTTPMiddleware` subclass: that base buffers the whole request to hand a body to the endpoint, which is the exact allocation this prevents.

`MAX_REQUEST_BODY_BYTES` defaults to 10 MB — generous on purpose, since the RAG document endpoint accepts long content and a limit that rejects realistic JSON gets switched off rather than tuned. `0` disables it. Documented in both `_env/*.example` files.

## Placement

Between CORS and TrustedHost in registration order, so the chain is `CorrelationId → RequestLog → CORS → BodySizeLimit → TrustedHost → App`. Verified on the real app that the 413 carries `X-Request-ID` and `access-control-allow-origin`, so it is logged, correlatable, and readable by a browser — and the body never reaches route parsing. `test_middleware_registration_order` caught the change and now documents why each placement is load-bearing.

## Six defects found before this PR opened, three by me and three by review

This went through more rounds than the diff suggests. Recording them because each was a real bug, not a style note.

**Self-probed, by deliberately testing the cases a reviewer would ask about:**

1. **Double response.** Rejecting from inside the wrapped `receive` while the app still intends to respond produces a second `http.response.start`, which ASGI servers refuse — httpx fails on `assert not response_started`. My comment claimed "Starlette discards whatever it tries to send afterwards". It does not. `send` is now wrapped so that is actually true.
2. **`DELETE` with a body was unbounded.** I had a `_BODYLESS_METHODS` skip list "to keep the hot path free of a wrapper". DELETE and OPTIONS may legally carry a body: `DELETE` + 8 KB returned 200 and the handler read all 8192 bytes. The list is gone.
3. **Second start on a streaming endpoint.** An app may commit a response while still reading. Emitting a 413 then is again a second start. It now stops the body and logs instead.

**Cross review (codex, read-only), which confirmed the cumulative counter and the DELETE fix and found three more:**

4. **[HIGH] My fix for (3) left the committed response unterminated.** Suppressing all app messages after rejection also suppressed the `http.response.body` frames that end a response already on the wire — 200 headers and an open connection, worse for the client than the oversized body. Body frames now flow; only `http.response.start` is suppressed. The exception guard also keyed off `rejected`, which is set on that branch without a 413 having been sent, so a genuine app error could be swallowed; it now keys off a separate `rejection_sent`.

   **My test let this through** and the review said so: it counted start messages only, so it passed either way. It now asserts the terminating frame is sent, and fails against the previous commit.

5. **[HIGH] The guarantee was narrower than my docstring implied.** Two measured gaps, now documented instead of implied away — the byte counter only runs when the app calls `receive()`, and a CORS preflight never reaches this middleware because `CORSMiddleware` answers it first (preflight with an 11-byte body against a 10-byte limit returns 200; a non-preflight `OPTIONS` returns 413). Neither re-introduces the parse-cost problem, since nothing reads those bytes. Both are pinned by tests so they stay deliberate boundaries, and the docstring now says plainly that "no request over N bytes reaches the process" belongs at the ingress proxy.

6. **[MEDIUM] The "chunked" tests did not test chunked.** `TestClient` coalesces a generator body into one ASGI message — probed, 3 bytes + 4 bytes arrives as one 7-byte message. They covered "no Content-Length", which is the property that defeats a header-only check, but not multi-message accumulation, while their names claimed otherwise. Renamed to what they verify, and accumulation now has its own raw-ASGI tests: three 400-byte messages against a 1024-byte limit must be rejected, two 300-byte messages must not.

## Verification

- `1728 passed, 42 skipped, 0 failed`. 24 tests in the new file.
- Confirmed OK by the review and independently: cumulative counting, an understated `Content-Length` (declaring 10 while sending 1800 → 413), negative and huge `Content-Length`, `Transfer-Encoding: chunked` alongside `Content-Length`, multipart, HTTP/2, websocket scopes excluded, and no task leak from repeated `http.disconnect`.
- `check_governor_footer.py --require-governor-footer` against the changed file list: `0 violations`, non-governor. Run, not assumed.
- mypy reports the same 7 pre-existing errors under `src/_apps/admin/`; nothing in the new file.

## One process note

I nearly shipped this believing the middleware did not work at all. A probe script wrote its results only at the end and I had redirected stderr to `/dev/null`, so a crashed run left the *previous* run's output file in place and I read stale numbers. Probes no longer suppress stderr.
