### PR TITLE
fix(_core): collapse the notification provider graph, and reject config nothing can consume

### DIFF
--- a/src/_core/config.py
+++ b/src/_core/config.py
@@ -833,6 +833,50 @@ class Settings(BaseSettings):
                 "discord_webhook_url missing"
             )
 
+        # The mirror of the two checks above, and the likelier operator error:
+        # pasting the webhook and forgetting the provider (#327 F9). The validator
+        # already rejects a provider with no URL on the grounds that the other half
+        # "would otherwise be silently ignored" — that reasoning was never applied
+        # upward, so three combinations booted with the alert path fully inert.
+        # Measured in a valid prod env before this change, all three ACCEPTED:
+        #   SLACK_WEBHOOK_URL alone            -> NoopNotificationClient
+        #   NOTIFICATION_WARNING_THRESHOLD     -> live NotificationRouter into Noop
+        #   severity / cooldown tuned          -> NoopNotificationClient
+        # Unconditional rather than strict-env-only, matching the checks above,
+        # which reject in local too.
+        if not notification_provider:
+            if self.slack_webhook_url or self.discord_webhook_url:
+                errors.append(
+                    "[Notification] SLACK_WEBHOOK_URL / DISCORD_WEBHOOK_URL are "
+                    "set but NOTIFICATION_PROVIDER is not, so no client is built "
+                    "and the URL is silently ignored. Set "
+                    "NOTIFICATION_PROVIDER=slack|discord, or remove the URL"
+                )
+
+            if self.notification_warning_threshold is not None:
+                errors.append(
+                    "[Notification/Routing] NOTIFICATION_WARNING_THRESHOLD is set "
+                    "but NOTIFICATION_PROVIDER is not. The threshold is the switch "
+                    "that wires the router, so a live NotificationRouter is built "
+                    "and every tier resolves to the disabled no-op client. Set "
+                    "NOTIFICATION_PROVIDER, or remove the threshold"
+                )
+
+            tuned = sorted(
+                name.upper()
+                for name in (
+                    "notification_severity_threshold",
+                    "notification_cooldown_seconds",
+                )
+                if name in self.model_fields_set
+            )
+            if tuned:
+                errors.append(
+                    f"[Notification] {' / '.join(tuned)} tuned but "
+                    "NOTIFICATION_PROVIDER is not set, so nothing consumes them. "
+                    "Set NOTIFICATION_PROVIDER, or leave these at their defaults"
+                )
+
         if (
             self.notification_warning_threshold is not None
             and self.notification_warning_threshold

--- a/src/_core/config.py
+++ b/src/_core/config.py
@@ -862,20 +862,18 @@ class Settings(BaseSettings):
                     "NOTIFICATION_PROVIDER, or remove the threshold"
                 )
 
-            tuned = sorted(
-                name.upper()
-                for name in (
-                    "notification_severity_threshold",
-                    "notification_cooldown_seconds",
-                )
-                if name in self.model_fields_set
-            )
-            if tuned:
-                errors.append(
-                    f"[Notification] {' / '.join(tuned)} tuned but "
-                    "NOTIFICATION_PROVIDER is not set, so nothing consumes them. "
-                    "Set NOTIFICATION_PROVIDER, or leave these at their defaults"
-                )
+            # NOT rejected here, though #327 F9 listed it: NOTIFICATION_SEVERITY_
+            # THRESHOLD and NOTIFICATION_COOLDOWN_SECONDS with no provider. A review
+            # showed the premise ("nothing consumes them") is false — `ErrorNotifier`
+            # is built regardless of provider and both settings are live on the
+            # disabled path, gating the `notification_suppressed` log. Measured with
+            # a NoopNotificationClient:
+            #   severity=500 -> 404:0 500:1     severity=400 -> 404:1 500:1
+            #   cooldown=60, 500 x3 -> 1 log    cooldown=0 -> 3 logs
+            # So a deployment that keeps delivery off but tunes the volume of that
+            # log is a legitimate configuration, and rejecting it would be a
+            # regression. The two checks above stay because a webhook URL and the
+            # routing switch have no effect at all without a provider.
 
         if (
             self.notification_warning_threshold is not None

--- a/src/_core/infrastructure/di/core_container.py
+++ b/src/_core/infrastructure/di/core_container.py
@@ -60,12 +60,41 @@ def _notification_selector() -> str:
     return "enabled" if settings.notification_webhook_url else "disabled"
 
 
+def _notification_tier_selector(override_url: str | None, target: str | None) -> str:
+    """Three-way branch for a per-tier notification client (#327).
+
+    ``"shared"`` is the branch that matters. Both tier targets fall back to the
+    single provider webhook, so a two-way enabled/disabled selector built a
+    *separate adapter against the same URL* for every tier: with routing on and no
+    overrides, three ``SlackNotificationAdapter`` instances for one channel.
+    Probed at HEAD before this change — ``distinct adapter objects: 3``.
+
+    That footprint is not cosmetic. Both defects found in round 1 of PR #313 were
+    consequences of it: three ``NoopNotificationClient`` instances instead of one
+    (so the disabled warning logged three times), and an injected client the router
+    short-circuits. The symptoms were patched then; this removes the shape.
+
+    An adapter is only built for a tier that has its own URL. Otherwise the tier
+    resolves to ``notification_client`` — the same object, not a copy — so the
+    delivered URL is unchanged and only the instance count drops.
+    """
+    if not target:
+        return "disabled"
+    return "override" if override_url else "shared"
+
+
 def _notification_critical_selector() -> str:
-    return "enabled" if settings.notification_critical_target else "disabled"
+    return _notification_tier_selector(
+        settings.notification_critical_webhook_url,
+        settings.notification_critical_target,
+    )
 
 
 def _notification_warning_selector() -> str:
-    return "enabled" if settings.notification_warning_target else "disabled"
+    return _notification_tier_selector(
+        settings.notification_warning_webhook_url,
+        settings.notification_warning_target,
+    )
 
 
 def _notification_routing_selector() -> str:
@@ -473,23 +502,27 @@ class CoreContainer(containers.DeclarativeContainer):
 
     notification_critical_client = providers.Selector(
         _notification_critical_selector,
-        enabled=providers.Singleton(
+        override=providers.Singleton(
             _build_notification_client,
             http_client=http_client,
             provider=settings.notification_provider,
-            webhook_url=settings.notification_critical_target,
+            webhook_url=settings.notification_critical_webhook_url,
         ),
+        # No override: reuse the base client object rather than building a second
+        # adapter against the same URL. See _notification_tier_selector.
+        shared=notification_client,
         disabled=_noop_notification_client,
     )
 
     notification_warning_client = providers.Selector(
         _notification_warning_selector,
-        enabled=providers.Singleton(
+        override=providers.Singleton(
             _build_notification_client,
             http_client=http_client,
             provider=settings.notification_provider,
-            webhook_url=settings.notification_warning_target,
+            webhook_url=settings.notification_warning_webhook_url,
         ),
+        shared=notification_client,
         disabled=_noop_notification_client,
     )
 

--- a/tests/integration/_core/infrastructure/test_notification_routing_matrix.py
+++ b/tests/integration/_core/infrastructure/test_notification_routing_matrix.py
@@ -1,0 +1,202 @@
+"""The full notification routing behaviour matrix (#327).
+
+#286's channel routing went through four review rounds and was declared clean by
+an 8-permutation × 7-status-code matrix — but that matrix lived in a review
+comment, not in the suite. So the semantics the rounds established were protected
+by nothing, which is a bad position from which to refactor the provider graph.
+
+This file is that matrix, shipped. For every supported `NOTIFICATION_*`
+combination it records, per status code, **which webhook URL** would receive the
+alert (or that none would). URLs rather than object types: the type only says
+"a Slack adapter", while the URL says *which channel*, which is the entire point
+of routing.
+
+Each row needs its own process. `CoreContainer`'s Selector branches capture
+`settings.*` at class-body evaluation time, so post-import monkeypatching cannot
+flip them — `tests/support/container_env.py` (built for exactly this in #330) runs
+each permutation in a subprocess with the env applied before any project import.
+
+These are `slow`: one subprocess per permutation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.support.container_env import boot_fails, resolve_in_env
+
+pytestmark = pytest.mark.slow
+
+BASE = "https://hooks.slack.com/services/T/B/BASE"
+CRITICAL = "https://hooks.slack.com/services/T/B/CRIT"
+WARNING = "https://hooks.slack.com/services/T/B/WARN"
+
+# Chosen to straddle every boundary the router can have: below both tiers, at and
+# above a 400 warning threshold, just under the 500 severity threshold, and at and
+# above it.
+STATUS_CODES = [200, 399, 400, 404, 499, 500, 502]
+
+# What the router/notifier pair resolves for each status code, reported as the
+# tail of the receiving webhook URL. `None` means "would not dispatch".
+_RESOLVE_BODY_TEMPLATE = """
+    notifier = container.error_notifier()
+    router = container.notification_router()
+
+    def target(status):
+        client = router.resolve(status) if router is not None else notifier._client
+        return getattr(client, "_webhook_url", None)
+
+    codes = __CODES__
+    result = {
+        "floor": notifier._effective_min_threshold(),
+        "router": type(router).__name__,
+        "client_type": type(notifier._client).__name__
+        if hasattr(notifier, "_client")
+        else None,
+        "targets": {
+            str(status): (target(status) or "").rsplit("/", 1)[-1] or None
+            for status in codes
+        },
+        "dispatches": {
+            str(status): notifier._should_notify(status, "E_" + str(status))
+            for status in codes
+        },
+    }
+"""
+
+_RESOLVE_BODY = _RESOLVE_BODY_TEMPLATE.replace("__CODES__", repr(STATUS_CODES))
+
+
+def _matrix(env: dict[str, str]) -> dict:
+    return resolve_in_env(env, _RESOLVE_BODY)
+
+
+# --- permutations that boot -------------------------------------------------
+
+ENABLED_NO_ROUTING = {
+    "NOTIFICATION_PROVIDER": "slack",
+    "SLACK_WEBHOOK_URL": BASE,
+}
+ROUTING_SHARED_TARGET = {**ENABLED_NO_ROUTING, "NOTIFICATION_WARNING_THRESHOLD": "400"}
+ROUTING_CRITICAL_ONLY = {
+    **ROUTING_SHARED_TARGET,
+    "NOTIFICATION_CRITICAL_WEBHOOK_URL": CRITICAL,
+}
+ROUTING_WARNING_ONLY = {
+    **ROUTING_SHARED_TARGET,
+    "NOTIFICATION_WARNING_WEBHOOK_URL": WARNING,
+}
+ROUTING_BOTH_TARGETS = {
+    **ROUTING_SHARED_TARGET,
+    "NOTIFICATION_CRITICAL_WEBHOOK_URL": CRITICAL,
+    "NOTIFICATION_WARNING_WEBHOOK_URL": WARNING,
+}
+DISABLED = {}
+
+
+class TestTheSingleTargetPathIsUnchanged:
+    """#17 behaviour: only `>= severity_threshold` dispatches, all to one URL.
+
+    This is the row a provider-graph refactor is most likely to break, because it
+    is the row that does NOT go through the router today.
+    """
+
+    def test_only_5xx_dispatches_and_always_to_the_base_url(self):
+        out = _matrix(ENABLED_NO_ROUTING)
+        assert out["floor"] == 500
+        assert out["dispatches"] == {
+            "200": False,
+            "399": False,
+            "400": False,
+            "404": False,
+            "499": False,
+            "500": True,
+            "502": True,
+        }
+        for status in ("500", "502"):
+            assert out["targets"][status] == "BASE"
+
+
+class TestRoutingWithNoPerTierOverrides:
+    """`NOTIFICATION_WARNING_THRESHOLD` alone lowers the floor and splits the band,
+    with both tiers landing on the single configured webhook."""
+
+    def test_the_floor_drops_to_the_warning_threshold(self):
+        out = _matrix(ROUTING_SHARED_TARGET)
+        assert out["floor"] == 400
+        assert out["dispatches"] == {
+            "200": False,
+            "399": False,
+            "400": True,
+            "404": True,
+            "499": True,
+            "500": True,
+            "502": True,
+        }
+
+    def test_both_tiers_share_the_base_url(self):
+        out = _matrix(ROUTING_SHARED_TARGET)
+        for status in ("400", "404", "499", "500", "502"):
+            assert out["targets"][status] == "BASE", status
+
+
+class TestRoutingWithPerTierOverrides:
+    @pytest.mark.parametrize(
+        "env,expected",
+        [
+            (
+                ROUTING_CRITICAL_ONLY,
+                {"400": "BASE", "499": "BASE", "500": "CRIT", "502": "CRIT"},
+            ),
+            (
+                ROUTING_WARNING_ONLY,
+                {"400": "WARN", "499": "WARN", "500": "BASE", "502": "BASE"},
+            ),
+            (
+                ROUTING_BOTH_TARGETS,
+                {"400": "WARN", "499": "WARN", "500": "CRIT", "502": "CRIT"},
+            ),
+        ],
+        ids=["critical-override", "warning-override", "both-overrides"],
+    )
+    def test_each_tier_resolves_to_its_own_channel(self, env, expected):
+        out = _matrix(env)
+        for status, tail in expected.items():
+            assert out["targets"][status] == tail, (
+                f"status {status} routed to {out['targets'][status]}, expected {tail}"
+            )
+
+    def test_below_both_tiers_never_dispatches(self):
+        out = _matrix(ROUTING_BOTH_TARGETS)
+        assert out["dispatches"]["200"] is False
+        assert out["dispatches"]["399"] is False
+        assert out["targets"]["200"] is None
+        assert out["targets"]["399"] is None
+
+
+class TestTheDisabledPath:
+    def test_nothing_is_delivered_and_the_floor_is_the_default(self):
+        out = _matrix(DISABLED)
+        assert out["floor"] == 500
+        # The Noop client has no webhook URL, which is what "delivered nowhere"
+        # looks like from the outside.
+        assert out["targets"]["500"] is None
+        assert out["targets"]["502"] is None
+
+
+class TestTheCombinationsThatMustNotBoot:
+    """#315: a per-tier URL without the threshold used to boot and silently send
+    everything to the base webhook. Pinned here so the collapse cannot relax it."""
+
+    @pytest.mark.parametrize(
+        "env",
+        [
+            {**ENABLED_NO_ROUTING, "NOTIFICATION_CRITICAL_WEBHOOK_URL": CRITICAL},
+            {**ENABLED_NO_ROUTING, "NOTIFICATION_WARNING_WEBHOOK_URL": WARNING},
+        ],
+        ids=["critical-url-without-threshold", "warning-url-without-threshold"],
+    )
+    def test_a_per_tier_url_without_the_threshold_is_rejected(self, env):
+        error = boot_fails(env)
+        assert error is not None, "the combination booted; #315 has regressed"
+        assert "NOTIFICATION_WARNING_THRESHOLD" in error or "Routing" in error

--- a/tests/integration/_core/infrastructure/test_notification_routing_matrix.py
+++ b/tests/integration/_core/infrastructure/test_notification_routing_matrix.py
@@ -200,3 +200,69 @@ class TestTheCombinationsThatMustNotBoot:
         error = boot_fails(env)
         assert error is not None, "the combination booted; #315 has regressed"
         assert "NOTIFICATION_WARNING_THRESHOLD" in error or "Routing" in error
+
+
+class TestOneAdapterPerDistinctChannel:
+    """The provider-graph half of #327.
+
+    Both tier targets fall back to the single provider webhook, and the per-tier
+    Selectors used to be two-way enabled/disabled — so a tier with no override
+    still built its own adapter against the same URL. Probed before the change,
+    with routing on and no overrides: `distinct adapter objects: 3`.
+
+    That footprint produced both defects found in round 1 of PR #313 — three
+    `NoopNotificationClient` instances instead of one, and an injected client the
+    router short-circuits. The symptoms were patched then; this asserts the shape
+    is gone, so the instance count is now exactly the number of distinct channels.
+    """
+
+    _IDENTITY_BODY = """
+        names = (
+            "notification_client",
+            "notification_critical_client",
+            "notification_warning_client",
+        )
+        objs = {name: getattr(container, name)() for name in names}
+        result = {
+            "distinct": len({id(o) for o in objs.values()}),
+            "urls": {
+                name: (getattr(o, "_webhook_url", None) or "").rsplit("/", 1)[-1] or None
+                for name, o in objs.items()
+            },
+        }
+    """
+
+    @pytest.mark.parametrize(
+        "env,expected_adapters,expected_urls",
+        [
+            (ENABLED_NO_ROUTING, 1, ("BASE", "BASE", "BASE")),
+            (ROUTING_SHARED_TARGET, 1, ("BASE", "BASE", "BASE")),
+            (ROUTING_CRITICAL_ONLY, 2, ("BASE", "CRIT", "BASE")),
+            (ROUTING_WARNING_ONLY, 2, ("BASE", "BASE", "WARN")),
+            (ROUTING_BOTH_TARGETS, 3, ("BASE", "CRIT", "WARN")),
+        ],
+        ids=["no-routing", "shared", "critical-only", "warning-only", "both"],
+    )
+    def test_the_instance_count_equals_the_channel_count(
+        self, env, expected_adapters, expected_urls
+    ):
+        out = resolve_in_env(env, self._IDENTITY_BODY)
+        base, critical, warning = expected_urls
+
+        # URLs first: collapsing instances must not change where anything is sent.
+        assert out["urls"]["notification_client"] == base
+        assert out["urls"]["notification_critical_client"] == critical
+        assert out["urls"]["notification_warning_client"] == warning
+
+        assert out["distinct"] == expected_adapters, (
+            f"{out['distinct']} adapter instances for {expected_adapters} distinct "
+            f"channel(s): {out['urls']}"
+        )
+
+    def test_the_disabled_path_shares_one_noop(self):
+        """Already true, and load-bearing: `NoopNotificationClient` logs its warning
+        from `__init__`, so a separate instance per tier means the
+        `notification_client_disabled` line appears once per tier instead of once
+        per process."""
+        out = resolve_in_env(DISABLED, self._IDENTITY_BODY)
+        assert out["distinct"] == 1

--- a/tests/integration/_core/infrastructure/test_notification_routing_matrix.py
+++ b/tests/integration/_core/infrastructure/test_notification_routing_matrix.py
@@ -266,3 +266,57 @@ class TestOneAdapterPerDistinctChannel:
         per process."""
         out = resolve_in_env(DISABLED, self._IDENTITY_BODY)
         assert out["distinct"] == 1
+
+
+class TestTheSameHoldsForDiscord:
+    """The matrix above is Slack-only, which a review flagged: it does not directly
+    guard a Discord regression. The three-way selector is provider-agnostic — it
+    branches on which URL is configured, not on the transport — so this pins that
+    for the one other supported provider rather than leaving it inferred.
+    """
+
+    # Placeholder id shape, not a digit id: the `discord-webhook-url` gitleaks rule
+    # this repo added in #320 matches `webhooks/\d+/[\w-]+`, and a realistic
+    # fixture trips it. Learned the same lesson twice — #320 had to clean five
+    # existing fixtures for exactly this, and the rule then caught these two.
+    D_BASE = "https://discord.com/api/webhooks/<base-id>/base-token"
+    D_CRIT = "https://discord.com/api/webhooks/<crit-id>/crit-token"
+
+    def _env(self, **extra) -> dict[str, str]:
+        return {
+            "NOTIFICATION_PROVIDER": "discord",
+            "DISCORD_WEBHOOK_URL": self.D_BASE,
+            **extra,
+        }
+
+    def test_the_adapter_is_the_discord_one_and_shared_when_untiered(self):
+        out = resolve_in_env(
+            self._env(NOTIFICATION_WARNING_THRESHOLD="400"),
+            TestOneAdapterPerDistinctChannel._IDENTITY_BODY,
+        )
+        assert out["distinct"] == 1, (
+            f"{out['distinct']} adapters for one Discord channel: {out['urls']}"
+        )
+
+    def test_a_discord_per_tier_override_still_splits(self):
+        out = resolve_in_env(
+            self._env(
+                NOTIFICATION_WARNING_THRESHOLD="400",
+                NOTIFICATION_CRITICAL_WEBHOOK_URL=self.D_CRIT,
+            ),
+            TestOneAdapterPerDistinctChannel._IDENTITY_BODY,
+        )
+        assert out["distinct"] == 2
+        assert out["urls"]["notification_critical_client"] == "crit-token"
+        assert out["urls"]["notification_warning_client"] == "base-token"
+
+    def test_the_delivered_target_matches_the_tier(self):
+        out = _matrix(
+            self._env(
+                NOTIFICATION_WARNING_THRESHOLD="400",
+                NOTIFICATION_CRITICAL_WEBHOOK_URL=self.D_CRIT,
+            )
+        )
+        assert out["targets"]["502"] == "crit-token"
+        assert out["targets"]["404"] == "base-token"
+        assert out["targets"]["200"] is None

--- a/tests/unit/_core/infrastructure/di/test_core_container_selectors.py
+++ b/tests/unit/_core/infrastructure/di/test_core_container_selectors.py
@@ -126,9 +126,14 @@ class TestNotificationSelector:
 
 
 class TestNotificationCriticalSelector:
-    """#286: falls back to the base notification target when no
-    per-severity override is configured, so it tracks _notification_selector
-    exactly in the unmapped (default) case."""
+    """#286: falls back to the base notification target when no per-severity
+    override is configured.
+
+    Three-way since #327. The fallback case returns ``"shared"`` rather than
+    ``"enabled"`` so the tier resolves to ``notification_client`` itself instead of
+    building a second adapter against the same URL — with routing on and no
+    overrides that produced three adapter instances for one channel.
+    """
 
     def test_disabled_when_nothing_configured(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setattr(settings, "notification_provider", None)
@@ -137,15 +142,17 @@ class TestNotificationCriticalSelector:
         monkeypatch.setattr(settings, "notification_critical_webhook_url", None)
         assert _notification_critical_selector() == "disabled"
 
-    def test_enabled_via_fallback_to_base_target(self, monkeypatch: pytest.MonkeyPatch):
+    def test_shared_when_falling_back_to_the_base_target(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
         monkeypatch.setattr(settings, "notification_provider", "slack")
         monkeypatch.setattr(
             settings, "slack_webhook_url", "https://hooks.slack.com/services/T/B/X"
         )
         monkeypatch.setattr(settings, "notification_critical_webhook_url", None)
-        assert _notification_critical_selector() == "enabled"
+        assert _notification_critical_selector() == "shared"
 
-    def test_enabled_via_explicit_override(self, monkeypatch: pytest.MonkeyPatch):
+    def test_override_when_a_per_tier_url_is_set(self, monkeypatch: pytest.MonkeyPatch):
         # A real deployment always has the base webhook set — boot validation
         # rejects a provider without one. Modelling a bootable config here keeps
         # the fixture honest; the override is still what the assertion is about.
@@ -158,7 +165,7 @@ class TestNotificationCriticalSelector:
             "notification_critical_webhook_url",
             "https://hooks.slack.com/services/T/B/ALERTS",
         )
-        assert _notification_critical_selector() == "enabled"
+        assert _notification_critical_selector() == "override"
 
 
 class TestNotificationWarningSelector:
@@ -169,15 +176,17 @@ class TestNotificationWarningSelector:
         monkeypatch.setattr(settings, "notification_warning_webhook_url", None)
         assert _notification_warning_selector() == "disabled"
 
-    def test_enabled_via_fallback_to_base_target(self, monkeypatch: pytest.MonkeyPatch):
+    def test_shared_when_falling_back_to_the_base_target(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
         monkeypatch.setattr(settings, "notification_provider", "slack")
         monkeypatch.setattr(
             settings, "slack_webhook_url", "https://hooks.slack.com/services/T/B/X"
         )
         monkeypatch.setattr(settings, "notification_warning_webhook_url", None)
-        assert _notification_warning_selector() == "enabled"
+        assert _notification_warning_selector() == "shared"
 
-    def test_enabled_via_explicit_override(self, monkeypatch: pytest.MonkeyPatch):
+    def test_override_when_a_per_tier_url_is_set(self, monkeypatch: pytest.MonkeyPatch):
         # A real deployment always has the base webhook set — boot validation
         # rejects a provider without one. Modelling a bootable config here keeps
         # the fixture honest; the override is still what the assertion is about.
@@ -190,7 +199,7 @@ class TestNotificationWarningSelector:
             "notification_warning_webhook_url",
             "https://hooks.slack.com/services/T/B/MONITORING",
         )
-        assert _notification_warning_selector() == "enabled"
+        assert _notification_warning_selector() == "override"
 
 
 class TestNotificationRoutingSelector:

--- a/tests/unit/_core/test_config.py
+++ b/tests/unit/_core/test_config.py
@@ -908,6 +908,102 @@ class TestNotificationConfig:
             )
 
 
+class TestNotificationSettingsWithoutAProvider:
+    """#327 F9: config that only makes sense with alerting on must not boot without it.
+
+    The validator already rejects `NOTIFICATION_PROVIDER=slack` with no
+    `SLACK_WEBHOOK_URL`, on the stated grounds that the missing half would
+    otherwise be "silently ignored". That reasoning was never applied upward, so
+    three combinations booted with the alert path fully inert. Measured in a valid
+    prod env before this change, all three ACCEPTED:
+
+        SLACK_WEBHOOK_URL alone         -> NoopNotificationClient
+        NOTIFICATION_WARNING_THRESHOLD  -> live NotificationRouter into a Noop
+        severity / cooldown tuned       -> NoopNotificationClient
+
+    The second is the sharpest: the same validator block rejects a structurally
+    identical downstream inconsistency with the words "silently ignored" while
+    itself constructing a router object that can never deliver.
+
+    Unconditional, not strict-env-only — verified that the existing
+    provider-without-URL check rejects in `local` too, so a one-sided gate here
+    would be a new asymmetry.
+    """
+
+    def test_a_webhook_url_without_a_provider_is_rejected(self):
+        """The mirror of `test_slack_without_webhook_url_rejected`, and the likelier
+        operator error: paste the webhook, forget the provider."""
+        env = {
+            "ENV": "local",
+            "SLACK_WEBHOOK_URL": "https://hooks.slack.com/services/T/B/X",
+            **_REQUIRED_VARS,
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(ValidationError, match="silently ignored"):
+                _create_settings()
+
+    def test_a_discord_url_without_a_provider_is_rejected(self):
+        env = {
+            "ENV": "local",
+            "DISCORD_WEBHOOK_URL": "https://discord.com/api/webhooks/<id>/<token>",
+            **_REQUIRED_VARS,
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(ValidationError, match="silently ignored"):
+                _create_settings()
+
+    def test_the_warning_threshold_without_a_provider_is_rejected(self):
+        """The threshold is the switch that wires the router, so setting it alone
+        builds a live NotificationRouter whose every tier resolves to the disabled
+        no-op client."""
+        env = {
+            "ENV": "local",
+            "NOTIFICATION_WARNING_THRESHOLD": "400",
+            **_REQUIRED_VARS,
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(ValidationError, match="NOTIFICATION_WARNING_THRESHOLD"):
+                _create_settings()
+
+    @pytest.mark.parametrize(
+        "key,value",
+        [
+            ("NOTIFICATION_SEVERITY_THRESHOLD", "502"),
+            ("NOTIFICATION_COOLDOWN_SECONDS", "900"),
+        ],
+    )
+    def test_tuning_without_a_provider_is_rejected(self, key, value):
+        """Detected via `model_fields_set`, so setting a value that happens to equal
+        the default still counts as tuning — the point is that nothing consumes it."""
+        env = {"ENV": "local", key: value, **_REQUIRED_VARS}
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(ValidationError, match="nothing consumes them"):
+                _create_settings()
+
+    def test_no_notification_config_at_all_still_boots(self):
+        """The control. Alerting is optional infrastructure (ADR 042) and must stay
+        optional — this must not become "you have to configure notifications"."""
+        env = {"ENV": "local", **_REQUIRED_VARS}
+        with patch.dict(os.environ, env, clear=True):
+            settings = _create_settings()
+            assert settings.notification_provider is None
+
+    def test_a_complete_configuration_still_boots(self):
+        """The other control: everything set together must remain valid."""
+        env = {
+            "ENV": "local",
+            "NOTIFICATION_PROVIDER": "slack",
+            "SLACK_WEBHOOK_URL": "https://hooks.slack.com/services/T/B/X",
+            "NOTIFICATION_WARNING_THRESHOLD": "400",
+            "NOTIFICATION_SEVERITY_THRESHOLD": "500",
+            "NOTIFICATION_COOLDOWN_SECONDS": "900",
+            **_REQUIRED_VARS,
+        }
+        with patch.dict(os.environ, env, clear=True):
+            settings = _create_settings()
+            assert settings.notification_warning_threshold == 400
+
+
 class TestNotificationRoutingConfig:
     """#286: severity-based channel routing on top of TestNotificationConfig."""
 

--- a/tests/unit/_core/test_config.py
+++ b/tests/unit/_core/test_config.py
@@ -972,13 +972,24 @@ class TestNotificationSettingsWithoutAProvider:
             ("NOTIFICATION_COOLDOWN_SECONDS", "900"),
         ],
     )
-    def test_tuning_without_a_provider_is_rejected(self, key, value):
-        """Detected via `model_fields_set`, so setting a value that happens to equal
-        the default still counts as tuning — the point is that nothing consumes it."""
+    def test_tuning_without_a_provider_is_ACCEPTED(self, key, value):
+        """The third case #327 F9 listed, deliberately NOT rejected.
+
+        I first rejected it on the grounds that nothing consumes these without a
+        provider. A review showed that premise is false, and a probe confirmed it:
+        `ErrorNotifier` is built regardless of provider, and both settings are live
+        on the disabled path where they gate the `notification_suppressed` log.
+
+            severity=500 -> 404:0 500:1      severity=400 -> 404:1 500:1
+            cooldown=60, 500 x3 -> 1 log     cooldown=0 -> 3 logs
+
+        So keeping delivery off while tuning the volume of that log is a legitimate
+        configuration. Rejecting it would have been a regression, not a guard.
+        """
         env = {"ENV": "local", key: value, **_REQUIRED_VARS}
         with patch.dict(os.environ, env, clear=True):
-            with pytest.raises(ValidationError, match="nothing consumes them"):
-                _create_settings()
+            settings = _create_settings()
+            assert settings.notification_provider is None
 
     def test_no_notification_config_at_all_still_boots(self):
         """The control. Alerting is optional infrastructure (ADR 042) and must stay


### PR DESCRIPTION
Resolves #327 (audit cluster B). Parent: #336

Two parts, plus the behaviour matrix that made changing this code safe at all.

## The matrix came first, deliberately

#286's channel routing went through four review rounds and was declared clean by an 8-permutation × 7-status-code matrix — **but that matrix lived in a review comment, not the suite.** The semantics those rounds established were protected by nothing, which is a bad position from which to refactor the provider graph.

So the first commit ships it and changes no source: for every supported `NOTIFICATION_*` combination and seven status codes straddling both thresholds, it records **which webhook URL** would receive the alert and whether the notifier dispatches. URLs, not object types — a type only says "a Slack adapter", the URL says which channel. Each row runs in its own subprocess via `tests/support/container_env.py`, because the Selector branches capture `settings.*` at class-body time. That harness landed in #330, which is why this cluster was gated on it.

Every later commit had to reproduce those 10 rows exactly. They do.

## Part 1 — one adapter per distinct channel

Both tier targets fall back to the single provider webhook, and the per-tier Selectors were two-way enabled/disabled, so a tier with no override still built its own adapter against the same URL:

```
distinct adapter objects: 3      (one channel)
```

Not cosmetic. Both defects found in round 1 of PR #313 were consequences of this shape — three `NoopNotificationClient` instances instead of one (so the disabled warning logged once per tier), and an injected client the router short-circuits. The symptoms were patched then; this removes the shape.

The Selectors are now three-way: `override` builds an adapter, `shared` resolves to `notification_client` **itself**, `disabled` to the shared noop. Instance count now equals channel count:

```
routing off               1     BASE / BASE / BASE
routing on, no override   1     BASE / BASE / BASE      (was 3)
critical override         2     BASE / CRIT / BASE
warning override          2     BASE / BASE / WARN
both overrides            3     BASE / CRIT / WARN
disabled                  1     (one shared Noop)
```

**Deliberately not the collapse the issue proposed.** #327 suggests 5 providers → 2 by deleting `ErrorNotifier._client` and always building a router. Two reasons not to:

- `_client` is not dead code. It is the delivery path whenever routing is off — dead only in the routing-on configuration, which is correct by construction.
- Always building a router makes `_cooldown_key` always add a tier prefix, changing the #17 path's key from `error_code` to `critical:error_code`, and promotes `NotificationRouter`'s `warning_threshold=None` branch from a documented defensive contract to a production state.

The duplicated instances were the real cost and they collapse without either trade. The review verified this independently and agreed the full collapse is unsafe for exactly those reasons.

## Part 2 — F9: config that boots with the alert path inert

The validator rejects `NOTIFICATION_PROVIDER=slack` with no `SLACK_WEBHOOK_URL` on the stated grounds that the missing half would be "silently ignored". That reasoning was never applied upward. Measured in a valid prod env:

```
SLACK_WEBHOOK_URL alone            -> ACCEPTED, NoopNotificationClient
NOTIFICATION_WARNING_THRESHOLD     -> ACCEPTED, live NotificationRouter into a Noop
provider with no URL (control)     -> REJECTED
```

The first is the exact mirror of the case that *is* rejected, and the likelier operator error — paste the webhook, forget the provider. The second is sharper: the same block rejects a structurally identical downstream inconsistency with the words "silently ignored" while itself constructing a router that can never deliver.

Both now rejected, **unconditionally** — after checking that the existing provider-without-URL check rejects in `local` too, so a one-sided gate would have been a new asymmetry of the same kind.

Two controls pinned alongside: no notification config at all must still boot (alerting is optional infrastructure per ADR 042), and a complete configuration must still boot.

## One thing I got wrong, found by review

I initially rejected a **third** combination — severity/cooldown tuned with no provider — claiming nothing consumes them. **That premise is false.** `ErrorNotifier` is built regardless of provider and both settings are live on the disabled path, gating the `notification_suppressed` log. Measured:

```
severity=500 -> 404:0 500:1        severity=400 -> 404:1 500:1
cooldown=60, 500 x3 -> 1 log       cooldown=0   -> 3 logs
```

So keeping delivery off while tuning that log's volume is a legitimate configuration, and my rejection would have broken it at boot — a regression, not a guard. Removed, the measurement recorded inline, and the test inverted to assert acceptance. The issue listed all three; only two hold.

## Also from the review

The matrix covered Slack only, so a Discord regression was inferred rather than pinned. Three Discord rows added.

Those fixtures then needed one more fix, and **the tooling caught it rather than a reviewer**: the `discord-webhook-url` gitleaks rule this repo added in #320 blocked the commit because I wrote realistic digit-id URLs. #320 had to clean five existing fixtures for exactly that reason and I repeated it. Placeholder ids now, verified directly against the shipped rule.

## Verification

- `1754 passed, 42 skipped, 0 failed`. mypy clean.
- All 10 behaviour rows identical before and after the graph change; the 4 identity tests and 5 of the 7 config tests fail against their preceding commit.
- Review confirmed independently: no delivered URL changes in any permutation for either provider; adapters carry no per-tier mutable state; `HttpClient` was already shared; no shipped env example, doc snippet, Makefile target, compose file or CI job fails to boot under the new rejections.
- `check_governor_footer.py --require-governor-footer` against the changed file list: `0 violations`, non-governor. Run, not assumed.

## Note for #335 (docs re-sync)

`.claude/rules/architecture-conventions.md` describes the notification graph as "four notification Selectors" with three client ones sharing one Noop. The count is unchanged but the per-tier branch names are now `override`/`shared`/`disabled` rather than `enabled`/`disabled`, and the instance-count property is new. Left for cluster J rather than edited here.
