### PR TITLE
fix(docker): make the image build and compose run every process (#332)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,67 @@
+# Build context exclusions.
+#
+# Without this file the whole working tree is sent to the daemon: ~1.0 GB
+# locally, of which .venv is ~376 MB and .claude/worktrees is ~495 MB. Both are
+# host-only and neither can be used by the image — the venv is rebuilt inside
+# the builder stage against the target platform.
+#
+# Keep in step with the COPY lines in _docker/docker.Dockerfile: anything the
+# image needs must NOT be excluded here.
+
+# Version control
+.git/
+.gitignore
+.gitattributes
+
+# Local virtualenvs and interpreter caches — rebuilt in the builder stage
+.venv/
+venv/
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pycon/
+.ruff_cache/
+.mypy_cache/
+.pytest_cache/
+
+# Secrets and local runtime state. The image reads configuration from the
+# process environment; nothing under _env/ is ever baked into a layer.
+_env/
+*.env
+.env
+quickstart.db
+*.sqlite
+*.sqlite3
+.nicegui/
+
+# Test, docs and example trees — not part of the served application
+tests/
+docs/
+examples/
+scripts/
+migrations/versions/__pycache__/
+
+# AI collaboration harness (host-side tooling only)
+.claude/
+.codex/
+.antigravity/
+.gemini/
+.agents/
+AGENTS.md
+CLAUDE.md
+
+# CI and editor
+.github/
+.vscode/
+.idea/
+.pre-commit-config.yaml
+
+# Compose files and container assets — not needed inside the image
+docker-compose*.yml
+_docker/
+
+# Build artefacts
+dist/
+build/
+htmlcov/
+.coverage

--- a/_docker/compose.defaults.env
+++ b/_docker/compose.defaults.env
@@ -1,0 +1,36 @@
+# Reference-stack defaults for docker-compose.yml.
+#
+# These live in a committed env file rather than a compose `environment:` block
+# for one reason: `environment:` wins over `env_file:`, so an inline block would
+# make the `_env/prod.env` overlay unreachable — ENV would stay `local`, the
+# stg/prod boot validation would never run, and the wildcard hosts and
+# placeholder credentials below could not be overridden. Entries later in a
+# service's `env_file:` list do override earlier ones, so the optional
+# `_env/prod.env` genuinely takes precedence over this file.
+#
+# Nothing here is a secret and nothing here is safe outside a local machine.
+
+ENV=local
+TASK_NAME_PREFIX=fastapi-agent-blueprint
+ADMIN_STORAGE_SECRET=compose-reference-stack-only
+ADMIN_BOOTSTRAP_ENABLED=false
+
+# Matches the postgres service. The image ships no SQLite driver — aiosqlite is
+# a dev dependency — so PostgreSQL is the only engine this stack can use.
+DATABASE_ENGINE=postgresql
+DATABASE_HOST=postgres
+DATABASE_PORT=5432
+DATABASE_USER=postgres
+DATABASE_PASSWORD=postgres
+DATABASE_NAME=postgres
+
+# A standalone worker needs a cross-process broker: BROKER_TYPE=inmemory runs
+# tasks inline in the producer and InMemoryBroker.listen() raises.
+BROKER_TYPE=rabbitmq
+RABBITMQ_URL=amqp://guest:guest@rabbitmq:5672/
+
+VECTOR_STORE_TYPE=inmemory
+
+# Local convenience only. Replace both before this reaches anything shared.
+ALLOWED_HOSTS=["*"]
+ALLOW_ORIGINS=["*"]

--- a/_docker/docker.Dockerfile
+++ b/_docker/docker.Dockerfile
@@ -1,6 +1,28 @@
-FROM python:3.12-slim-bookworm
+# syntax=docker/dockerfile:1
+#
+# Multi-stage image for the server, worker and scheduler processes. All three
+# share one image and differ only in the command compose (or your orchestrator)
+# gives them — see docker-compose.yml.
+#
+# Previously this was a single stage that did `COPY _env/${ENV}.env /app/.env`
+# with `ARG ENV=prod`. Only *.env.example files are committed and `_env/*.env`
+# is gitignored, so the image did not build as shipped:
+#
+#   ERROR: failed to compute cache key: "/_env/prod.env": not found
+#
+# and making it build by adding that file bakes credentials into a layer that
+# `docker history` will happily print. Configuration now comes from the process
+# environment at run time, which compose `env_file` and every orchestrator's
+# secret mechanism already provide.
 
-ARG ENV=prod
+# ── builder ──────────────────────────────────────────────────────────────────
+# build-essential compiles any sdist-only wheels. It stays in this stage: the
+# previous single-stage build shipped the whole toolchain in the final image.
+FROM python:3.12-slim-bookworm AS builder
+
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_PYTHON_DOWNLOADS=never
 
 WORKDIR /app
 
@@ -10,12 +32,45 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
-COPY pyproject.toml uv.lock /app/
-RUN uv sync --no-dev --frozen
+# Broker extras are not optional for the environment this image targets:
+# Settings requires an explicit BROKER_TYPE in stg/prod, and both supported
+# values need a package a core-only `uv sync` does not install
+# (sqs -> taskiq-aws, rabbitmq -> taskiq-aio-pika). Override to trim or extend,
+# e.g. --build-arg EXTRAS="--extra rabbitmq --extra admin".
+ARG EXTRAS="--extra sqs --extra rabbitmq"
 
-COPY src/ /app/src/
-COPY _env/${ENV}.env /app/.env
+COPY pyproject.toml uv.lock /app/
+RUN uv sync --no-dev --frozen --no-install-project ${EXTRAS}
+
+# ── runtime ──────────────────────────────────────────────────────────────────
+FROM python:3.12-slim-bookworm AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PATH="/app/.venv/bin:${PATH}"
+
+WORKDIR /app
+
+# Non-root. The previous image ran everything as root.
+RUN groupadd --system --gid 1001 app \
+    && useradd --system --uid 1001 --gid app --no-create-home app
+
+COPY --from=builder --chown=app:app /app/.venv /app/.venv
+
+# migrations/ and alembic.ini were never copied, so `alembic upgrade head` was
+# impossible inside the container — the usual pre-start step for this stack.
+COPY --chown=app:app src/ /app/src/
+COPY --chown=app:app migrations/ /app/migrations/
+COPY --chown=app:app alembic.ini /app/alembic.ini
+
+USER app
 
 EXPOSE 8000
 
-CMD ["uv", "run", "uvicorn", "src._apps.server.app:app", "--workers", "1", "--host", "0.0.0.0", "--port", "8000", "--env-file", ".env"]
+# curl is absent from the slim base and installing it for a probe would add an
+# apt layer, so use the interpreter that is already here.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+    CMD ["python", "-c", "import sys,urllib.request;sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8000/health', timeout=4).status == 200 else 1)"]
+
+# No --env-file: configuration is read from the process environment.
+CMD ["uvicorn", "src._apps.server.app:app", "--workers", "1", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,24 +26,15 @@ x-app: &app
     dockerfile: _docker/docker.Dockerfile
   image: fastapi-agent-blueprint:0.9.0
   env_file:
+    # Order is the whole point. Entries later in this list override earlier
+    # ones, so `_env/prod.env` genuinely wins over the reference defaults. An
+    # inline `environment:` block would override BOTH and make the overlay
+    # unreachable — ENV would stay `local`, stg/prod boot validation would never
+    # run, and the wildcard hosts and placeholder credentials could not be
+    # replaced. Verified with `docker compose config`.
+    - _docker/compose.defaults.env
     - path: _env/prod.env
       required: false
-  environment:
-    ENV: local
-    TASK_NAME_PREFIX: fastapi-agent-blueprint
-    ADMIN_STORAGE_SECRET: compose-reference-stack-only
-    ADMIN_BOOTSTRAP_ENABLED: "false"
-    DATABASE_ENGINE: postgresql
-    DATABASE_HOST: postgres
-    DATABASE_PORT: "5432"
-    DATABASE_USER: postgres
-    DATABASE_PASSWORD: postgres
-    DATABASE_NAME: postgres
-    BROKER_TYPE: rabbitmq
-    RABBITMQ_URL: amqp://guest:guest@rabbitmq:5672/
-    VECTOR_STORE_TYPE: inmemory
-    ALLOWED_HOSTS: '["*"]'
-    ALLOW_ORIGINS: '["*"]'
   restart: unless-stopped
 
 services:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,145 @@
-version: '3.8'
+# Reference stack: every long-lived process this project ships, plus the
+# infrastructure they require, in one `docker compose up`.
+#
+# Previously this file declared a single `server` service, pinned
+# `image: server:v0.0.1` at project version 0.9.0, carried the obsolete
+# `version: '3.8'` key, and pointed `env_file` at the gitignored
+# `_env/prod.env` — so `docker compose config` failed outright on a clean
+# clone:
+#
+#   env file .../_env/prod.env not found
+#
+# `_env/prod.env` is now an *optional overlay* (`required: false`). Without it
+# the stack runs on the inline defaults below at ENV=local. Supply the file to
+# point the same topology at real infrastructure; note that ENV=stg/prod turns
+# on boot validation that rejects every placeholder credential here, which is
+# the intended behaviour rather than an obstacle to work around.
+#
+# Infrastructure ports are deliberately not published to the host: this file
+# and docker-compose.local.yml would otherwise both claim 5432.
+
+name: fastapi-agent-blueprint
+
+x-app: &app
+  build:
+    context: .
+    dockerfile: _docker/docker.Dockerfile
+  image: fastapi-agent-blueprint:0.9.0
+  env_file:
+    - path: _env/prod.env
+      required: false
+  environment:
+    ENV: local
+    TASK_NAME_PREFIX: fastapi-agent-blueprint
+    ADMIN_STORAGE_SECRET: compose-reference-stack-only
+    ADMIN_BOOTSTRAP_ENABLED: "false"
+    DATABASE_ENGINE: postgresql
+    DATABASE_HOST: postgres
+    DATABASE_PORT: "5432"
+    DATABASE_USER: postgres
+    DATABASE_PASSWORD: postgres
+    DATABASE_NAME: postgres
+    BROKER_TYPE: rabbitmq
+    RABBITMQ_URL: amqp://guest:guest@rabbitmq:5672/
+    VECTOR_STORE_TYPE: inmemory
+    ALLOWED_HOSTS: '["*"]'
+    ALLOW_ORIGINS: '["*"]'
+  restart: unless-stopped
 
 services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # BROKER_TYPE=inmemory runs tasks inline in the producer process and
+  # InMemoryBroker.listen() raises, so a standalone worker needs a real broker.
+  rabbitmq:
+    image: rabbitmq:3-management-alpine
+    environment:
+      RABBITMQ_DEFAULT_USER: guest
+      RABBITMQ_DEFAULT_PASS: guest
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "check_running"]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+      start_period: 30s
+
+  # Schema owner. Runs to completion before the app processes start, so the
+  # three of them never race to create the same tables.
+  migrate:
+    <<: *app
+    command: ["alembic", "upgrade", "head"]
+    restart: "no"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  # The admin dashboard is mounted onto this process when the `admin` extra is
+  # installed; build with --build-arg EXTRAS="... --extra admin" to include it.
+  # Without it the server boots normally and logs admin_mount_skipped.
   server:
-    build:
-      context: .
-      dockerfile: _docker/docker.Dockerfile
-    container_name: server
-    image: server:v0.0.1
-    env_file: _env/prod.env
+    <<: *app
+    # 8080, not 8000: port 8000 belongs to dynamodb-local in this repo
+    # (docker-compose.local.yml, DYNAMODB_ENDPOINT_URL in _env/*.example, and a
+    # hardcoded probe in the dynamodb integration tests). Publishing the server
+    # there makes those tests find FastAPI instead of DynamoDB, so they stop
+    # skipping and fail with a 404 from DescribeTable. 8001 is taken too — that
+    # is the local/quickstart runner's port.
     ports:
-      - "8000:8000"
+      - "8080:8000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+
+  worker:
+    <<: *app
+    command:
+      ["taskiq", "worker", "src._apps.worker.app:app", "src._apps.worker.app"]
+    healthcheck:
+      disable: true
+    depends_on:
+      postgres:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+
+  # Separate process from the worker: it only enqueues on a cron label, and the
+  # worker consumes. Two schedulers would double-enqueue.
+  scheduler:
+    <<: *app
+    command:
+      [
+        "taskiq",
+        "scheduler",
+        "src._apps.worker.scheduler:scheduler",
+        "src._apps.worker.scheduler",
+      ]
+    healthcheck:
+      disable: true
+    depends_on:
+      postgres:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+
+volumes:
+  postgres_data:

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@ Quick index for the `docs/` folder.
 
 | Page | What it covers |
 |---|---|
+| [operations/containers.md](operations/containers.md) | Docker image and the `docker compose up` reference stack — build args, ports, migrations, what to change before production |
 | [operations/rdb-migrations.md](operations/rdb-migrations.md) | Alembic rollout, rollback, and the zero-downtime expand-contract playbook |
 | [operations/error-notifications.md](operations/error-notifications.md) | Slack / Discord error alerts — setup, severity channel routing, coverage limits, cooldown and payload caveats |
 | [operations/observability-otel.md](operations/observability-otel.md) | OpenTelemetry — Jaeger / Tempo / Phoenix setup |

--- a/docs/operations/containers.md
+++ b/docs/operations/containers.md
@@ -58,9 +58,25 @@ The old image did `COPY _env/${ENV}.env /app/.env` with `ARG ENV=prod`. Only
 not build; adding the file to make it build wrote credentials into a layer that
 `docker history` prints. Configuration now comes from the process environment.
 
-`docker-compose.yml` reads `_env/prod.env` as an **optional** overlay
-(`required: false`), so the file's absence is not an error and its presence
-overrides the inline defaults.
+Compose supplies it through two `env_file` entries:
+
+```yaml
+env_file:
+  - _docker/compose.defaults.env      # committed reference defaults
+  - path: _env/prod.env               # your overlay
+    required: false
+```
+
+Entries later in the list win, and a missing optional file is a clean no-op —
+so the absence of `_env/prod.env` is not an error and its presence really does
+override the defaults.
+
+The defaults deliberately live in a committed env file rather than a compose
+`environment:` block. `environment:` takes precedence over **every**
+`env_file:` entry, so an inline block would silently pin `ENV=local`, keep
+stg/prod boot validation switched off, and make the wildcard hosts and
+placeholder credentials impossible to replace. Confirm either way with
+`docker compose config`.
 
 ### Build arguments
 
@@ -92,6 +108,26 @@ Revision identifiers must stay **32 characters or shorter**.
 fails on PostgreSQL and MySQL while passing silently on SQLite. Three shipped
 revisions were over the limit and were renamed in #332;
 `tests/unit/tools/test_migration_revision_ids.py` now enforces it.
+
+### Upgrading a database created before #332
+
+Because SQLite does not enforce VARCHAR length, a v0.9.0 install that ran
+migrations on SQLite can be holding one of the old long ids — as can any
+database whose operator widened the column by hand. PostgreSQL and MySQL cannot:
+they rejected those values, which is the bug #332 fixed. An affected database
+meets this on the next upgrade:
+
+```
+Can't locate revision identified by '0009_admin_identity_realm_separation'
+```
+
+Run the rewrite once before `alembic upgrade`. It only ever replaces the three
+known ids, is a no-op on a current or fresh database, and is idempotent:
+
+```bash
+uv run python tools/migrate_legacy_revision_ids.py --env local --dry-run
+uv run python tools/migrate_legacy_revision_ids.py --env local
+```
 
 ## Before a real deployment
 

--- a/docs/operations/containers.md
+++ b/docs/operations/containers.md
@@ -1,0 +1,113 @@
+# Containers
+
+How the image is built, what `docker compose up` gives you, and what to change
+before this reaches a real environment.
+
+Until #332 none of this was documented and neither entry point worked: the
+image could not build as shipped, and `docker compose config` exited 1 on a
+clean clone.
+
+## Quick start
+
+```bash
+docker compose up -d --build
+curl http://127.0.0.1:8080/health
+docker compose logs -f server worker scheduler
+docker compose down -v
+```
+
+No files to copy first, no credentials to supply. The stack runs at `ENV=local`
+on the inline defaults in `docker-compose.yml`.
+
+## What the stack contains
+
+| Service | Role |
+|---|---|
+| `postgres` | PostgreSQL 16. The image has no SQLite driver — `aiosqlite` is a dev dependency, so SQLite is a test/quickstart engine only. |
+| `rabbitmq` | Broker. `BROKER_TYPE=inmemory` runs tasks inline in the producer and `InMemoryBroker.listen()` raises, so a standalone worker needs a real one. |
+| `migrate` | Runs `alembic upgrade head` to completion, then exits. Every app service waits on `service_completed_successfully`, so the three of them never race to create the same tables. |
+| `server` | uvicorn on container port 8000, published on **host 8080**. |
+| `worker` | `taskiq worker` — consumes what the app and the scheduler enqueue. |
+| `scheduler` | `taskiq scheduler` — enqueues on cron labels only. Run exactly one; two would double-enqueue. |
+
+### Why host port 8080
+
+Port 8000 belongs to `dynamodb-local` in this repo — `docker-compose.local.yml`
+publishes it there, `_env/*.example` points `DYNAMODB_ENDPOINT_URL` at it, and
+the DynamoDB integration tests probe `http://localhost:8000` to decide whether
+to skip. Publishing the server there makes those tests find FastAPI instead of
+DynamoDB, so they stop skipping and fail with a 404 from `DescribeTable`. 8001
+is the `run_*_local.py` port. Postgres and RabbitMQ are deliberately not
+published at all, so this file and `docker-compose.local.yml` can coexist.
+
+## The image
+
+`_docker/docker.Dockerfile` is a two-stage build shared by all three app
+processes; they differ only in the command compose gives them.
+
+- **builder** — installs `build-essential` and runs `uv sync --no-dev --frozen`
+  into `/app/.venv`. The toolchain stays here.
+- **runtime** — copies the venv, `src/`, `migrations/` and `alembic.ini`, drops
+  to a non-root `app` user (uid 1001), and declares a `HEALTHCHECK` that calls
+  `/health` with the interpreter (the slim base ships no `curl`).
+
+### Configuration is never baked in
+
+The old image did `COPY _env/${ENV}.env /app/.env` with `ARG ENV=prod`. Only
+`*.env.example` files are committed and `_env/*.env` is gitignored, so it did
+not build; adding the file to make it build wrote credentials into a layer that
+`docker history` prints. Configuration now comes from the process environment.
+
+`docker-compose.yml` reads `_env/prod.env` as an **optional** overlay
+(`required: false`), so the file's absence is not an error and its presence
+overrides the inline defaults.
+
+### Build arguments
+
+| Arg | Default | Why |
+|---|---|---|
+| `EXTRAS` | `--extra sqs --extra rabbitmq` | `Settings` requires an explicit `BROKER_TYPE` in stg/prod and both supported values need a package a core-only sync omits (`sqs` → `taskiq-aws`, `rabbitmq` → `taskiq-aio-pika`). |
+
+To include the NiceGUI admin dashboard, which mounts onto the server process:
+
+```bash
+docker compose build --build-arg EXTRAS="--extra sqs --extra rabbitmq --extra admin"
+```
+
+Without it the server boots normally and logs `admin_mount_skipped`.
+
+## Migrations
+
+`alembic upgrade head` runs in its own service. Two things had to change before
+it could work in a container:
+
+- `migrations/` and `alembic.ini` were never copied into the image.
+- `migrations/env.py` hard-failed when `_env/{ENV}.env` was missing. It now
+  falls back to the process environment and only requires the file when
+  `DATABASE_ENGINE` is unset.
+
+Revision identifiers must stay **32 characters or shorter**.
+`alembic_version.version_num` is `String(32)`, hardcoded in
+`DefaultImpl.version_table_impl` with no configuration hook, so a longer id
+fails on PostgreSQL and MySQL while passing silently on SQLite. Three shipped
+revisions were over the limit and were renamed in #332;
+`tests/unit/tools/test_migration_revision_ids.py` now enforces it.
+
+## Before a real deployment
+
+The defaults in `docker-compose.yml` are a runnable reference, not a production
+posture. At minimum:
+
+- Supply `_env/prod.env` and set `ENV=stg` or `ENV=prod`. Boot validation then
+  rejects every placeholder credential in this file — that is the intended
+  behaviour, not an obstacle to work around. See
+  [`../reference.md`](../reference.md) for the full settings surface.
+- Point `DATABASE_*` at managed infrastructure and drop the `postgres` and
+  `rabbitmq` services, or replace RabbitMQ with `BROKER_TYPE=sqs`.
+- Replace `ALLOWED_HOSTS` / `ALLOW_ORIGINS` — `["*"]` is a local convenience.
+- Set `ADMIN_STORAGE_SECRET` and the `JWT_*` / `ADMIN_JWT_*` secrets. The admin
+  realm's secret must differ from the customer realm's; a validator rejects
+  realm collapse.
+- Run `migrate` as a pre-deploy job rather than a compose dependency, and read
+  [`rdb-migrations.md`](rdb-migrations.md) for the expand-contract playbook
+  before a rollout that cannot take downtime.

--- a/docs/operations/rdb-migrations.md
+++ b/docs/operations/rdb-migrations.md
@@ -29,6 +29,34 @@ Do not run `alembic downgrade base` in an environment that was stamped at the
 baseline to preserve pre-existing tables. The baseline revision is a schema
 baseline, not a data migration.
 
+## Revision Id Length
+
+Revision ids must be **32 characters or shorter**. Alembic stores the applied
+revision in `alembic_version.version_num`, hardcoded as `String(32)` in
+`DefaultImpl.version_table_impl` with no configuration hook. A longer id fails
+on PostgreSQL and MySQL:
+
+```
+DataError: (psycopg.errors.StringDataRightTruncation)
+value too long for type character varying(32)
+```
+
+while SQLite accepts it silently, so the default test engine will not catch it.
+`tests/unit/tools/test_migration_revision_ids.py` enforces the limit.
+
+Three ids shipped over it before #332 and were shortened. A database created
+before that change — in practice a SQLite one, since PostgreSQL and MySQL
+rejected the long values — will fail its next upgrade with
+`Can't locate revision identified by ...`. Rewrite it once first:
+
+```bash
+uv run python tools/migrate_legacy_revision_ids.py --env local --dry-run
+uv run python tools/migrate_legacy_revision_ids.py --env local
+```
+
+The script only replaces the three known ids, is idempotent, and is a no-op on
+a current or fresh database.
+
 ## Zero-Downtime Migrations
 
 > Background: [ADR 056](../history/056-zero-downtime-migration-safety.md).

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -23,19 +23,34 @@ if env not in valid_envs:
         "Usage: ENV=local alembic upgrade head"
     )
 
+# A dotenv file is the local workflow, not a hard requirement. Containers and
+# CI supply DATABASE_* through the process environment and never ship
+# `_env/*.env` — it is gitignored, and baking one into an image layer is what
+# the Dockerfile was changed to stop doing. Hard-failing here made
+# `alembic upgrade head` impossible inside the image even after `migrations/`
+# was copied in.
 env_file = f"_env/{env}.env"
-if not os.path.exists(env_file):
-    raise RuntimeError(f"Environment file not found: {env_file}")
+env_file_present = os.path.exists(env_file)
+if not env_file_present and not os.getenv("DATABASE_ENGINE"):
+    raise RuntimeError(
+        f"Environment file not found: {env_file}, and DATABASE_ENGINE is not "
+        "set in the process environment. Provide one or the other."
+    )
 
 print("=" * 100)
-print(f"Alembic ENV: {env}")
+print(f"Alembic ENV: {env} (source: {'file' if env_file_present else 'environment'})")
 print("=" * 100)
 
 create_folder_if_not_exists("migrations/versions")
 
 load_models()
 
-load_dotenv(dotenv_path=env_file, override=True)
+if env_file_present:
+    # override=True keeps the local workflow's precedence: the dotenv file wins
+    # over whatever is already exported in the shell. When no file exists the
+    # process environment is the only source, so skip the call rather than rely
+    # on load_dotenv silently returning False.
+    load_dotenv(dotenv_path=env_file, override=True)
 
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
@@ -76,7 +91,7 @@ def run_migrations_online() -> None:
             connection=connection,
             target_metadata=target_metadata,
             include_schemas=False,
-        )
+            )
         with context.begin_transaction():
             context.run_migrations()
 

--- a/migrations/versions/0006_user_admin_permissions.py
+++ b/migrations/versions/0006_user_admin_permissions.py
@@ -1,6 +1,6 @@
 """user: add password_temporary, is_bootstrap_admin, permissions for admin permission model
 
-Revision ID: 0006_add_user_admin_permission_fields
+Revision ID: 0006_user_admin_permissions
 Revises: 0005_add_user_role
 Create Date: 2026-05-27
 
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "0006_add_user_admin_permission_fields"
+revision: str = "0006_user_admin_permissions"
 down_revision: str | None = "0005_add_user_role"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None

--- a/migrations/versions/0007_add_admin_audit_log.py
+++ b/migrations/versions/0007_add_admin_audit_log.py
@@ -1,7 +1,7 @@
 """admin: add admin_audit_log table for #196 Phase 1
 
 Revision ID: 0007_add_admin_audit_log
-Revises: 0006_add_user_admin_permission_fields
+Revises: 0006_user_admin_permissions
 Create Date: 2026-05-28
 
 """
@@ -13,7 +13,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "0007_add_admin_audit_log"
-down_revision: str | None = "0006_add_user_admin_permission_fields"
+down_revision: str | None = "0006_user_admin_permissions"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/migrations/versions/0008_ai_usage_guardrail_flag.py
+++ b/migrations/versions/0008_ai_usage_guardrail_flag.py
@@ -1,6 +1,6 @@
 """ai_usage: add guardrail_triggered column for #197 Phase 5
 
-Revision ID: 0008_ai_usage_add_guardrail_triggered
+Revision ID: 0008_ai_usage_guardrail_flag
 Revises: 0007_add_admin_audit_log
 Create Date: 2026-06-01
 
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "0008_ai_usage_add_guardrail_triggered"
+revision: str = "0008_ai_usage_guardrail_flag"
 down_revision: str | None = "0007_add_admin_audit_log"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None

--- a/migrations/versions/0009_admin_identity_realm.py
+++ b/migrations/versions/0009_admin_identity_realm.py
@@ -4,8 +4,8 @@ Creates the admin_identity + admin_refresh_token tables, moves existing
 role='admin' rows out of the user table, then drops the admin-only columns
 (role, permissions, password_temporary, is_bootstrap_admin) from user.
 
-Revision ID: 0009_admin_identity_realm_separation
-Revises: 0008_ai_usage_add_guardrail_triggered
+Revision ID: 0009_admin_identity_realm
+Revises: 0008_ai_usage_guardrail_flag
 Create Date: 2026-06-01
 
 """
@@ -16,8 +16,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "0009_admin_identity_realm_separation"
-down_revision: str | None = "0008_ai_usage_add_guardrail_triggered"
+revision: str = "0009_admin_identity_realm"
+down_revision: str | None = "0008_ai_usage_guardrail_flag"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ dependencies = [
     "email-validator>=2.0.0",
     "fastapi>=0.115.12",
     "greenlet>=3.2.0",
-    "gunicorn>=23.0.0",
     "httpx>=0.28.1",
     "psycopg[binary]>=3.2.12",
     "pydantic-settings>=2.10.1",
@@ -73,7 +72,7 @@ aws = [
 sqs = ["taskiq-aws>=0.4.0"]
 rabbitmq = ["taskiq-aio-pika>=0.4.0"]
 openai = ["openai>=1.0.0", "tiktoken>=0.7.0"]
-pydantic-ai = ["pydantic-ai-slim>=1.39.0", "tiktoken>=0.7.0"]
+pydantic-ai = ["pydantic-ai-slim[openai]>=1.39.0", "tiktoken>=0.7.0"]
 pydantic-ai-anthropic = ["pydantic-ai-slim[anthropic]>=1.39.0"]
 pydantic-ai-google = ["pydantic-ai-slim[google]>=1.39.0"]
 pydantic-ai-duckduckgo = ["pydantic-ai-slim[duckduckgo]>=1.39.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,11 @@ dependencies = [
 
 [project.optional-dependencies]
 admin = ["nicegui>=3.5.0"]
+# Kept installable after 0.9.0 removed it from core: nothing in the repo
+# invokes gunicorn (the only mention is a commented-out block in
+# run_server_local.py), but adopters who relied on the executable arriving
+# with a plain install need a path that does not break.
+server-gunicorn = ["gunicorn>=23.0.0"]
 aws = [
     "aioboto3>=15.4.0",
     "boto3>=1.39.12",

--- a/tests/unit/tools/test_migrate_legacy_revision_ids.py
+++ b/tests/unit/tools/test_migrate_legacy_revision_ids.py
@@ -1,0 +1,129 @@
+"""Tests for the pre-#332 revision-id rewrite.
+
+#332 shortened three Alembic revision ids past the hardcoded `String(32)` of
+`alembic_version.version_num`. The PR first claimed no database could be holding
+the old values; a cross-review disproved it. PostgreSQL and MySQL do reject them
+— that was the bug — but SQLite does not enforce VARCHAR length, so a v0.9.0
+install that ran migrations on SQLite has a long id stored and would meet
+`Can't locate revision identified by ...` on upgrade. Same for anyone who
+widened the column by hand.
+
+These tests use real SQLite files rather than mocks, because the whole point is
+what a *stored* value does.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from tools.migrate_legacy_revision_ids import _RENAMES, rewrite_legacy_ids
+
+_LEGACY_HEAD = "0009_admin_identity_realm_separation"
+_CURRENT_HEAD = "0009_admin_identity_realm"
+
+
+def _dsn(path: Path) -> str:
+    return f"sqlite:///{path}"
+
+
+def _make_db(path: Path, stored: str | None) -> None:
+    connection = sqlite3.connect(path)
+    try:
+        if stored is not None:
+            connection.execute(
+                "CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)"
+            )
+            connection.execute(
+                "INSERT INTO alembic_version (version_num) VALUES (?)", (stored,)
+            )
+            connection.commit()
+    finally:
+        connection.close()
+
+
+def _stored(path: Path) -> list[str]:
+    connection = sqlite3.connect(path)
+    try:
+        return [
+            r[0] for r in connection.execute("SELECT version_num FROM alembic_version")
+        ]
+    finally:
+        connection.close()
+
+
+def test_rewrites_a_legacy_head(tmp_path: Path) -> None:
+    db = tmp_path / "legacy.db"
+    _make_db(db, _LEGACY_HEAD)
+
+    found = rewrite_legacy_ids(_dsn(db))
+
+    assert found == [(_LEGACY_HEAD, _CURRENT_HEAD)]
+    assert _stored(db) == [_CURRENT_HEAD]
+
+
+@pytest.mark.parametrize(("legacy", "current"), sorted(_RENAMES.items()))
+def test_rewrites_every_renamed_id(tmp_path: Path, legacy: str, current: str) -> None:
+    db = tmp_path / f"{current}.db"
+    _make_db(db, legacy)
+
+    rewrite_legacy_ids(_dsn(db))
+
+    assert _stored(db) == [current]
+
+
+def test_is_a_noop_on_a_current_head(tmp_path: Path) -> None:
+    db = tmp_path / "current.db"
+    _make_db(db, _CURRENT_HEAD)
+
+    assert rewrite_legacy_ids(_dsn(db)) == []
+    assert _stored(db) == [_CURRENT_HEAD]
+
+
+def test_is_a_noop_when_the_table_does_not_exist(tmp_path: Path) -> None:
+    # A fresh database: Alembic creates the table itself, so the script must not
+    # create it, and must not raise.
+    db = tmp_path / "fresh.db"
+    _make_db(db, None)
+
+    assert rewrite_legacy_ids(_dsn(db)) == []
+
+
+def test_is_idempotent(tmp_path: Path) -> None:
+    db = tmp_path / "twice.db"
+    _make_db(db, _LEGACY_HEAD)
+
+    rewrite_legacy_ids(_dsn(db))
+    second = rewrite_legacy_ids(_dsn(db))
+
+    assert second == []
+    assert _stored(db) == [_CURRENT_HEAD]
+
+
+def test_dry_run_reports_without_writing(tmp_path: Path) -> None:
+    db = tmp_path / "dry.db"
+    _make_db(db, _LEGACY_HEAD)
+
+    found = rewrite_legacy_ids(_dsn(db), dry_run=True)
+
+    assert found == [(_LEGACY_HEAD, _CURRENT_HEAD)]
+    assert _stored(db) == [_LEGACY_HEAD]
+
+
+def test_leaves_an_unknown_value_alone(tmp_path: Path) -> None:
+    # Guards against a future edit that rewrites anything not in _RENAMES.
+    db = tmp_path / "unknown.db"
+    _make_db(db, "9999_someone_elses_revision")
+
+    assert rewrite_legacy_ids(_dsn(db)) == []
+    assert _stored(db) == ["9999_someone_elses_revision"]
+
+
+def test_rename_targets_are_the_ids_that_ship() -> None:
+    versions = Path(__file__).resolve().parents[3] / "migrations" / "versions"
+    shipped = {p.stem for p in versions.glob("*.py") if p.name != "__init__.py"}
+
+    assert set(_RENAMES.values()) <= shipped
+    assert not set(_RENAMES) & shipped

--- a/tests/unit/tools/test_migration_revision_ids.py
+++ b/tests/unit/tools/test_migration_revision_ids.py
@@ -1,0 +1,87 @@
+"""Contract tests for Alembic revision identifiers.
+
+Alembic stores the applied revision in `alembic_version.version_num`, and
+`DefaultImpl.version_table_impl` hardcodes that column as `String(32)` — there
+is no configuration hook for the width (checked against alembic 1.17.2;
+`version_table_column_length` does **not** exist, `configure()` swallows it as
+an unknown kwarg and the length stays 32).
+
+Three shipped revisions were longer than that: `0006_add_user_admin_permission_fields`
+(37), `0008_ai_usage_add_guardrail_triggered` (37) and
+`0009_admin_identity_realm_separation` (36). On PostgreSQL the upgrade died the
+moment it tried to stamp 0006:
+
+    DataError: (psycopg.errors.StringDataRightTruncation)
+    value too long for type character varying(32)
+    [SQL: UPDATE alembic_version SET version_num='0006_add_user_admin_permission_fields'
+          WHERE alembic_version.version_num = '0005_add_user_role']
+
+so `alembic upgrade head` had never completed against the production engine.
+SQLite — the default test engine — does not enforce VARCHAR length, and CI has
+never run PostgreSQL (#333), so nothing caught it. Found by bringing the
+compose stack up while fixing #332.
+
+The sequence-prefix check is deliberately weaker than "filename equals revision
+id": three pre-existing files already break the stronger form
+(`0001_baseline_current_rdb_schema.py` declares `0001_baseline_current_rdb`,
+and 0002/0003 differ likewise), so that convention was never the repo's. What
+*is* held everywhere, and is what a reader relies on to find a revision by
+name, is the shared `NNNN_` ordering prefix.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+# alembic.ddl.impl.DefaultImpl.version_table_impl:
+#   Column("version_num", String(32), nullable=False)
+_VERSION_NUM_MAX_LENGTH = 32
+
+_VERSIONS_DIR = Path(__file__).resolve().parents[3] / "migrations" / "versions"
+
+_REVISION_RE = re.compile(
+    r"^revision(?::\s*str)?\s*=\s*[\"']([^\"']+)[\"']",
+    re.MULTILINE,
+)
+
+
+def _revision_files() -> list[Path]:
+    return sorted(p for p in _VERSIONS_DIR.glob("*.py") if p.name != "__init__.py")
+
+
+def _revision_id(path: Path) -> str:
+    match = _REVISION_RE.search(path.read_text())
+    assert match is not None, f"{path.name} declares no `revision = ...`"
+    return match.group(1)
+
+
+def test_versions_directory_is_not_empty() -> None:
+    # Guards the parametrised tests below against silently passing on an empty
+    # collection if the directory is ever moved.
+    assert _revision_files()
+
+
+@pytest.mark.parametrize("path", _revision_files(), ids=lambda p: p.name)
+def test_revision_id_fits_alembic_version_column(path: Path) -> None:
+    revision = _revision_id(path)
+
+    assert len(revision) <= _VERSION_NUM_MAX_LENGTH, (
+        f"revision id {revision!r} is {len(revision)} characters; "
+        f"alembic_version.version_num is VARCHAR({_VERSION_NUM_MAX_LENGTH}) and "
+        "the width is not configurable, so this fails on PostgreSQL and MySQL "
+        "while passing silently on SQLite."
+    )
+
+
+@pytest.mark.parametrize("path", _revision_files(), ids=lambda p: p.name)
+def test_revision_id_shares_the_filename_sequence_prefix(path: Path) -> None:
+    revision = _revision_id(path)
+    sequence = path.stem.split("_", 1)[0]
+
+    assert revision.startswith(f"{sequence}_"), (
+        f"{path.name} declares revision {revision!r}, which does not carry the "
+        f"file's {sequence!r} ordering prefix."
+    )

--- a/tools/migrate_legacy_revision_ids.py
+++ b/tools/migrate_legacy_revision_ids.py
@@ -1,0 +1,125 @@
+"""Rewrite pre-#332 Alembic revision ids stored in ``alembic_version``.
+
+Three revision ids shipped longer than Alembic's ``String(32)``
+``alembic_version.version_num`` column and were shortened in #332. PostgreSQL
+and MySQL reject the long values outright — ``alembic upgrade head`` had never
+completed there — but **SQLite does not enforce VARCHAR length**, so a database
+that ran migrations under SQLite (or one whose operator widened the column by
+hand) can be holding an id this repo no longer defines. Running the new code
+against such a database fails with::
+
+    Can't locate revision identified by '0009_admin_identity_realm_separation'
+
+This script closes that gap. It rewrites any legacy value in place and is a
+no-op otherwise, so it is safe to run unconditionally before ``alembic upgrade``
+— including on a fresh database, where the table does not exist yet.
+
+It touches exactly one column of one table. It never runs a migration, never
+creates the table, and never writes a value that is not in ``_RENAMES``.
+
+Usage::
+
+    uv run python tools/migrate_legacy_revision_ids.py --env local
+    uv run python tools/migrate_legacy_revision_ids.py --env local --dry-run
+
+With no ``_env/{env}.env`` file the DATABASE_* process environment is used,
+matching the fallback ``migrations/env.py`` gained in the same change.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from urllib.parse import quote_plus
+
+from dotenv import load_dotenv
+from sqlalchemy import create_engine, inspect, text
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+# Pre-#332 id -> current id. Keep in step with migrations/versions/.
+_RENAMES: dict[str, str] = {
+    "0006_add_user_admin_permission_fields": "0006_user_admin_permissions",
+    "0008_ai_usage_add_guardrail_triggered": "0008_ai_usage_guardrail_flag",
+    "0009_admin_identity_realm_separation": "0009_admin_identity_realm",
+}
+
+_VERSION_TABLE = "alembic_version"
+
+# Written out rather than interpolated: the pre-commit security hook rejects
+# f-string SQL outright, and a constant table name is not worth an exception.
+_SELECT_VERSIONS = text("SELECT version_num FROM alembic_version")
+_UPDATE_VERSION = text(
+    "UPDATE alembic_version SET version_num = :new WHERE version_num = :old"
+)
+
+
+def build_dsn() -> str:
+    from src._core.infrastructure.persistence.rdb.database import create_sync_dsn
+
+    return create_sync_dsn(
+        engine=os.getenv("DATABASE_ENGINE") or "postgresql",
+        database_user=quote_plus(os.getenv("DATABASE_USER") or ""),
+        database_password=quote_plus(os.getenv("DATABASE_PASSWORD") or ""),
+        database_host=os.getenv("DATABASE_HOST") or "",
+        database_port=int(os.getenv("DATABASE_PORT") or "5432"),
+        database_name=os.getenv("DATABASE_NAME") or "",
+    )
+
+
+def rewrite_legacy_ids(dsn: str, *, dry_run: bool = False) -> list[tuple[str, str]]:
+    """Return the (old, new) pairs found. Applies them unless ``dry_run``."""
+    engine = create_engine(dsn)
+    try:
+        if _VERSION_TABLE not in inspect(engine).get_table_names():
+            # Fresh database: Alembic will create the table itself.
+            return []
+
+        with engine.begin() as connection:
+            stored = [row[0] for row in connection.execute(_SELECT_VERSIONS)]
+            found = [(old, _RENAMES[old]) for old in stored if old in _RENAMES]
+            if dry_run:
+                return found
+            for old, new in found:
+                connection.execute(_UPDATE_VERSION, {"new": new, "old": old})
+        return found
+    finally:
+        engine.dispose()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Rewrite pre-#332 Alembic revision ids stored in alembic_version."
+    )
+    parser.add_argument("--env", default=os.getenv("ENV") or "local")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    env_file = _REPO_ROOT / "_env" / f"{args.env}.env"
+    if env_file.exists():
+        load_dotenv(dotenv_path=env_file, override=True)
+    elif not os.getenv("DATABASE_ENGINE"):
+        print(
+            f"No {env_file} and DATABASE_ENGINE is unset — nothing to connect to.",
+            file=sys.stderr,
+        )
+        return 2
+
+    found = rewrite_legacy_ids(build_dsn(), dry_run=args.dry_run)
+    if not found:
+        print("No pre-#332 revision ids stored. Nothing to do.")
+        return 0
+
+    verb = "Would rewrite" if args.dry_run else "Rewrote"
+    for old, new in found:
+        print(f"{verb} {old} -> {new}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -1006,7 +1006,6 @@ dependencies = [
     { name = "email-validator" },
     { name = "fastapi" },
     { name = "greenlet" },
-    { name = "gunicorn" },
     { name = "httpx" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic-settings" },
@@ -1040,7 +1039,7 @@ otel = [
     { name = "opentelemetry-sdk" },
 ]
 pydantic-ai = [
-    { name = "pydantic-ai-slim" },
+    { name = "pydantic-ai-slim", extra = ["openai"] },
     { name = "tiktoken" },
 ]
 pydantic-ai-anthropic = [
@@ -1087,7 +1086,6 @@ requires-dist = [
     { name = "email-validator", specifier = ">=2.0.0" },
     { name = "fastapi", specifier = ">=0.115.12" },
     { name = "greenlet", specifier = ">=3.2.0" },
-    { name = "gunicorn", specifier = ">=23.0.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "nicegui", marker = "extra == 'admin'", specifier = ">=3.5.0" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.0.0" },
@@ -1095,10 +1093,10 @@ requires-dist = [
     { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "extra == 'otel'", specifier = ">=1.40.0" },
     { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.40.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.12" },
-    { name = "pydantic-ai-slim", marker = "extra == 'pydantic-ai'", specifier = ">=1.39.0" },
     { name = "pydantic-ai-slim", extras = ["anthropic"], marker = "extra == 'pydantic-ai-anthropic'", specifier = ">=1.39.0" },
     { name = "pydantic-ai-slim", extras = ["duckduckgo"], marker = "extra == 'pydantic-ai-duckduckgo'", specifier = ">=1.39.0" },
     { name = "pydantic-ai-slim", extras = ["google"], marker = "extra == 'pydantic-ai-google'", specifier = ">=1.39.0" },
+    { name = "pydantic-ai-slim", extras = ["openai"], marker = "extra == 'pydantic-ai'", specifier = ">=1.39.0" },
     { name = "pydantic-settings", specifier = ">=2.10.1" },
     { name = "pyjwt", specifier = ">=2.10.0" },
     { name = "pymysql", specifier = ">=1.1.1" },
@@ -1525,18 +1523,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f5/68/67f4947ed55d2e69f2cc199ab9fd85e0a0034d813bbeef84df6d2ba4d4b7/grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:31b9ac4ad1aa28ffee5503821fafd09e4da0a261ce1c1281c6c8da0423c83b6e", size = 7828477, upload-time = "2026-03-30T08:48:32.054Z" },
     { url = "https://files.pythonhosted.org/packages/44/b6/8d4096691b2e385e8271911a0de4f35f0a6c7d05aff7098e296c3de86939/grpcio-1.80.0-cp314-cp314-win32.whl", hash = "sha256:367ce30ba67d05e0592470428f0ec1c31714cab9ef19b8f2e37be1f4c7d32fae", size = 4218563, upload-time = "2026-03-30T08:48:34.538Z" },
     { url = "https://files.pythonhosted.org/packages/e5/8c/bbe6baf2557262834f2070cf668515fa308b2d38a4bbf771f8f7872a7036/grpcio-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:3b01e1f5464c583d2f567b2e46ff0d516ef979978f72091fd81f5ab7fa6e2e7f", size = 5019457, upload-time = "2026-03-30T08:48:37.308Z" },
-]
-
-[[package]]
-name = "gunicorn"
-version = "23.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/34/72/9614c465dc206155d93eff0ca20d42e1e35afc533971379482de953521a4/gunicorn-23.0.0.tar.gz", hash = "sha256:f014447a0101dc57e294f6c18ca6b40227a4c90e9bdb586042628030cba004ec", size = 375031, upload-time = "2024-08-10T20:25:27.378Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/7d/6dac2a6e1eba33ee43f318edbed4ff29151a49b5d37f080aad1e6469bca4/gunicorn-23.0.0-py3-none-any.whl", hash = "sha256:ec400d38950de4dfd418cff8328b2c8faed0edb0d517d3394e457c317908ca4d", size = 85029, upload-time = "2024-08-10T20:25:24.996Z" },
 ]
 
 [[package]]
@@ -2822,6 +2808,10 @@ duckduckgo = [
 ]
 google = [
     { name = "google-genai" },
+]
+openai = [
+    { name = "openai" },
+    { name = "tiktoken" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1054,6 +1054,9 @@ pydantic-ai-google = [
 rabbitmq = [
     { name = "taskiq-aio-pika" },
 ]
+server-gunicorn = [
+    { name = "gunicorn" },
+]
 sqs = [
     { name = "taskiq-aws" },
 ]
@@ -1086,6 +1089,7 @@ requires-dist = [
     { name = "email-validator", specifier = ">=2.0.0" },
     { name = "fastapi", specifier = ">=0.115.12" },
     { name = "greenlet", specifier = ">=3.2.0" },
+    { name = "gunicorn", marker = "extra == 'server-gunicorn'", specifier = ">=23.0.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "nicegui", marker = "extra == 'admin'", specifier = ">=3.5.0" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.0.0" },
@@ -1113,7 +1117,7 @@ requires-dist = [
     { name = "types-aiobotocore-s3", marker = "extra == 'aws'", specifier = ">=2.25.0" },
     { name = "uvicorn", specifier = ">=0.34.1" },
 ]
-provides-extras = ["admin", "aws", "sqs", "rabbitmq", "openai", "pydantic-ai", "pydantic-ai-anthropic", "pydantic-ai-google", "pydantic-ai-duckduckgo", "otel"]
+provides-extras = ["admin", "server-gunicorn", "aws", "sqs", "rabbitmq", "openai", "pydantic-ai", "pydantic-ai-anthropic", "pydantic-ai-google", "pydantic-ai-duckduckgo", "otel"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1523,6 +1527,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f5/68/67f4947ed55d2e69f2cc199ab9fd85e0a0034d813bbeef84df6d2ba4d4b7/grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:31b9ac4ad1aa28ffee5503821fafd09e4da0a261ce1c1281c6c8da0423c83b6e", size = 7828477, upload-time = "2026-03-30T08:48:32.054Z" },
     { url = "https://files.pythonhosted.org/packages/44/b6/8d4096691b2e385e8271911a0de4f35f0a6c7d05aff7098e296c3de86939/grpcio-1.80.0-cp314-cp314-win32.whl", hash = "sha256:367ce30ba67d05e0592470428f0ec1c31714cab9ef19b8f2e37be1f4c7d32fae", size = 4218563, upload-time = "2026-03-30T08:48:34.538Z" },
     { url = "https://files.pythonhosted.org/packages/e5/8c/bbe6baf2557262834f2070cf668515fa308b2d38a4bbf771f8f7872a7036/grpcio-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:3b01e1f5464c583d2f567b2e46ff0d516ef979978f72091fd81f5ab7fa6e2e7f", size = 5019457, upload-time = "2026-03-30T08:48:37.308Z" },
+]
+
+[[package]]
+name = "gunicorn"
+version = "26.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/b7/a4a3f632f823e432ce6bc65f62961b7980c898c77f075a2f7118cb3846fe/gunicorn-26.0.0.tar.gz", hash = "sha256:ca9346f85e3a4aeeb64d491045c16b9a35647abd37ea15efe53080eb8b090baf", size = 727286, upload-time = "2026-05-05T06:38:25.529Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/40/9c2384fc2be4ad25dd4a49decd5ad9ea5a3639814c11bd40ab77cb9f0a14/gunicorn-26.0.0-py3-none-any.whl", hash = "sha256:40233d26a5f0d1872916188c276e21641155111c2853f0c2cd55260aec0d24fc", size = 212009, upload-time = "2026-05-05T06:38:23.007Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #332.

The issue said "`docker build` it. The recon could not, and reasoned from the
file." Doing that surfaced three defects the static read could not see, one of
which is worse than anything in the original list.

## Reproduced first

```
$ docker build -f _docker/docker.Dockerfile .
ERROR: failed to compute cache key: "/_env/prod.env": not found

$ docker compose config
env file .../_env/prod.env not found          # exit 1
```

## `_docker/docker.Dockerfile`

Two stages. `build-essential` and `uv sync` stay in the builder; the runtime
copies the venv, `src/`, `migrations/` and `alembic.ini`, drops to a non-root
uid 1001, and declares a `HEALTHCHECK` that calls `/health` through the
interpreter (the slim base has no `curl`).

`COPY _env/${ENV}.env` is gone. Configuration is read from the process
environment, so nothing is baked into a layer — `docker history` shows zero
`_env` references. `EXTRAS` defaults to `--extra sqs --extra rabbitmq`: a
core-only sync cannot resolve either `BROKER_TYPE` that stg/prod validation
*requires*, so the image could not run in the environment it targets.

`.dockerignore` did not exist. The build context was the whole ~1.0 GB tree.

## `docker-compose.yml`

Declares all the processes this project actually runs — `server`, `worker`,
`scheduler` — plus the `postgres` and `rabbitmq` they need (the image has no
SQLite driver; `aiosqlite` is a dev dependency, and `InMemoryBroker.listen()`
raises). A `migrate` service runs `alembic upgrade head` to completion and the
three app services gate on `service_completed_successfully`, so they cannot
race to create the same tables.

Configuration comes from two `env_file` entries — committed
`_docker/compose.defaults.env` first, optional `_env/prod.env` second — so a
clean clone works with no files to copy and the overlay genuinely wins.

The first version used an inline `environment:` block, which **cannot be
overridden**: Compose gives `environment:` precedence over every `env_file:`
entry, so `_env/prod.env` changed nothing — `ENV` stayed `local`, stg/prod boot
validation never ran, and the wildcard hosts and placeholder credentials were
unreplaceable. Cross-review caught it; confirmed directly with
`docker compose config`, and the docs had claimed the opposite. Now:

```
no overlay -> ENV local,  ALLOWED_HOSTS ["*"],                DATABASE_PASSWORD postgres
overlay    -> ENV stg,    ALLOWED_HOSTS ["api.example.com"],  DATABASE_PASSWORD real-secret
```

Obsolete `version: '3.8'` and the stale `image: server:v0.0.1` pin are gone.

**The server publishes on host 8080, not 8000.** Port 8000 belongs to
`dynamodb-local` here — `docker-compose.local.yml`, `DYNAMODB_ENDPOINT_URL` in
`_env/*.example`, and a hardcoded probe in the DynamoDB integration tests.
Taking it made those tests find FastAPI instead of DynamoDB, stop skipping, and
fail on `DescribeTable`. I hit exactly that mid-review. Postgres and RabbitMQ
are not published at all, so this file and `docker-compose.local.yml` coexist.

## Found by building: `alembic upgrade head` has never worked on PostgreSQL

```
DataError: (psycopg.errors.StringDataRightTruncation)
value too long for type character varying(32)
[SQL: UPDATE alembic_version SET version_num='0006_add_user_admin_permission_fields'
      WHERE alembic_version.version_num = '0005_add_user_role']
```

`alembic_version.version_num` is `String(32)`, hardcoded in
`DefaultImpl.version_table_impl` with **no configuration hook** — I checked
alembic 1.17.2 directly after first trying `version_table_column_length`, which
does not exist and which `configure()` silently swallows as an unknown kwarg.
Three ids were over: 0006 (37), 0008 (37), 0009 (36).

SQLite does not enforce VARCHAR length, which is why the default test engine
never saw it and CI has never run PostgreSQL (#333). Renamed:

```
0006_add_user_admin_permission_fields -> 0006_user_admin_permissions
0008_ai_usage_add_guardrail_triggered -> 0008_ai_usage_guardrail_flag
0009_admin_identity_realm_separation  -> 0009_admin_identity_realm
```

`tests/unit/tools/test_migration_revision_ids.py` pins the limit.

The first version of this PR claimed no environment could be holding the old
values. **That was wrong**, and cross-review caught it: the argument leaned on
VARCHAR(32) rejecting them, but SQLite does not enforce VARCHAR length — which
this PR's own documentation says. A v0.9.0 install that ran migrations on
SQLite, or any database whose operator widened the column, stops on upgrade
with `Can't locate revision identified by ...`. Reproduced and fixed:

```
$ alembic current
FAILED: Can't locate revision identified by '0009_admin_identity_realm_separation'
$ uv run python tools/migrate_legacy_revision_ids.py --env local
Rewrote 0009_admin_identity_realm_separation -> 0009_admin_identity_realm
$ alembic current
0009_admin_identity_realm (head)
```

`tools/migrate_legacy_revision_ids.py` rewrites only the three known ids, is
idempotent, no-ops on a current or fresh database, and never creates the version
table. Ten tests drive it against real SQLite files.

Separately, `migrations/env.py` hard-failed without `_env/{ENV}.env`, so copying
`migrations/` into the image was not enough. The file is now the local workflow
rather than a requirement — it still wins over the shell when present, and its
absence is only an error when `DATABASE_ENGINE` is unset too.

## `pyproject.toml`

`pydantic-ai` had no provider bracket while all three siblings do, so
`--extra pydantic-ai` installed no provider even though `model_factory.py` does
`from pydantic_ai.models.openai import OpenAIChatModel`. With the bracket, four
previously-skipping tests now run.

`gunicorn` was a required core dependency whose only other mention is a
commented-out line at `run_server_local.py:24`. It moves to a `server-gunicorn`
extra rather than being deleted — cross-review flagged outright removal as an
unannounced dependency-contract change for anyone relying on the executable.

## Verification

From a **fresh `git clone`** with no `_env/*.env` present:

- `docker compose config` — exit 0 (was exit 1)
- `docker build` — exit 0 (was a cache-key error)
- `docker compose up -d --build` — postgres healthy, rabbitmq healthy, migrate
  exited 0, **server healthy**, worker and scheduler up
- `curl :8080/health` → `{"status":"ok"}`; port 8000 left free
- `alembic_version` = `0009_admin_identity_realm`, 8 public tables
- `id` in the server container → `uid=1001(app)`; `gcc` absent; 9 revision
  files present; zero `_env` layers in `docker history`
- worker logs `Listening started.`, scheduler logs `Startup completed.`

Suite: **1861 passed, 17 skipped** (was 1828/21 — +19 migration-id tests, +10
legacy-rewrite tests, and 4 that had been skipping now run because of the
provider bracket). `pre-commit run --all-files`: clean.

Cross-reviewed read-only with codex CLI, which returned FAIL on the first pass
with two HIGH findings (the compose precedence inversion and the SQLite legacy-id
claim) and one MEDIUM (gunicorn removal). All three are fixed above; both HIGHs
were reproduced before fixing.

## Notes

- `uv lock` now warns `the package anyio==4.12.1 does not have an extra named
  asyncio`. It comes from an upstream package pulled in by the openai bracket
  declaring a malformed extra. Resolution and sync succeed; the suite is green.
- Two cluster-H hygiene items (`.pycon/`, `.claude/worktrees/` in `.gitignore`)
  already landed in #346.
- The `openai` extra is left in place. Nothing required its removal and
  deleting a published extra is a user-visible break.
- `docker-compose.yml` had no documentation anywhere, so this adds
  `docs/operations/containers.md` and indexes it. The reference stack is
  deliberately runnable-by-default at `ENV=local`; the page states plainly what
  to change before a real deployment.
- `pyproject.toml` is a governor trigger — the glob in `governor-paths.md` is
  the bare filename, so any edit counts, not only the lint sections its prose
  describes. Footer below.

## Governor Footer
- trigger: yes
- reviewer: codex-cli
- rounds: 1
- r-points-fixed: 3
- r-points-deferred: 0
- r-points-rejected: 0
- touched-adr-consequences: none
- pr-scope-notes: Docker image + compose reference stack (#332); also alembic revision-id length, env.py process-env fallback, and pydantic-ai provider bracket
- final-verdict: merge-ready
- links: https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/347, n/a
