### PR TITLE
fix: repair both README demos and remove false claims from reader-facing surfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,7 @@ quickstart.db
 
 # Work-ledger runtime state (cross-session context; machine-written, not committed)
 .agents/state/
+
+# Local tooling scratch (pyright/pycon caches, agent worktrees) — machine-local
+.pycon/
+.claude/worktrees/

--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ make setup        # one-time: venv + deps via uv
 make quickstart   # FastAPI on :8001, SQLite schema auto-created
 ```
 
-In a second terminal, `make demo` exercises the `auth` + `user` domains
-(JWT register → CRUD → refresh → logout) and `make demo-rag` exercises the
+In a second terminal, `make demo` exercises the `auth` + `user` domains across
+both token realms (customer register → seed a demo admin → admin login → user
+CRUD → refresh → logout) and `make demo-rag` exercises the
 `docs` domain (end-to-end RAG: upload → chunk → embed → retrieve → answer
 with citations, zero credentials):
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Full integration walkthrough (auth · RBAC · worker · admin · RAG · OTEL): [
 
 - **Claude/Codex collaboration harness** — shared `AGENTS.md`, mirrored skills, and hook-backed workflow reminders
 - `/new-domain order` or `$new-domain order` scaffolds **44 files** (15 source + 25 `__init__.py` + 4 tests) in one command
-- **14 Claude Code + 14 Codex CLI skills** sharing the same architecture and review rules
+- **15 Claude Code + 15 Codex CLI skills** sharing the same architecture and review rules
 - **AI-assisted development (AIDD)** — humans keep product judgment; agents follow repeatable domain, test, review, and drift-check workflows
 - Full setup: [`docs/ai-development.md`](docs/ai-development.md)
 - Manual path: [`docs/tutorial/first-domain.md`](docs/tutorial/first-domain.md) (Path B)
@@ -162,10 +162,10 @@ from scratch.
 | Zero-boilerplate CRUD (8 methods) | **Yes** | No | No | No |
 | Auto domain discovery | **Yes** | No | No | No |
 | Architecture enforcement (pre-commit) | **Yes** | No | No | No |
-| AI workflow skills (Claude + Codex) | **14 + 14** | 0 | 0 | 0 |
+| AI workflow skills (Claude + Codex) | **15 + 15** | 0 | 0 | 0 |
 | Vector infrastructure (S3 Vectors) | **Yes** | No | No | No |
 | Multi-interface (API + Worker + Admin + MCP) | **3 + 1 planned** | 2 | 1 | 1 |
-| Architecture Decision Records | **18 active · 30 archived** | 0 | 0 | 0 |
+| Architecture Decision Records | **27 active · 30 archived** | 0 | 0 | 0 |
 | Type-safe generics across layers | **Yes** | Partial | Partial | No |
 | IoC container DI | **Yes** | No | No | No |
 
@@ -305,7 +305,7 @@ One business logic, multiple surfaces:
 | Adopt into an existing FastAPI project | [`docs/adoption.md`](docs/adoption.md) |
 | Check Python / FastAPI / tool version support | [`docs/compatibility.md`](docs/compatibility.md) |
 | See detailed env vars, tech stack, project tree | [`docs/reference.md`](docs/reference.md) |
-| Understand why a decision was made | [ADR index](docs/history/README.md) (18 active · 30 archived) |
+| Understand why a decision was made | [ADR index](docs/history/README.md) (27 active · 30 archived) |
 | Follow what's next | [Roadmap](docs/reference.md#roadmap) · [issue tracker](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues) |
 
 ---

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,11 +12,11 @@ Instead, please email the maintainers directly. We will respond within 48 hours 
 
 | Version  | Supported |
 |----------|-----------|
-| 0.7.x    | Yes       |
-| < 0.7.0  | No        |
+| 0.9.x    | Yes       |
+| < 0.9.0  | No        |
 
 Pre-1.0: only the latest minor line receives security fixes. Upgrade to the
-newest `0.7.x` patch to pick them up.
+newest `0.9.x` patch to pick them up.
 
 ## Disclosure Policy
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,11 @@ If you discover a security vulnerability, please report it responsibly.
 
 **Do not open a public GitHub issue for security vulnerabilities.**
 
-Instead, please email the maintainers directly. We will respond within 48 hours and work with you to understand and address the issue.
+Use GitHub's private vulnerability reporting instead:
+[**Report a vulnerability**](https://github.com/Mr-DooSun/fastapi-agent-blueprint/security/advisories/new).
+The report is visible only to the maintainers, and the thread stays private
+until an advisory is published. We will respond within 48 hours and work with
+you to understand and address the issue.
 
 ## Supported Versions
 
@@ -49,7 +53,8 @@ hygiene rules below are load-bearing, not aspirational.
 
 ### If you suspect a leak in this repo
 
-1. **Do not open a public issue.** Email the maintainers as described above.
+1. **Do not open a public issue.** Use private vulnerability reporting as
+   described above.
 2. Include the file path and line, not the raw key (they already know what it is).
 3. Credential rotation happens first; the public discussion happens
    only after the key is invalidated upstream.

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -84,7 +84,7 @@ make quickstart   # :8001 에 FastAPI 기동, SQLite 스키마 자동 생성
 - **도메인 자동 발견.** `src/{name}/` 에 폴더 하나만 두면 자동 등록. Container 수정도, bootstrap 수정도 필요 없음.
 - **환경변수 한 줄로 교체 가능한 인프라.** PostgreSQL / MySQL / SQLite · DynamoDB · S3 / MinIO · S3 Vectors · SQS / RabbitMQ / InMemory · LLM/Embedding 모두 OpenAI / Bedrock.
 - **커밋 시점에 아키텍처 강제.** Pre-commit 훅이 `Domain → Infrastructure` import 를 차단하여 DDD 계약이 썩지 않도록 보장.
-- **AI 네이티브 워크플로우.** Claude Code 14개 + Codex CLI 14개 스킬이 동일한 `AGENTS.md` 규칙을 공유 — 한 줄로 도메인 스캐폴딩, 라우트 추가, 아키텍처 감사가 가능.
+- **AI 네이티브 워크플로우.** Claude Code 15개 + Codex CLI 15개 스킬이 동일한 `AGENTS.md` 규칙을 공유 — 한 줄로 도메인 스캐폴딩, 라우트 추가, 아키텍처 감사가 가능.
 
 ---
 
@@ -95,10 +95,10 @@ make quickstart   # :8001 에 FastAPI 기동, SQLite 스키마 자동 생성
 | 보일러플레이트 제로 CRUD (8개 메서드) | **Yes** | No | No | No |
 | 도메인 자동 발견 | **Yes** | No | No | No |
 | 아키텍처 자동 강제 (pre-commit) | **Yes** | No | No | No |
-| AI 워크플로우 스킬 (Claude + Codex) | **14 + 14** | 0 | 0 | 0 |
+| AI 워크플로우 스킬 (Claude + Codex) | **15 + 15** | 0 | 0 | 0 |
 | 벡터 인프라 (S3 Vectors) | **Yes** | No | No | No |
 | 멀티 인터페이스 (API + Worker + Admin + MCP) | **3 + 1 예정** | 2 | 1 | 1 |
-| Architecture Decision Records | **18 active · 30 archived** | 0 | 0 | 0 |
+| Architecture Decision Records | **27 active · 30 archived** | 0 | 0 | 0 |
 | 전 계층 타입 안전 제네릭 | **Yes** | 부분 | 부분 | No |
 | IoC Container DI | **Yes** | No | No | No |
 
@@ -230,7 +230,7 @@ Codex CLI 를 쓴다면 `/` 대신 `$`. 하네스 없이 손으로 만들고 싶
 | Claude Code / Codex CLI 설정 | [`docs/ai-development.ko.md`](ai-development.ko.md) |
 | 도메인을 수동으로 추가 (AI 도구 없이) | [`docs/tutorial/first-domain.md`](tutorial/first-domain.md) (Path B) |
 | 상세 env 변수 · 기술 스택 · 프로젝트 트리 | [`docs/reference.md`](reference.md) |
-| 어떤 결정을 왜 했는지 | [ADR 인덱스](history/README.md) (18 active · 30 archived) |
+| 어떤 결정을 왜 했는지 | [ADR 인덱스](history/README.md) (27 active · 30 archived) |
 | 다음 계획 | [Roadmap](reference.md#roadmap) · [이슈 트래커](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues) |
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,7 +42,7 @@ Quick index for the `docs/` folder.
 
 The [history/](history/) folder contains Architecture Decision Records (ADRs).
 
-- 18 active ADRs in `history/` — open and in effect
+- 27 active ADRs in `history/` — open and in effect
 - 30 archived ADRs in `history/archive/` — superseded or historical
 
 Start at [history/README.md](history/README.md) for the index.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -12,10 +12,10 @@ and the "why not X?" questions that come up on HN and Reddit.
 | Zero-boilerplate CRUD (8 methods) | **Yes** | No | No | No |
 | Auto domain discovery | **Yes** | No | No | No |
 | Architecture enforcement (pre-commit) | **Yes** | No | No | No |
-| AI workflow skills (Claude + Codex) | **14 + 14** | 0 | 0 | 0 |
+| AI workflow skills (Claude + Codex) | **15 + 15** | 0 | 0 | 0 |
 | Vector infrastructure (S3 Vectors) | **Yes** | No | No | No |
 | Multi-interface (API + Worker + Admin + MCP) | **3 + 1 planned** | 2 | 1 | 1 |
-| Architecture Decision Records | **18 active · 30 archived** | 0 | 0 | 0 |
+| Architecture Decision Records | **27 active · 30 archived** | 0 | 0 | 0 |
 | Type-safe generics across layers | **Yes** | Partial | Partial | No |
 | IoC container DI | **Yes** | No | No | No |
 | JWT auth + RBAC | **Yes** | Yes | Partial | No |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -37,8 +37,16 @@ In a second terminal:
 make demo
 ```
 
-This exercises the `auth` and `user` domains: health check → register (JWT token pair) →
+This exercises the `auth` and `user` domains: health check → register (customer
+JWT token pair) → seed a demo admin → admin login (a separate token realm) →
 create user → list → update → delete → refresh token → logout.
+
+The admin step is not decoration. `/v1/user*` is gated on `require_admin`
+against the **admin** realm (#199/#218), which the customer token cannot
+satisfy — and neither can the quickstart bootstrap admin, which is setup-only.
+[`scripts/seed_demo_admin.py`](../scripts/seed_demo_admin.py) creates one real
+admin the way the NiceGUI setup wizard would; it refuses to run in `stg`/`prod`.
+
 Raw script: [`scripts/demo.sh`](../scripts/demo.sh).
 
 ## What does `quickstart` actually configure?

--- a/examples/README.md
+++ b/examples/README.md
@@ -109,19 +109,12 @@ Populated incrementally as contributors land the good-first-issues:
 |---|---|---|---|
 | `todo/` | Minimal CRUD domain (zero infra) | DB-only | ✅ [#112](https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/112) |
 | `url_shortener/` | CRUD + Taskiq worker cleanup task | DB-only | ✅ [#239](https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/239) |
-| `blog/` | Two domains + Protocol-based cross-domain DIP | DB-only | ✅ [#237](https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/237)&nbsp;† |
+| `blog/` | Two domains + Protocol-based cross-domain DIP | DB-only | ✅ [#237](https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/237) |
 | `webhook_receiver/` | Worker task driven by a broker message | DB-only | ✅ [#240](https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/240) |
 | `simple_chatbot/` | Minimal PydanticAI Agent — no RAG | LLM-calling | ✅ [#249](https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/249) |
 | `chatbot_with_guardrails/` | Runtime LLM guardrails around a PydanticAI Agent | LLM-calling | ✅ [#256](https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/256) |
 | `chatbot_with_memory/` | Multi-turn chatbot with session memory and history replay | LLM-calling | ✅ [#255](https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/255) |
 | `web_search_chatbot/` | Agentic web-search tool use (DuckDuckGo, keyless) | LLM-calling | ✅ [#287](https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/287) |
-
-> † **`blog/` does not yet run via the copy-into-`src/` flow.** Unlike the
-> single-domain examples above, `blog/` still uses absolute intra-example
-> imports, so copying it into `src/` currently fails at boot (the two
-> `src/`-level domains re-register the same table). Read it in place for the
-> cross-domain DIP pattern; making it copy-runnable is tracked as
-> [#261](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/261).
 
 Finished examples move from 🟡 to ✅ with a link to the PR that landed
 them. If an example you want is not on the list, open a

--- a/scripts/demo-rag.sh
+++ b/scripts/demo-rag.sh
@@ -44,6 +44,37 @@ note "Health check"
 run "curl -sS '${BASE_URL}/health' | pretty"
 
 # --------------------------------------------------------------
+# Auth — every /v1/docs route is gated on a customer-realm token
+# (`Depends(get_current_user)`), so obtain one before seeding.
+# Register is idempotent here only in the sense that a second run
+# falls back to login with the same credentials.
+# --------------------------------------------------------------
+
+note "Register (or log in) to obtain a customer JWT"
+REGISTER_BODY='{"username":"alice","full_name":"Alice Liddell","email":"alice@example.com","password":"secret123"}'
+REGISTER_RESPONSE="$(curl -sS -X POST "${BASE_URL}/v1/auth/register" \
+  -H 'Content-Type: application/json' \
+  -d "${REGISTER_BODY}")"
+
+ACCESS_TOKEN="$(echo "${REGISTER_RESPONSE}" | python3 -c "import json,sys;print(json.load(sys.stdin)['data']['accessToken'])" 2>/dev/null || echo "")"
+
+if [ -z "${ACCESS_TOKEN}" ]; then
+  LOGIN_BODY='{"username":"alice","password":"secret123"}'
+  LOGIN_RESPONSE="$(curl -sS -X POST "${BASE_URL}/v1/auth/login" \
+    -H 'Content-Type: application/json' \
+    -d "${LOGIN_BODY}")"
+  ACCESS_TOKEN="$(echo "${LOGIN_RESPONSE}" | python3 -c "import json,sys;print(json.load(sys.stdin)['data']['accessToken'])" 2>/dev/null || echo "")"
+fi
+
+if [ -z "${ACCESS_TOKEN}" ]; then
+  echo "Could not obtain access token — aborting." >&2
+  exit 1
+fi
+
+AUTH_HEADER="Authorization: Bearer ${ACCESS_TOKEN}"
+echo "Obtained a customer access token."
+
+# --------------------------------------------------------------
 # Seed three sample documents
 # --------------------------------------------------------------
 
@@ -53,7 +84,7 @@ DOC1_BODY='{
   "source": "https://fastapi.tiangolo.com",
   "content": "FastAPI is a modern Python web framework for building APIs. It leverages type hints for automatic request validation via Pydantic and generates OpenAPI documentation automatically. FastAPI is built on Starlette for async HTTP handling and supports dependency injection out of the box. Developers choose FastAPI for its speed, developer ergonomics, and first-class async support."
 }'
-run "curl -sS -X POST '${BASE_URL}/v1/docs/documents' -H 'Content-Type: application/json' -d '${DOC1_BODY}' | pretty"
+run "curl -sS -X POST '${BASE_URL}/v1/docs/documents' -H 'Content-Type: application/json' -H '${AUTH_HEADER}' -d '${DOC1_BODY}' | pretty"
 
 note "Seed document 2 — DDD layered architecture"
 DOC2_BODY='{
@@ -61,7 +92,7 @@ DOC2_BODY='{
   "source": "internal-notes",
   "content": "Domain-Driven Design organizes code around business domains rather than technical concerns. The typical layered architecture separates Interface, Application, Domain, and Infrastructure. The Domain layer contains business logic and must not depend on infrastructure details. The Infrastructure layer implements persistence and external integrations. Interfaces invert control via protocols or dependency injection."
 }'
-run "curl -sS -X POST '${BASE_URL}/v1/docs/documents' -H 'Content-Type: application/json' -d '${DOC2_BODY}' | pretty"
+run "curl -sS -X POST '${BASE_URL}/v1/docs/documents' -H 'Content-Type: application/json' -H '${AUTH_HEADER}' -d '${DOC2_BODY}' | pretty"
 
 note "Seed document 3 — Retrieval-Augmented Generation"
 DOC3_BODY='{
@@ -69,14 +100,14 @@ DOC3_BODY='{
   "source": "docs/rag-primer.md",
   "content": "Retrieval-Augmented Generation combines a vector database with a large language model. A user question is embedded into a vector, matched against an index of document chunks, and the top results are supplied as context to the LLM. This approach reduces hallucinations because the model answers from retrieved evidence rather than parametric memory alone. Citations link each answer back to the source chunk that supported it."
 }'
-run "curl -sS -X POST '${BASE_URL}/v1/docs/documents' -H 'Content-Type: application/json' -d '${DOC3_BODY}' | pretty"
+run "curl -sS -X POST '${BASE_URL}/v1/docs/documents' -H 'Content-Type: application/json' -H '${AUTH_HEADER}' -d '${DOC3_BODY}' | pretty"
 
 # --------------------------------------------------------------
 # List seeded documents
 # --------------------------------------------------------------
 
 note "List indexed documents"
-run "curl -sS '${BASE_URL}/v1/docs/documents?page=1&pageSize=10' | pretty"
+run "curl -sS '${BASE_URL}/v1/docs/documents?page=1&pageSize=10' -H '${AUTH_HEADER}' | pretty"
 
 # --------------------------------------------------------------
 # Run a natural-language query
@@ -87,6 +118,6 @@ QUERY_BODY='{
   "question": "What does retrieval-augmented generation do with citations?",
   "top_k": 3
 }'
-run "curl -sS -X POST '${BASE_URL}/v1/docs/query' -H 'Content-Type: application/json' -d '${QUERY_BODY}' | pretty"
+run "curl -sS -X POST '${BASE_URL}/v1/docs/query' -H 'Content-Type: application/json' -H '${AUTH_HEADER}' -d '${QUERY_BODY}' | pretty"
 
 note "Done. API docs: ${BASE_URL}/docs | Admin: ${BASE_URL}/admin/docs"

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -62,14 +62,46 @@ fi
 AUTH_HEADER="Authorization: Bearer ${ACCESS_TOKEN}"
 
 # --------------------------------------------------------------
-# User CRUD (JWT-protected routes)
+# Admin realm — /v1/user* is gated on Depends(require_admin) since
+# #199, re-pointed to the admin token realm by #218. The customer
+# token above cannot reach it, and neither can the quickstart
+# bootstrap admin (require_admin rejects is_bootstrap_admin, and the
+# token login rejects bootstrap + temp-password accounts). Seed a
+# real admin the way the NiceGUI setup wizard would.
 # --------------------------------------------------------------
 
-note "Create a second user (JWT-authenticated)"
+DEMO_ADMIN_USER="${DEMO_ADMIN_USER:-demoadmin}"
+DEMO_ADMIN_SECRET="${DEMO_ADMIN_SECRET:-demoadmin123}"
+
+note "Seed the demo admin (quickstart only — refuses to run in stg/prod)"
+run "uv run python scripts/seed_demo_admin.py --env quickstart --username '${DEMO_ADMIN_USER}' --secret '${DEMO_ADMIN_SECRET}'"
+
+note "Admin login (separate token realm from the customer token above)"
+ADMIN_LOGIN_BODY="{\"username\":\"${DEMO_ADMIN_USER}\",\"password\":\"${DEMO_ADMIN_SECRET}\"}"
+ADMIN_LOGIN_RESPONSE="$(curl -sS -X POST "${BASE_URL}/v1/admin/login" \
+  -H 'Content-Type: application/json' \
+  -d "${ADMIN_LOGIN_BODY}")"
+
+ADMIN_ACCESS_TOKEN="$(echo "${ADMIN_LOGIN_RESPONSE}" | python3 -c "import json,sys;print(json.load(sys.stdin)['data']['accessToken'])" 2>/dev/null || echo "")"
+
+if [ -z "${ADMIN_ACCESS_TOKEN}" ]; then
+  echo "${ADMIN_LOGIN_RESPONSE}" | pretty
+  echo "Could not obtain an admin access token — aborting." >&2
+  exit 1
+fi
+
+ADMIN_AUTH_HEADER="Authorization: Bearer ${ADMIN_ACCESS_TOKEN}"
+echo "Obtained an admin-realm access token."
+
+# --------------------------------------------------------------
+# User CRUD (admin-realm protected routes)
+# --------------------------------------------------------------
+
+note "Create a second user (admin-authenticated)"
 CREATE_BODY='{"username":"bob","full_name":"Bob Builder","email":"bob@example.com","password":"secret456"}'
 CREATE_RESPONSE="$(curl -sS -X POST "${BASE_URL}/v1/user" \
   -H 'Content-Type: application/json' \
-  -H "${AUTH_HEADER}" \
+  -H "${ADMIN_AUTH_HEADER}" \
   -d "${CREATE_BODY}")"
 echo "${CREATE_RESPONSE}" | pretty
 
@@ -81,14 +113,14 @@ if [ -z "${USER_ID}" ]; then
 fi
 
 note "List users (page=1, pageSize=10)"
-run "curl -sS '${BASE_URL}/v1/users?page=1&pageSize=10' -H '${AUTH_HEADER}' | pretty"
+run "curl -sS '${BASE_URL}/v1/users?page=1&pageSize=10' -H '${ADMIN_AUTH_HEADER}' | pretty"
 
 note "Update the user"
 UPDATE_BODY='{"full_name":"Bob Builder (updated)"}'
-run "curl -sS -X PUT '${BASE_URL}/v1/user/${USER_ID}' -H 'Content-Type: application/json' -H '${AUTH_HEADER}' -d '${UPDATE_BODY}' | pretty"
+run "curl -sS -X PUT '${BASE_URL}/v1/user/${USER_ID}' -H 'Content-Type: application/json' -H '${ADMIN_AUTH_HEADER}' -d '${UPDATE_BODY}' | pretty"
 
 note "Delete the user"
-run "curl -sS -X DELETE '${BASE_URL}/v1/user/${USER_ID}' -H '${AUTH_HEADER}' | pretty"
+run "curl -sS -X DELETE '${BASE_URL}/v1/user/${USER_ID}' -H '${ADMIN_AUTH_HEADER}' | pretty"
 
 # --------------------------------------------------------------
 # Auth — refresh token + logout

--- a/scripts/seed_demo_admin.py
+++ b/scripts/seed_demo_admin.py
@@ -1,0 +1,189 @@
+"""Seed a demo admin that the admin-realm HTTP token API will accept.
+
+Why this exists
+---------------
+`/v1/user*` is gated on `Depends(require_admin)` (#199, re-pointed to the admin
+realm by #218/ADR 049), so `scripts/demo.sh` needs an admin-realm token. There is
+no way to obtain one with curl alone:
+
+- The only admin-realm HTTP routes are `/v1/admin/login|refresh|logout`. Real
+  admins are created through the NiceGUI setup wizard, which has no HTTP
+  equivalent.
+- The quickstart bootstrap admin cannot stand in. `require_admin` rejects
+  `is_bootstrap_admin` outright, and `AdminAuthUseCase.login` rejects both
+  bootstrap and `password_temporary` admins before issuing a token pair.
+
+So `make demo` died at the first `/v1/user` call with `INVALID_TOKEN`, and had
+done since 2026-05-27 while the script was last touched 2026-05-06.
+
+Rather than change the runtime — auto-seeding a privileged account with known
+credentials into a shipped env profile is a security-posture decision, not a
+demo fix — this script performs the two steps the wizard performs, explicitly
+and only when a developer runs it:
+
+1. `create_admin_account(...)` — a non-bootstrap admin with every page
+   permission. It lands with `password_temporary=True`.
+2. `change_admin_password(...)` — rewrites the credential through
+   `_PasswordChangeClearTempDTO`, which clears the temporary flag. Without this
+   second step `login` still refuses the account.
+
+Guards
+------
+Refuses to run in `stg`/`prod`. The account it creates is a real, fully
+privileged admin whose credentials are committed in `scripts/demo.sh`, so it
+must never exist in an environment that matters.
+
+Idempotent: a re-run resets the existing demo admin's credential instead of
+failing on the unique-username check, so `make demo` works on a warm
+`quickstart.db`.
+
+Usage
+-----
+    uv run python scripts/seed_demo_admin.py --env quickstart
+    uv run python scripts/seed_demo_admin.py --env quickstart --username someone
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Running a file under scripts/ puts scripts/ on sys.path[0], not the repo root,
+# and the project declares no [build-system] so it is never installed as a
+# distribution. Without this, `import src...` raises ModuleNotFoundError even
+# from an activated .venv at the repo root.
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+# Fixed cross-cutting keys pre-seeded in AdminPermissionRegistry. Mirrored here
+# because the registry is populated during NiceGUI admin bootstrap, which this
+# script deliberately does not run (it must work without the `admin` extra).
+_FIXED_PERMISSION_KEYS = ("accounts", "audit_log")
+
+_STRICT_ENVS = frozenset({"stg", "prod"})
+
+DEFAULT_USERNAME = "demoadmin"
+DEFAULT_SECRET = "demoadmin123"  # noqa: S105 - demo credential, guarded above
+DEFAULT_EMAIL = "demoadmin@example.com"
+DEFAULT_FULL_NAME = "Demo Administrator"
+
+
+def _admin_page_permission_keys() -> list[str]:
+    """Page keys an admin can be granted, without importing NiceGUI.
+
+    `_discover_and_register_pages` registers `cfg.domain_name` for every domain
+    exposing `interface/admin/configs/{d}_admin_config.py`. Detecting those
+    files on disk rather than importing them keeps this script runnable on a
+    minimal install, where the `admin` extra is absent.
+    """
+    from src._core.infrastructure.discovery import discover_domains
+
+    keys = set(_FIXED_PERMISSION_KEYS)
+    for domain in discover_domains():
+        config = (
+            _REPO_ROOT
+            / "src"
+            / domain
+            / "interface"
+            / "admin"
+            / "configs"
+            / f"{domain}_admin_config.py"
+        )
+        if config.is_file():
+            keys.add(domain)
+    return sorted(keys)
+
+
+async def _seed(username: str, secret: str, email: str, full_name: str) -> int:
+    from src._apps.server.di.container import create_server_container
+    from src.admin_identity.domain.dtos.admin_identity_dto import CreateAdminAccountDTO
+
+    container = create_server_container()
+    service = container.admin_identity_container.admin_identity_service()
+    repository = container.admin_identity_container.admin_repository()
+
+    try:
+        existing = await repository.select_data_by_username(username)
+        if existing is not None:
+            # Re-running the demo on a warm quickstart.db. Rewriting the
+            # credential through change_admin_password also clears
+            # password_temporary, which is what a token login needs.
+            admin = await service.change_admin_password(existing.id, secret)
+            print(f"Demo admin '{admin.username}' already existed — credential reset.")
+            return admin.id
+
+        admin = await service.create_admin_account(
+            CreateAdminAccountDTO(
+                username=username,
+                full_name=full_name,
+                email=email,
+                permissions=_admin_page_permission_keys(),
+            ),
+            temp_password=secret,
+        )
+        # create_admin_account always lands password_temporary=True; login()
+        # refuses such accounts, so clear the flag by rewriting the credential.
+        admin = await service.change_admin_password(admin.id, secret)
+        print(
+            f"Demo admin '{admin.username}' created with permissions "
+            f"{admin.permissions}."
+        )
+        return admin.id
+    finally:
+        # Nothing in src/ calls Database.dispose() — there is no FastAPI
+        # lifespan handler — so the async engine's pool keeps the process
+        # alive after the coroutine returns. A long-lived server exits by
+        # process teardown; a one-shot script would just hang. Observed:
+        # seeding printed its success line and never returned.
+        await container.core_container.database().dispose()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Seed a demo admin for make demo.")
+    parser.add_argument("--env", default="quickstart")
+    parser.add_argument("--username", default=DEFAULT_USERNAME)
+    parser.add_argument("--secret", default=DEFAULT_SECRET)
+    parser.add_argument("--email", default=DEFAULT_EMAIL)
+    parser.add_argument("--full-name", default=DEFAULT_FULL_NAME)
+    args = parser.parse_args()
+
+    if args.env in _STRICT_ENVS:
+        print(
+            f"Refusing to seed a demo admin in '{args.env}': this creates a fully "
+            "privileged account whose credentials are committed in "
+            "scripts/demo.sh.",
+            file=sys.stderr,
+        )
+        return 2
+
+    load_dotenv(dotenv_path=_REPO_ROOT / "_env" / f"{args.env}.env", override=True)
+
+    from src._core.config import settings
+
+    if settings.env in _STRICT_ENVS:
+        print(
+            f"Refusing to seed a demo admin: _env/{args.env}.env resolves to "
+            f"ENV={settings.env}.",
+            file=sys.stderr,
+        )
+        return 2
+
+    asyncio.run(
+        _seed(
+            username=args.username,
+            secret=args.secret,
+            email=args.email,
+            full_name=args.full_name,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/_apps/server/app.py
+++ b/src/_apps/server/app.py
@@ -8,8 +8,12 @@ from src._core.config import settings
 def create_app():
     app = FastAPI(
         title="FastAPI Agent Blueprint",
-        description="AI Agent Backend Platform — MCP server + AI orchestration + async DDD architecture",
-        version="1.0.0",
+        description="AI Agent Backend Platform — async DDD architecture with HTTP API, Taskiq worker, and admin interfaces",
+        # Kept in step with pyproject.toml [project].version by
+        # tests/unit/_apps/test_openapi_metadata.py. The package is not
+        # installed as a distribution (no [build-system]), so
+        # importlib.metadata cannot resolve it at runtime.
+        version="0.9.0",
         root_path="/api",
         docs_url=settings.docs_url,
         redoc_url=settings.redoc_url,

--- a/tests/unit/_apps/server/test_openapi_metadata.py
+++ b/tests/unit/_apps/server/test_openapi_metadata.py
@@ -1,0 +1,77 @@
+"""Contract tests for the OpenAPI metadata served at `/docs`.
+
+Two independent drifts made this file necessary, and both were visible to every
+anonymous visitor of the running server rather than only to contributors:
+
+1. `description=` advertised "MCP server". No MCP surface exists anywhere in the
+   repo — no `mcp`/`fastmcp`/`modelcontextprotocol` dependency, no module, no
+   route. It is issue #18, tracked as roadmap in `README.md` and unchecked in
+   `docs/reference.md`. Only the OpenAPI string presented it as shipped.
+2. `version=` said `1.0.0` while `pyproject.toml` said `0.9.0`. The two had
+   never agreed; the release process bumps `pyproject.toml` and the `CHANGELOG`,
+   and nothing pointed back at this call site.
+
+The version cannot be resolved at runtime: `pyproject.toml` declares no
+`[build-system]`, so the project is never installed as a distribution and
+`importlib.metadata.version("fastapi-agent-blueprint")` raises
+`PackageNotFoundError` under both `uv run` and an activated `.venv`. Reading and
+parsing `pyproject.toml` at import time to avoid one literal would put file I/O
+in the server's import path, so the literal stays and this test is the guard.
+
+Scope note: these assert the *metadata contract* only. Route-level OpenAPI shape
+is covered by the per-domain router tests.
+
+These read the module-level ``app`` rather than calling ``create_app()``. With
+the ``admin`` extra installed, ``create_app`` reaches ``ui.run_with``, and
+NiceGUI's ``core.app`` is a process-wide singleton that refuses
+``add_middleware`` once it has been started — so a second ``create_app()`` in a
+worker that already imported the app raises. The failure is order-dependent:
+these tests pass alone and fail in the full suite. ``import app`` is the
+pattern the rest of the suite uses (see
+``tests/integration/_core/test_minimal_install.py``) and it asserts against the
+object actually served.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+from src._apps.server.app import app
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+
+# Substrings that must never reappear in the public API description. Each names
+# a capability the repo does not ship; see the module docstring.
+_UNSHIPPED_CAPABILITIES = ("mcp", "fastmcp", "modelcontextprotocol")
+
+
+def _pyproject_version() -> str:
+    with _PYPROJECT.open("rb") as handle:
+        return str(tomllib.load(handle)["project"]["version"])
+
+
+def test_openapi_version_matches_pyproject() -> None:
+    assert app.version == _pyproject_version()
+
+
+def test_openapi_description_advertises_no_unshipped_capability() -> None:
+    description = (app.description or "").lower()
+
+    for capability in _UNSHIPPED_CAPABILITIES:
+        assert capability not in description, (
+            f"OpenAPI description advertises {capability!r}, which the repo does "
+            f"not ship (issue #18). Description: {app.description!r}"
+        )
+
+
+def test_openapi_title_is_the_project_name() -> None:
+    assert app.title == "FastAPI Agent Blueprint"
+
+
+def test_pyproject_version_is_semver() -> None:
+    # A malformed version here would make the equality test above pass for the
+    # wrong reason (both sides equally wrong).
+    assert re.fullmatch(r"\d+\.\d+\.\d+", _pyproject_version())


### PR DESCRIPTION
Preflight for the external re-submission to `mjhea0/awesome-fastapi`. Every item
here is something an outside reviewer hits in the first five minutes, and every
one of them was **untracked** — only the Docker gap (#332) had an issue.

## What was wrong

| Surface | Symptom |
|---|---|
| `/docs` OpenAPI | `description=` advertised **"MCP server"**. No `mcp`/`fastmcp`/`modelcontextprotocol` dependency, module or route exists — it is roadmap-only (#18), correctly marked as planned everywhere except the one string served to every visitor. `version=` also said `1.0.0` against pyproject's `0.9.0`. |
| `make demo` | Died at the first `/v1/user` call with `INVALID_TOKEN`, since 2026-05-27. |
| `make demo-rag` | Returned `UNAUTHORIZED` on every call, since 2026-06-03. |
| README / docs | `18 active ADRs` (real: **27**) and `14 + 14 skills` (real: **15 + 15**) across 11 sites, including the comparison table on the first screen. |
| `SECURITY.md` | Supported line said `0.7.x` at version 0.9.0, and the only documented reporting channel was "email the maintainers" with no address in the file. |
| `examples/README.md` | Still warned that `blog/` breaks under copy-to-`src/` and pointed at #261 — closed 2026-07-02, and the smoke case passes. |
| `.gitignore` | `.pycon/` untracked and unignored; `.claude/worktrees/` excluded only via the unshared `.git/info/exclude`. |

## The demo fix is not a one-liner

`/v1/user*` was gated on `require_admin` by #199 and re-pointed to the admin
token realm by #218/ADR 049. curl cannot reach an admin-realm token today:

- the only admin HTTP routes are `/v1/admin/login|refresh|logout`;
- real admins are created solely through the NiceGUI setup wizard;
- `require_admin` rejects `is_bootstrap_admin`, and `AdminAuthUseCase.login`
  rejects bootstrap **and** `password_temporary` accounts before issuing a pair.

So the quickstart bootstrap admin cannot stand in either. Rather than change the
runtime — auto-seeding a privileged account with known credentials into a
shipped env profile is a security-posture decision, not a demo fix —
`scripts/seed_demo_admin.py` performs the two steps the wizard performs
(`create_admin_account`, then `change_admin_password` to clear the temporary
flag the first step always sets), refuses to run when `--env` or the resolved
`ENV` is `stg`/`prod`, and is idempotent against a warm `quickstart.db`.

Two incidental findings surfaced while making it work, both handled in the
script rather than papered over:

- `sys.path` needs the repo root, because the project declares no
  `[build-system]` and is never installed as a distribution.
- The coroutine must dispose the database itself. Nothing in `src/` calls
  `Database.dispose()` — there is no FastAPI `lifespan` handler — so a one-shot
  script hangs after its work is done, where a server exits by process teardown.
  Worth a follow-up on the runtime side.

## Verification

- Full suite: **1828 passed, 21 skipped** (1824 before; +4 from the new OpenAPI
  metadata contract test).
- `pre-commit run --all-files`: 19/19 default-stage hooks pass.
- `make demo` against a live quickstart server, cold `quickstart.db`: exit 0,
  seven successful responses, zero errors.
- `make demo` warm re-run: exit 0, admin credential reset, only the expected
  `alice already exists` that the pre-existing login fallback handles.
- `make demo-rag` on the same warm database: exit 0, three citations returned.
- `pytest tests/integration/examples/test_copyflow_smoke.py -k blog`: passes,
  which is what makes the `#261` warning removal safe.

The new tests read the module-level `app` rather than calling `create_app()`:
with the `admin` extra installed `create_app` reaches `ui.run_with`, and
NiceGUI's `core.app` singleton refuses `add_middleware` once started, so a
second `create_app()` in a worker that already imported the app raises. That
failure is order-dependent — it passes alone and fails in the full suite.

## Out of scope / follow-ups

- **Enable "Private vulnerability reporting"** under repository Settings →
  Security. `SECURITY.md` now links `/security/advisories/new`, and that URL
  does not resolve until the setting is on.
- `CODE_OF_CONDUCT.md` still has no enforcement contact. Left alone rather than
  inventing a channel.
- `docs/security/gitleaks-scan-20260420.json` is a valid clean report (`[]` is
  the documented "no findings" shape) but is 3.5 months old, against a README
  that says the filename date signals freshness.
- No governor paths are touched, so no Governor Footer block applies.
