### PR TITLE
fix(audit): drop the wrong-realm actor FK and stop losing audit writes silently (#348)

### DIFF
--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -98,7 +98,7 @@ make quickstart   # :8001 에 FastAPI 기동, SQLite 스키마 자동 생성
 | AI 워크플로우 스킬 (Claude + Codex) | **15 + 15** | 0 | 0 | 0 |
 | 벡터 인프라 (S3 Vectors) | **Yes** | No | No | No |
 | 멀티 인터페이스 (API + Worker + Admin + MCP) | **3 + 1 예정** | 2 | 1 | 1 |
-| Architecture Decision Records | **27 active · 30 archived** | 0 | 0 | 0 |
+| Architecture Decision Records | **28 active · 30 archived** | 0 | 0 | 0 |
 | 전 계층 타입 안전 제네릭 | **Yes** | 부분 | 부분 | No |
 | IoC Container DI | **Yes** | No | No | No |
 
@@ -230,7 +230,7 @@ Codex CLI 를 쓴다면 `/` 대신 `$`. 하네스 없이 손으로 만들고 싶
 | Claude Code / Codex CLI 설정 | [`docs/ai-development.ko.md`](ai-development.ko.md) |
 | 도메인을 수동으로 추가 (AI 도구 없이) | [`docs/tutorial/first-domain.md`](tutorial/first-domain.md) (Path B) |
 | 상세 env 변수 · 기술 스택 · 프로젝트 트리 | [`docs/reference.md`](reference.md) |
-| 어떤 결정을 왜 했는지 | [ADR 인덱스](history/README.md) (27 active · 30 archived) |
+| 어떤 결정을 왜 했는지 | [ADR 인덱스](history/README.md) (28 active · 30 archived) |
 | 다음 계획 | [Roadmap](reference.md#roadmap) · [이슈 트래커](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues) |
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,7 +43,7 @@ Quick index for the `docs/` folder.
 
 The [history/](history/) folder contains Architecture Decision Records (ADRs).
 
-- 27 active ADRs in `history/` — open and in effect
+- 28 active ADRs in `history/` — open and in effect
 - 30 archived ADRs in `history/archive/` — superseded or historical
 
 Start at [history/README.md](history/README.md) for the index.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -15,7 +15,7 @@ and the "why not X?" questions that come up on HN and Reddit.
 | AI workflow skills (Claude + Codex) | **15 + 15** | 0 | 0 | 0 |
 | Vector infrastructure (S3 Vectors) | **Yes** | No | No | No |
 | Multi-interface (API + Worker + Admin + MCP) | **3 + 1 planned** | 2 | 1 | 1 |
-| Architecture Decision Records | **27 active · 30 archived** | 0 | 0 | 0 |
+| Architecture Decision Records | **28 active · 30 archived** | 0 | 0 | 0 |
 | Type-safe generics across layers | **Yes** | Partial | Partial | No |
 | IoC container DI | **Yes** | No | No | No |
 | JWT auth + RBAC | **Yes** | Yes | Partial | No |

--- a/docs/history/057-audit-actor-correlation-only.md
+++ b/docs/history/057-audit-actor-correlation-only.md
@@ -1,0 +1,178 @@
+# 057. Admin Audit Actor — Correlation-Only, No Foreign Key
+
+- Status: Accepted
+- Date: 2026-08-04
+- Issue: [#348](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/348)
+- Supersedes: the `admin_audit_log.admin_user_id` constraint introduced in migration `0007`
+- Related: [ADR 049](049-admin-identity-realm-separation.md) (realm separation), [ADR 042](042-optional-infrastructure-di-pattern.md) (optional infra), [ADR 056](056-zero-downtime-migration-safety.md) (migration safety)
+
+## Summary
+
+`admin_audit_log.admin_user_id` is a plain nullable integer holding an
+`admin_identity.id`, with **no foreign key**. Referential expectations moved from
+the DDL to the read path and to CI. The swallowed audit-write failure it was
+hiding became loud in the same change.
+
+## Background
+
+### Trigger
+
+Enabling the PostgreSQL CI matrix leg for [#333](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/333)
+failed two audit tests immediately:
+
+```
+asyncpg.exceptions.ForeignKeyViolationError: insert or update on table "admin_audit_log"
+violates foreign key constraint "admin_audit_log_admin_user_id_fkey"
+DETAIL:  Key (admin_user_id)=(1) is not present in table "user".
+```
+
+Migration `0007` created the column as
+`FOREIGN KEY (admin_user_id) REFERENCES "user" (id) ON DELETE SET NULL`. Since
+ADR 049 / #218 the value written at runtime is an `admin_identity.id`:
+`AdminAuthUseCase._admin_session_for` sets `user_id=admin.id` from an
+`AdminIdentityDTO`, and `AdminAuditLogger` reads it back from the NiceGUI
+session.
+
+### Why it went unnoticed for two releases
+
+Two independent silences compounded:
+
+- **SQLite does not enforce foreign keys** unless `PRAGMA foreign_keys=ON`, which
+  nothing in `src/` or `tests/` sets. CI only ever ran SQLite (#333).
+- **`AuditLogger.log` swallowed the violation.** The fallback logged at
+  `warning` with `action`, `domain`, `result` and `error_type` only, and its own
+  comment claimed the dropped event was "reconstructable from these
+  non-sensitive fields" — while omitting the actor and the target. Nothing
+  alerted.
+
+### Production impact before this ADR
+
+Only the two login-failure paths pass `admin_user_id=None`; every authenticated
+action carries a non-null `admin_identity.id`. On PostgreSQL and MySQL that means
+**rejected logins were recorded and successful admin actions were not**. An
+operator reading `admin_audit_log` saw a list of failed logins and no indication
+that anything was missing — which reads as a complete trail in which no admin
+ever did anything.
+
+## Problem
+
+Three distinct properties were in conflict:
+
+1. An audit trail must record what happened, and must not lose events.
+2. The actor id must not be able to mean two different things.
+3. `_core` must not depend on a bounded context's schema.
+
+The `0007` constraint satisfied none of them.
+
+## Alternatives Considered
+
+### A. Repoint the constraint at `admin_identity.id` — rejected
+
+The obvious fix, and the one the repo owner's instinct favoured. Rejected on two
+verified grounds.
+
+**It can certify a falsehood.** Migration `0009` copies admins with
+`SELECT id, username, ... FROM "user" WHERE role = 'admin'` — *preserving ids* —
+and then advances only `admin_identity`'s sequence:
+
+```sql
+SELECT setval(pg_get_serial_sequence('admin_identity', 'id'),
+              COALESCE((SELECT MAX(id) FROM admin_identity), 1))
+```
+
+`user`'s sequence is untouched, so the two id spaces overlap. A constraint
+against either table can be **satisfied by the wrong row**, recording that a
+customer performed an admin action. This is not hypothetical: the first version
+of `test_audit_actor_fk.py` had to pin `_PROBE_ADMIN_ID = 900_001` because an
+earlier test's `user` row satisfied the constraint and turned an expected failure
+into an XPASS.
+
+**It breaks a documented extension point.** `project-dna.md` §17 IC-218-7
+sanctions pointing "the `admin_identity` repository at a separate database URL —
+no core change required". Cross-database foreign keys do not exist on PostgreSQL
+or MySQL, and `admin_audit_log` is owned by `_core`.
+
+It would also be the only `_core`-owned foreign key in the tree, and the only
+cross-realm one — establishing a precedent for future `_core` cross-cutting
+tables (outbox, notification ledger, job history) to copy.
+
+### B. Keep a constraint and stop deleting actors (tombstones) — rejected for now
+
+The textbook relational answer: an audit log should reference an immutable actor
+dimension. Repoint to `admin_identity.id` with `ON DELETE NO ACTION` and convert
+`AdminAccountUseCase.delete_account` from a physical delete to a `deleted_at`
+tombstone.
+
+This is the strongest form of the "keep integrity" position and is **not
+dismissed** — it is out of scope. It requires a soft-delete column, filtering in
+`delete_account`, `count_accounts_permission_holders`, credential verification,
+`has_real_admin` and the `/admin/accounts` UI, plus redesigning the bootstrap
+admin's hard delete on every fresh install. And it does not solve A's id-space
+overlap or the IC-218-7 conflict.
+
+### C. `ON DELETE RESTRICT` on the existing target — rejected
+
+Every admin action is audited, so no admin with any history could ever be
+deleted. That breaks the accounts page and the setup flow.
+
+### D. Drop the constraint, move integrity to the read path — chosen
+
+## Decision
+
+**D1.** `admin_audit_log.admin_user_id` carries no foreign key. It is a nullable
+`Integer` with a schema `comment=` stating: `admin_identity.id` of the actor,
+realm-scoped, correlation-only, never join to `user`, `admin_username` is the
+durable reference.
+
+**D2.** `admin_username` remains the durable actor reference, as the model
+already claimed. Nothing dereferences `admin_user_id`: the repository selects it
+raw, filters use `admin_username`/`action`/`domain`/`result`/`created_at`, and
+the audit-log page displays `admin_username`.
+
+**D3.** Referential expectations are asserted on the **read** side, in
+`tests/unit/_core/infrastructure/admin/audit/test_audit_actor_fk.py`: a stored
+actor id resolves through the `admin_identity` repository — the access path §17
+IC-218-1 mandates — and does not collide with a `user` row. A read cannot reject,
+and therefore cannot lose, an audit event.
+
+**D4.** The audit-write failure path stays non-raising but stops being silent. It
+logs at `error` with `admin_username`, `admin_user_id` and `record_id` (still
+excluding `before_state` / `after_state` / `failure_reason`, which may carry
+unvetted detail), names a constraint rejection distinctly
+(`audit_write_rejected_by_constraint`), and dispatches through `ErrorNotifier`
+at severity 500 so a persistent failure pages an operator.
+
+**D5.** Existing data is left as found. Pre-#218 rows on PostgreSQL/MySQL already
+had `admin_user_id` nulled by `0009`'s `DELETE FROM "user" WHERE role = 'admin'`
+cascading through the `SET NULL` created in `0007`; the same rows on SQLite still
+hold the old customer ids. Backfilling would mean guessing which id space a value
+came from.
+
+## Consequences
+
+- **ADR057-G1** — No `_core`-owned table may declare a foreign key into a
+  bounded context's table. Cross-context references are correlation-only and are
+  reconciled through the owning domain's repository or protocol (§17 IC-218-1).
+  This inherits to any future `_core` cross-cutting table: outbox, notification
+  ledger, job history.
+- **ADR057-G2** — An audit-write failure must never be logged below `error`, and
+  must carry actor and target. Any future change to `AuditLogger`'s failure path
+  inherits this; `test_audit_write_failure_visibility.py` enforces it.
+- **ADR057-G3** — `user.id` and `admin_identity.id` overlap as a consequence of
+  `0009`'s id-preserving copy. Treat the two as separate, non-comparable id
+  spaces. Any code that resolves an admin-realm id must go through
+  `admin_identity`; any constraint or join that mixes them is a defect regardless
+  of whether it currently passes.
+- **ADR057-G4** — Option B (immutable actor dimension via tombstones) remains
+  the preferred long-term shape if admin deletion semantics are ever revisited.
+  Whoever does that work should re-evaluate D1, and must resolve G3 first —
+  a constraint over overlapping id spaces is unsafe even with tombstones.
+- A dangling `admin_user_id` is now possible: deleting an admin leaves the id in
+  past audit rows. That is the intended behaviour for an append-only trail, and
+  is why D3 asserts resolution rather than existence.
+
+## Post-decision Update
+
+_To be filled in after the first deployment that exercises D4 — specifically
+whether the `ErrorNotifier` dispatch produces useful signal or noise under a
+sustained audit-write failure._

--- a/docs/history/README.md
+++ b/docs/history/README.md
@@ -65,6 +65,7 @@ Read top-to-bottom; each builds on the ones above it.
 | [054](054-plan-execute-boundary-hard-gate.md) | Plan→Execute Boundary Hard Gate | `/plan-feature` ends at the approved Execution Packet; implementing from the `planned` stage without `/execute-plan` or a waiver token is hard-blocked on Claude, advisory on Codex. |
 | [055](055-summary-finding-ledger.md) | Summary Finding Ledger | Out-of-diff review findings post as a task-list ledger with complete carry-forward per round; any `OPEN` ledger key blocks Approve and the completion gate (closes the #292 merge-gate bypass). |
 | [056](056-zero-downtime-migration-safety.md) | Zero-Downtime Migration Safety | No-downtime migration playbook (expand-contract + per-engine safe/unsafe DDL) + an advisory checker that scans Alembic revisions for unsafe DDL; advisory-first, plan-time data-model contracts explicitly out of scope. |
+| [057](057-audit-actor-correlation-only.md) | Admin Audit Actor — Correlation-Only, No Foreign Key | `admin_audit_log.admin_user_id` drops its foreign key: the value is an `admin_identity.id` and migration 0009's id-preserving copy left the two id spaces overlapping, so a constraint against either table can be satisfied by the wrong row. Integrity moves to the read path; the swallowed audit-write failure that hid it becomes loud. |
 
 ## Archive
 

--- a/migrations/versions/0010_drop_audit_actor_fk.py
+++ b/migrations/versions/0010_drop_audit_actor_fk.py
@@ -53,27 +53,36 @@ _COMMENT = (
 )
 
 
-def _table_without_actor_fk() -> sa.Table:
-    """The table as it exists at 0009, minus the actor foreign key.
+def _audit_table(*, with_actor_fk: bool) -> sa.Table:
+    """The 0009 table shape, with or without the actor foreign key.
 
-    SQLite cannot drop a constraint, and ``batch_alter_table`` rebuilds from the
-    **reflected** schema — not from the ORM model — so a bare ``alter_column``
-    carries the old ``FOREIGN KEY`` straight into the new table. Alembic needs an
-    explicit ``copy_from`` describing the intended shape.
+    SQLite cannot drop or add a constraint in place, and ``batch_alter_table``
+    rebuilds from the **reflected** schema — not from the ORM model — so a bare
+    ``alter_column`` carries the old ``FOREIGN KEY`` straight into the new table.
+    ``copy_from`` has to describe the intended shape.
+
+    Everything the rebuild must preserve has to be declared here, indexes
+    included. Omitting them silently drops all four: verified by running the
+    revision against SQLite, where ``sqlite_master`` went from four ``idx_audit_*``
+    rows to zero. They back the repository's time-ordered list and its
+    actor/action/domain filters.
 
     Declared inline rather than imported from ``AdminAuditLog``: a revision must
     describe the schema at *this* point in history, and the model will keep
-    moving. Mirrors the 0009 DDL exactly, minus the FK, with ``comment`` applied.
+    moving.
 
-    Dropping it on SQLite matters even though SQLite does not enforce foreign
-    keys by default: leaving it in the DDL means enabling
+    Dropping the FK on SQLite matters even though SQLite does not enforce foreign
+    keys by default — leaving it in the DDL means enabling
     ``PRAGMA foreign_keys=ON`` would resurrect the defect this revision removes.
     """
-    return sa.Table(
-        _TABLE,
-        sa.MetaData(),
+    columns: list[sa.SchemaItem] = [
         sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column(_COLUMN, sa.Integer(), nullable=True, comment=_COMMENT),
+        sa.Column(
+            _COLUMN,
+            sa.Integer(),
+            nullable=True,
+            comment=None if with_actor_fk else _COMMENT,
+        ),
         sa.Column("admin_username", sa.String(255), nullable=False),
         sa.Column("action", sa.String(50), nullable=False),
         sa.Column("domain", sa.String(100), nullable=False),
@@ -91,7 +100,16 @@ def _table_without_actor_fk() -> sa.Table:
             nullable=False,
         ),
         sa.PrimaryKeyConstraint("id"),
-    )
+        sa.Index("idx_audit_created_at", "created_at"),
+        sa.Index("idx_audit_user_created", "admin_username", "created_at"),
+        sa.Index("idx_audit_action_created", "action", "created_at"),
+        sa.Index("idx_audit_domain_created", "domain", "created_at"),
+    ]
+    if with_actor_fk:
+        columns.append(
+            sa.ForeignKeyConstraint([_COLUMN], ["user.id"], ondelete="SET NULL")
+        )
+    return sa.Table(_TABLE, sa.MetaData(), *columns)
 
 
 def _actor_fk_name(bind) -> str | None:
@@ -109,7 +127,7 @@ def upgrade() -> None:
         # copy_from is required — see _table_without_actor_fk. Without it the
         # rebuild reflects the old FOREIGN KEY back into the new table.
         with op.batch_alter_table(
-            _TABLE, copy_from=_table_without_actor_fk()
+            _TABLE, copy_from=_audit_table(with_actor_fk=False)
         ) as batch_op:
             batch_op.alter_column(_COLUMN, existing_type=sa.Integer(), comment=_COMMENT)
         return
@@ -125,7 +143,12 @@ def downgrade() -> None:
     bind = op.get_bind()
 
     if bind.dialect.name == "sqlite":
-        with op.batch_alter_table(_TABLE) as batch_op:
+        # Rebuild *with* the constraint. Only removing the comment would leave
+        # the downgrade asymmetric with the other engines and, worse, silently
+        # non-reversible: the foreign key this revision removed would stay gone.
+        with op.batch_alter_table(
+            _TABLE, copy_from=_audit_table(with_actor_fk=True)
+        ) as batch_op:
             batch_op.alter_column(_COLUMN, existing_type=sa.Integer(), comment=None)
         return
 

--- a/migrations/versions/0010_drop_audit_actor_fk.py
+++ b/migrations/versions/0010_drop_audit_actor_fk.py
@@ -1,0 +1,145 @@
+"""admin_audit_log: drop the actor foreign key (ADR 057, #348)
+
+Revision ID: 0010_drop_audit_actor_fk
+Revises: 0009_admin_identity_realm
+Create Date: 2026-08-04
+
+``admin_audit_log.admin_user_id`` carried ``FOREIGN KEY (admin_user_id)
+REFERENCES "user" (id) ON DELETE SET NULL`` from 0007. Since ADR 049 / #218 the
+value written there is an ``admin_identity.id``, so on PostgreSQL and MySQL every
+authenticated admin action failed the constraint and ``AdminAuditLogger``
+swallowed it — the audit trail recorded rejected logins (which pass NULL) and
+nothing else.
+
+Repointing the constraint at ``admin_identity.id`` was rejected. 0009 copied
+admins across preserving their ids and advanced only ``admin_identity``'s
+sequence, so the two id spaces overlap: a constraint against either table can be
+satisfied by the *wrong* row and assert that a customer performed an admin
+action. ``ON DELETE SET NULL`` also let a non-audit path rewrite append-only
+evidence, and 0009's ``DELETE FROM "user" WHERE role = 'admin'`` already did
+exactly that on engines that enforce foreign keys.
+
+Zero-downtime note (ADR 056): dropping a constraint takes a brief ACCESS
+EXCLUSIVE lock on the table and no rewrite, and nothing reads ``admin_user_id``
+relationally, so old and new application versions both keep working across the
+deploy — the old one simply stops having its inserts rejected.
+
+Data left as found, deliberately. Pre-#218 rows on PostgreSQL/MySQL already had
+``admin_user_id`` nulled by 0009's cascade; the same rows on SQLite still hold
+the old customer ids. Backfilling would mean guessing which id space a value
+came from. ``admin_username`` is the durable reference and is unaffected.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.types import JSON
+
+revision: str = "0010_drop_audit_actor_fk"
+down_revision: str | None = "0009_admin_identity_realm"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "admin_audit_log"
+_COLUMN = "admin_user_id"
+
+# 0007 created the constraint unnamed, so the name is whatever the backend
+# generated. Resolving it from the inspector keeps this revision correct on a
+# database created by 0007 as well as one created by `Base.metadata.create_all`.
+_COMMENT = (
+    "admin_identity.id of the actor. Realm-scoped and correlation-only:"
+    " never join to user. admin_username is the durable reference."
+)
+
+
+def _table_without_actor_fk() -> sa.Table:
+    """The table as it exists at 0009, minus the actor foreign key.
+
+    SQLite cannot drop a constraint, and ``batch_alter_table`` rebuilds from the
+    **reflected** schema — not from the ORM model — so a bare ``alter_column``
+    carries the old ``FOREIGN KEY`` straight into the new table. Alembic needs an
+    explicit ``copy_from`` describing the intended shape.
+
+    Declared inline rather than imported from ``AdminAuditLog``: a revision must
+    describe the schema at *this* point in history, and the model will keep
+    moving. Mirrors the 0009 DDL exactly, minus the FK, with ``comment`` applied.
+
+    Dropping it on SQLite matters even though SQLite does not enforce foreign
+    keys by default: leaving it in the DDL means enabling
+    ``PRAGMA foreign_keys=ON`` would resurrect the defect this revision removes.
+    """
+    return sa.Table(
+        _TABLE,
+        sa.MetaData(),
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column(_COLUMN, sa.Integer(), nullable=True, comment=_COMMENT),
+        sa.Column("admin_username", sa.String(255), nullable=False),
+        sa.Column("action", sa.String(50), nullable=False),
+        sa.Column("domain", sa.String(100), nullable=False),
+        sa.Column("record_id", sa.String(128), nullable=True),
+        sa.Column("before_state", JSON, nullable=True),
+        sa.Column("after_state", JSON, nullable=True),
+        sa.Column("result", sa.String(20), nullable=False),
+        sa.Column("failure_reason", sa.Text(), nullable=True),
+        sa.Column("ip_address", sa.String(45), nullable=True),
+        sa.Column("correlation_id", sa.String(36), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def _actor_fk_name(bind) -> str | None:
+    inspector = sa.inspect(bind)
+    for fk in inspector.get_foreign_keys(_TABLE):
+        if fk.get("constrained_columns") == [_COLUMN]:
+            return fk.get("name")
+    return None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    if bind.dialect.name == "sqlite":
+        # copy_from is required — see _table_without_actor_fk. Without it the
+        # rebuild reflects the old FOREIGN KEY back into the new table.
+        with op.batch_alter_table(
+            _TABLE, copy_from=_table_without_actor_fk()
+        ) as batch_op:
+            batch_op.alter_column(_COLUMN, existing_type=sa.Integer(), comment=_COMMENT)
+        return
+
+    name = _actor_fk_name(bind)
+    if name:
+        op.drop_constraint(name, _TABLE, type_="foreignkey")
+
+    op.alter_column(_TABLE, _COLUMN, existing_type=sa.Integer(), comment=_COMMENT)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+
+    if bind.dialect.name == "sqlite":
+        with op.batch_alter_table(_TABLE) as batch_op:
+            batch_op.alter_column(_COLUMN, existing_type=sa.Integer(), comment=None)
+        return
+
+    op.alter_column(_TABLE, _COLUMN, existing_type=sa.Integer(), comment=None)
+
+    # Restoring the constraint can fail on real data: any row whose
+    # admin_user_id is an admin_identity.id with no matching user row will
+    # violate it. That is the defect this revision removed, and a faithful
+    # downgrade has to reintroduce it rather than silently drop the rows.
+    op.create_foreign_key(
+        "admin_audit_log_admin_user_id_fkey",
+        _TABLE,
+        "user",
+        [_COLUMN],
+        ["id"],
+        ondelete="SET NULL",
+    )

--- a/src/_apps/admin/bootstrap.py
+++ b/src/_apps/admin/bootstrap.py
@@ -75,7 +75,17 @@ def bootstrap_admin(fastapi_app: FastAPI) -> None:
     # and query while /v1/* ran on the swapped database.
     audit_repo = AdminAuditLogRepository(admin_container.core_container.database)
     configure_audit_repository(audit_repo)
-    configure_audit_logger(AuditLogger(audit_repo))
+    # Pass the notifier so a persistent audit-write failure reaches an operator
+    # instead of only structlog (#348). The *provider*, not a resolved notifier,
+    # for the same reason as the database above — and because the disabled branch
+    # is a shared Singleton that logs its one-time warning from __init__, so
+    # resolving it at boot consumes that warning before anything can observe it.
+    configure_audit_logger(
+        AuditLogger(
+            audit_repo,
+            error_notifier=admin_container.core_container.error_notifier,
+        )
+    )
     configure_admin_account_use_case_provider(
         admin_container.admin_identity_container.admin_account_use_case
     )

--- a/src/_core/infrastructure/admin/audit/logger.py
+++ b/src/_core/infrastructure/admin/audit/logger.py
@@ -204,8 +204,15 @@ class AuditLogger:
                 error_code=event,
                 message=f"admin audit write failed ({error_type})",
             )
-        except Exception:  # noqa: BLE001 - see docstring
-            _logger.warning("audit_write_failure_notify_failed", exc_info=True)
+        except Exception as exc:  # noqa: BLE001 - see docstring
+            # exc_type only, no exc_info. The notifier is duck-typed and may be
+            # any provider a deployment wires in; its exceptions can carry the
+            # webhook URL or other configuration. ErrorNotifier._safe_send takes
+            # the same precaution for the same reason (security-checklist §13).
+            _logger.warning(
+                "audit_write_failure_notify_failed",
+                error_type=type(exc).__name__,
+            )
 
 
 def _safe_session_get(key: str):

--- a/src/_core/infrastructure/admin/audit/logger.py
+++ b/src/_core/infrastructure/admin/audit/logger.py
@@ -2,8 +2,13 @@
 
 Design invariants (codex-reviewed):
 - **Audit-write never raises into the caller.** A repository failure is
-  swallowed and surfaced via structlog as a warning so that a transient DB
-  hiccup cannot break the user action that triggered the log.
+  swallowed so a transient DB hiccup cannot break the user action that
+  triggered the log. It is *not* silent: the fallback logs at ``error`` with
+  enough identity to reconstruct the dropped event, and dispatches through
+  ``ErrorNotifier`` so a persistent failure pages someone (#348). Before ADR
+  057 this path logged at ``warning`` with only action/domain/result, which is
+  how a wrong foreign key destroyed every authenticated admin audit write on
+  PostgreSQL for two releases without anyone noticing.
 - **Actor + correlation auto-fill.** When ``admin_user_id`` / ``admin_username``
   are not passed (typical for instrumentation inside a NiceGUI page callback),
   they are read from ``app.storage.user``. ``correlation_id`` is read from
@@ -48,11 +53,38 @@ _UNSET = object()
 _ADMIN_USERNAME_MAX = 255
 
 
+def _loggable(value: Any) -> Any:
+    """Render ``_UNSET`` as a readable marker for the failure log.
+
+    A raw ``object()`` repr in a log line tells the reader nothing; knowing the
+    write failed *before* actor auto-fill ran is diagnostically different from
+    knowing the actor was genuinely unknown.
+    """
+    return "<unset>" if value is _UNSET else value
+
+
 class AuditLogger:
     """Thin facade callers use to record an audit entry."""
 
-    def __init__(self, repository: AdminAuditLogRepository) -> None:
+    def __init__(
+        self,
+        repository: AdminAuditLogRepository,
+        error_notifier: Any | None = None,
+    ) -> None:
         self._repository = repository
+        # A *provider* (zero-arg callable) or an already-built notifier, or None.
+        # Providers are resolved lazily in _notify_write_failure for the same
+        # reason bootstrap_admin passes the database provider rather than a
+        # resolved Database: resolving at boot freezes container state into
+        # module state. Here it also consumes the one-time
+        # notification_client_disabled warning, because the disabled branch is a
+        # shared Singleton that logs from __init__ — resolving it eagerly made
+        # test_noop_notification_client_disabled_warning_emitted_once see zero
+        # warnings instead of one.
+        #
+        # Duck-typed rather than imported: this module must not take a hard
+        # dependency on the notification package just to report a failure.
+        self._error_notifier = error_notifier
 
     async def log(
         self,
@@ -108,17 +140,72 @@ class AuditLogger:
             )
             await self._repository.insert(dto)
         except Exception as exc:  # noqa: BLE001 - swallowed by design
-            # The dropped event is reconstructable from these non-sensitive
-            # fields only (no before_state/after_state/failure_reason — they
-            # may contain detail not yet vetted by the whitelist).
-            _logger.warning(
-                "audit_write_failed",
+            # Identity is included on purpose. The previous version claimed the
+            # dropped event was "reconstructable from these non-sensitive
+            # fields" while omitting actor and record, so it recorded that
+            # *something* failed and nothing about who or what. These three are
+            # the minimum needed to reconstruct the entry; before_state /
+            # after_state / failure_reason stay out because they may carry
+            # detail the whitelist has not vetted.
+            #
+            # ``error``, not ``warning``: a dropped audit entry is a lost
+            # security record, not a degraded nicety.
+            #
+            # ``Database.session()`` translates IntegrityError into a curated
+            # ``DatabaseException`` with this error_code (see
+            # ``persistence/rdb/database.py``), which is also how
+            # ``user_repository`` and ``admin_identity_repository`` detect it —
+            # a constraint rejection never arrives here as a raw IntegrityError.
+            rejected_by_constraint = (
+                getattr(exc, "error_code", None) == "DB_INTEGRITY_ERROR"
+            )
+            event = (
+                "audit_write_rejected_by_constraint"
+                if rejected_by_constraint
+                else "audit_write_failed"
+            )
+            _logger.error(
+                event,
                 exc_info=exc,
                 action=getattr(action, "value", str(action)),
                 domain=domain,
                 result=getattr(result, "value", str(result)),
+                # Both are function parameters, so they always exist as locals;
+                # they may still hold the _UNSET sentinel if the failure landed
+                # before actor auto-fill, which is itself worth seeing.
+                admin_username=_loggable(admin_username),
+                admin_user_id=_loggable(admin_user_id),
+                record_id=record_id,
                 error_type=type(exc).__name__,
             )
+            self._notify_write_failure(event, type(exc).__name__)
+
+    def _notify_write_failure(self, event: str, error_type: str) -> None:
+        """Page an operator when audit writes are failing.
+
+        status_code=500 so the default NOTIFICATION_SEVERITY_THRESHOLD (500)
+        lets it through; ``ErrorNotifier`` applies its own per-error_code
+        cooldown, so a storm of failures produces one alert per quiet window
+        rather than one per admin action.
+
+        Never raises: a notification problem must not become a second failure
+        on a path whose entire contract is "does not raise into the caller".
+        """
+        notifier = self._error_notifier
+        if notifier is None:
+            return
+        try:
+            # dependency-injector providers are callable and return the instance;
+            # an already-built notifier exposes maybe_dispatch directly.
+            if not hasattr(notifier, "maybe_dispatch"):
+                notifier = notifier()
+            notifier.maybe_dispatch(
+                status_code=500,
+                error_code=event,
+                message=f"admin audit write failed ({error_type})",
+            )
+        except Exception:  # noqa: BLE001 - see docstring
+            _logger.warning("audit_write_failure_notify_failed", exc_info=True)
 
 
 def _safe_session_get(key: str):

--- a/src/_core/infrastructure/admin/audit/models/audit_log_model.py
+++ b/src/_core/infrastructure/admin/audit/models/audit_log_model.py
@@ -7,7 +7,6 @@ diff) ships in Phase 2 alongside the ``/admin/audit-log`` UI.
 from sqlalchemy import (
     BigInteger,
     DateTime,
-    ForeignKey,
     Index,
     Integer,
     String,
@@ -24,8 +23,9 @@ class AdminAuditLog(Base):
     """Persistent record of every admin action — login/logout, account
     management, password change, etc. (#196).
 
-    ``admin_username`` is denormalized so log entries survive deletion of the
-    acting user (FK is ``ON DELETE SET NULL``).
+    ``admin_username`` is the durable actor reference — denormalized so entries
+    survive deletion of the acting admin. ``admin_user_id`` is correlation-only
+    and carries no foreign key; see the column comment and ADR 057 (#348).
     """
 
     __tablename__ = "admin_audit_log"
@@ -48,12 +48,29 @@ class AdminAuditLog(Base):
         autoincrement=True,
     )
 
-    # FK to user.id, SET NULL on delete; ``admin_username`` survives as the
-    # durable actor reference.
+    # Deliberately unconstrained. This carried a foreign key to ``user.id`` with
+    # ``ON DELETE SET NULL`` until ADR 057 (#348), which was wrong twice over:
+    #
+    # - The value is an ``admin_identity.id`` (ADR 049 / #218), not a customer
+    #   id. Migration 0009 copied admins across *preserving ids* and advanced
+    #   only ``admin_identity``'s sequence, so the two id spaces overlap — a
+    #   constraint against either table can be satisfied by the wrong row and
+    #   certify that a customer performed an admin action.
+    # - ``SET NULL`` let a non-audit code path rewrite append-only evidence.
+    #   0009's ``DELETE FROM "user" WHERE role = 'admin'`` ran *after* 0007
+    #   created the constraint, nulling the actor on every pre-#218 row on
+    #   PostgreSQL/MySQL while SQLite (which does not enforce foreign keys)
+    #   kept them.
+    #
+    # Integrity now lives on the read side and in CI, not in the DDL — see
+    # tests/unit/_core/infrastructure/admin/audit/test_audit_actor_fk.py.
     admin_user_id: Mapped[int | None] = mapped_column(
         Integer,
-        ForeignKey("user.id", ondelete="SET NULL"),
         nullable=True,
+        comment=(
+            "admin_identity.id of the actor. Realm-scoped and correlation-only:"
+            " never join to user. admin_username is the durable reference."
+        ),
     )
     admin_username: Mapped[str] = mapped_column(String(255), nullable=False)
 

--- a/tests/unit/_core/infrastructure/admin/audit/test_audit_actor_fk.py
+++ b/tests/unit/_core/infrastructure/admin/audit/test_audit_actor_fk.py
@@ -1,30 +1,28 @@
-"""Keep the production audit-actor defect visible in the suite (#348).
+"""The production audit-actor path, asserted on every engine (#348, ADR 057).
 
-Every other DB-touching test in this package writes `admin_user_id=None`,
-because `project-dna.md` §17 IC-218-1 says "No admin row may exist in `user`"
-and `admin_audit_log.admin_user_id` still carries `ForeignKey("user.id")`. There
-is no honest non-null value to write until #348 decides where that FK should
-point.
+This file began as an `xfail(strict=True)` probe. `admin_audit_log.admin_user_id`
+carried `ForeignKey("user.id", ondelete="SET NULL")` while the value written at
+runtime is an `admin_identity.id`, so on PostgreSQL every authenticated admin
+action failed the constraint and `AdminAuditLogger` swallowed it — the trail
+recorded rejected logins (which pass NULL) and nothing else.
 
-Writing NULL everywhere would make the package pass on both engines and leave
-nothing in the suite that knows the production path is broken. This file is that
-something.
+ADR 057 dropped the constraint rather than repointing it: migration 0009 copied
+admins across preserving ids and advanced only `admin_identity`'s sequence, so
+the id spaces overlap and a constraint against either table can be satisfied by
+the *wrong* row — certifying that a customer performed an admin action.
 
-At runtime the actor id is an `admin_identity.id`
-(`AdminAuthUseCase._admin_session_for` sets `user_id=admin.id`, and
-`AdminAuditLogger` reads it back from the session), so on PostgreSQL the insert
-below is exactly what production attempts — and it fails the constraint. The
-production logger swallows that exception (`# noqa: BLE001 - swallowed by
-design`), which is why the breakage is invisible outside a test like this one.
+The xfail is gone; these are now positive assertions. Integrity moved from the
+DDL to here, which only works if the tests are the real thing: the actor is a
+genuine `admin_identity` row, the write goes through the production repository,
+and the stored id is read back and resolved through the `admin_identity`
+repository the way `project-dna` §17 IC-218-1 requires ("Cross-realm reads go
+only through the owning domain's repository/protocol").
 
-`strict=True` is the point: when #348 lands, this XPASSes, CI fails, and whoever
-fixed it is told to come back here and turn it into a real assertion instead of
-leaving a stale marker behind.
+The read-side reconciliation is deliberately a *read*: unlike a foreign key it
+cannot reject — and therefore cannot lose — an audit event.
 """
 
 from __future__ import annotations
-
-import os
 
 import pytest
 import pytest_asyncio
@@ -34,22 +32,17 @@ from src._core.infrastructure.admin.audit import (
     AdminAction,
     AdminAuditLogRepository,
     AuditLogDTO,
+    AuditLogFilter,
     AuditResult,
 )
 from src._core.infrastructure.admin.audit.models.audit_log_model import AdminAuditLog
 from src.admin_identity.infrastructure.database.models.admin_identity_model import (
     AdminIdentityModel,
 )
-from src.user.infrastructure.database.models.user_model import UserModel
-
-_ON_POSTGRESQL = os.environ.get("TEST_DB_ENGINE", "sqlite").lower() == "postgresql"
-
-_pytestmark_reason = (
-    "admin_audit_log.admin_user_id FKs to user.id while runtime writes an "
-    "admin_identity.id (#348). SQLite does not enforce foreign keys, so this "
-    "only fails on the engine production uses."
+from src.admin_identity.infrastructure.repositories.admin_identity_repository import (
+    AdminIdentityRepository,
 )
-
+from src.user.infrastructure.database.models.user_model import UserModel
 
 # An explicit, deliberately out-of-range id. With an autoincrement id this test
 # is order-dependent and unusable: `tests/conftest.py::test_db` is session-scoped
@@ -97,7 +90,6 @@ async def admin_identity_row(test_db):
         return admin.id
 
 
-@pytest.mark.xfail(_ON_POSTGRESQL, reason=_pytestmark_reason, strict=True)
 @pytest.mark.asyncio
 async def test_audit_write_accepts_an_admin_identity_actor(test_db, admin_identity_row):
     repo = AdminAuditLogRepository(test_db)
@@ -127,3 +119,65 @@ async def test_audit_write_accepts_an_admin_identity_actor(test_db, admin_identi
 
     assert len(stored) == 1
     assert stored[0].admin_user_id == admin_identity_row
+
+
+@pytest.mark.asyncio
+async def test_stored_actor_resolves_through_the_admin_identity_repository(
+    test_db, admin_identity_row
+):
+    """The reconciliation that replaces the dropped foreign key.
+
+    A FK asserted "this id exists in some table" at write time, and paid for it
+    by being able to reject — and, given the swallow, silently lose — the event.
+    This asserts the stronger property on the read side instead: the id stored
+    in an audit row resolves to a real admin *in the owning context's own
+    repository*, which is the access path §17 IC-218-1 mandates.
+    """
+    repo = AdminAuditLogRepository(test_db)
+    await repo.insert(
+        AuditLogDTO(
+            admin_user_id=admin_identity_row,
+            admin_username="audit-fk-probe",
+            action=AdminAction.ACCOUNT_CREATE,
+            domain="admin_identity",
+            result=AuditResult.SUCCESS,
+        )
+    )
+
+    rows, _ = await repo.list_filtered(AuditLogFilter(username_like="audit-fk-probe"))
+    actor_ids = {r.admin_user_id for r in rows if r.admin_user_id is not None}
+    assert actor_ids, "the audit row stored no actor id to reconcile"
+
+    admin_repository = AdminIdentityRepository(test_db)
+    for actor_id in actor_ids:
+        # select_data_by_id raises 404 rather than returning None, so an
+        # unresolvable actor fails this test loudly instead of via a None check.
+        assert await admin_repository.exists_by_id(actor_id), (
+            f"audit row references admin_identity id {actor_id}, which does not "
+            "resolve through the admin_identity repository"
+        )
+        resolved = await admin_repository.select_data_by_id(actor_id)
+        assert resolved.username == "audit-fk-probe"
+
+
+@pytest.mark.asyncio
+async def test_actor_id_is_not_a_customer_id(test_db, admin_identity_row):
+    """The misattribution the dropped FK could have certified.
+
+    Migration 0009 copied admins into admin_identity preserving ids and advanced
+    only that table's sequence, so the id spaces overlap. A constraint against
+    `user.id` can therefore be *satisfied* by a customer who happens to occupy
+    the same id — recording that a customer performed an admin action. Assert
+    the column is read as an admin-realm id and nothing else.
+    """
+    async with test_db.session() as session:
+        customer_at_same_id = (
+            await session.execute(
+                select(UserModel.id).where(UserModel.id == admin_identity_row)
+            )
+        ).scalar_one_or_none()
+
+    assert customer_at_same_id is None, (
+        "a user row shares this id, so any FK to user.id would be satisfied by "
+        "the wrong realm — see ADR 057"
+    )

--- a/tests/unit/_core/infrastructure/admin/audit/test_audit_write_failure_visibility.py
+++ b/tests/unit/_core/infrastructure/admin/audit/test_audit_write_failure_visibility.py
@@ -1,0 +1,227 @@
+"""A dropped audit write must be loud (#348, ADR 057).
+
+`AuditLogger.log` never raises — locking an operator out of the dashboard over
+an audit hiccup would be worse than the hiccup. That contract is kept. What
+changed is everything around it.
+
+Before ADR 057 the fallback logged at `warning` with `action`, `domain`,
+`result` and `error_type`, and its own comment claimed the dropped event was
+"reconstructable from these non-sensitive fields". It was not: the actor and the
+target were both omitted, so the record said *something* failed and nothing
+about who or what. Nothing alerted. That is how a wrong foreign key destroyed
+every authenticated admin audit write on PostgreSQL for two releases.
+
+These tests pin the three properties that make the swallow survivable:
+
+1. it still does not raise,
+2. the log line carries enough identity to reconstruct the entry,
+3. a failure reaches `ErrorNotifier`, and a constraint rejection is
+   distinguishable from any other failure.
+"""
+
+from __future__ import annotations
+
+import pytest
+import structlog
+from structlog.testing import capture_logs
+
+from src._core.infrastructure.admin.audit.dtos.audit_log_dto import (
+    AdminAction,
+    AuditResult,
+)
+from src._core.infrastructure.admin.audit.logger import AuditLogger
+from src._core.infrastructure.persistence.rdb.exceptions import DatabaseException
+
+
+class _ExplodingRepository:
+    """Stands in for a repository whose insert fails."""
+
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+        self.calls = 0
+
+    async def insert(self, dto) -> None:
+        self.calls += 1
+        raise self._exc
+
+
+class _RecordingNotifier:
+    def __init__(self) -> None:
+        self.dispatched: list[dict] = []
+
+    def maybe_dispatch(
+        self, *, status_code: int, error_code: str, message: str
+    ) -> None:
+        self.dispatched.append(
+            {"status_code": status_code, "error_code": error_code, "message": message}
+        )
+
+
+class _RaisingNotifier:
+    def maybe_dispatch(self, **_kwargs) -> None:
+        raise RuntimeError("notifier is broken too")
+
+
+def _integrity_error() -> DatabaseException:
+    """What `Database.session()` actually raises on a constraint violation.
+
+    It translates `IntegrityError` into a curated `DatabaseException` carrying
+    this `error_code`, so a raw `IntegrityError` never reaches the logger — the
+    same detection `user_repository` and `admin_identity_repository` use.
+    """
+    return DatabaseException(
+        status_code=400,
+        message="Data integrity error",
+        error_code="DB_INTEGRITY_ERROR",
+    )
+
+
+async def _log_once(repository, notifier=None) -> list[dict]:
+    logger = AuditLogger(repository, error_notifier=notifier)
+    with capture_logs() as logs:
+        await logger.log(
+            action=AdminAction.LOGIN,
+            domain="auth",
+            result=AuditResult.SUCCESS,
+            record_id="rec-7",
+            admin_user_id=900_002,
+            admin_username="someone",
+        )
+    return logs
+
+
+@pytest.fixture(autouse=True)
+def _reset_structlog():
+    # cache_logger_on_first_use=True makes capture_logs order-dependent; the
+    # repo-wide fixture does this too, repeated here so this file is honest on
+    # its own.
+    structlog.reset_defaults()
+    yield
+    structlog.reset_defaults()
+
+
+@pytest.mark.asyncio
+async def test_write_failure_does_not_raise_into_the_caller():
+    repository = _ExplodingRepository(RuntimeError("db down"))
+
+    await _log_once(repository)
+
+    assert repository.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_failure_is_logged_at_error_with_enough_identity():
+    logs = await _log_once(_ExplodingRepository(RuntimeError("db down")))
+
+    entry = next(log for log in logs if log["event"] == "audit_write_failed")
+    assert entry["log_level"] == "error"
+    # The three fields the old version omitted, which is what made the dropped
+    # event unreconstructable.
+    assert entry["admin_username"] == "someone"
+    assert entry["admin_user_id"] == 900_002
+    assert entry["record_id"] == "rec-7"
+    assert entry["error_type"] == "RuntimeError"
+
+
+@pytest.mark.asyncio
+async def test_failure_log_still_excludes_unvetted_state():
+    logs = await _log_once(_ExplodingRepository(RuntimeError("db down")))
+
+    entry = next(log for log in logs if log["event"] == "audit_write_failed")
+    for field in ("before_state", "after_state", "failure_reason"):
+        assert field not in entry
+
+
+@pytest.mark.asyncio
+async def test_constraint_rejection_has_its_own_event_name():
+    logs = await _log_once(_ExplodingRepository(_integrity_error()))
+
+    events = {log["event"] for log in logs}
+    assert "audit_write_rejected_by_constraint" in events
+    assert "audit_write_failed" not in events
+
+
+@pytest.mark.asyncio
+async def test_failure_is_dispatched_to_the_error_notifier():
+    notifier = _RecordingNotifier()
+
+    await _log_once(_ExplodingRepository(_integrity_error()), notifier)
+
+    assert len(notifier.dispatched) == 1
+    dispatched = notifier.dispatched[0]
+    # 500 regardless of the DatabaseException's own 400: losing an audit record
+    # is an operational incident, and the default
+    # NOTIFICATION_SEVERITY_THRESHOLD is 500.
+    assert dispatched["status_code"] == 500
+    assert dispatched["error_code"] == "audit_write_rejected_by_constraint"
+    assert "DatabaseException" in dispatched["message"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_is_skipped_when_no_notifier_is_wired():
+    # Unit tests and notification-disabled deployments construct the logger
+    # without one; that must not become a second failure.
+    logs = await _log_once(_ExplodingRepository(RuntimeError("db down")), None)
+
+    assert any(log["event"] == "audit_write_failed" for log in logs)
+
+
+@pytest.mark.asyncio
+async def test_a_broken_notifier_cannot_break_the_audit_path():
+    logs = await _log_once(
+        _ExplodingRepository(RuntimeError("db down")), _RaisingNotifier()
+    )
+
+    events = {log["event"] for log in logs}
+    assert "audit_write_failed" in events
+    assert "audit_write_failure_notify_failed" in events
+
+
+@pytest.mark.asyncio
+async def test_unset_actor_is_rendered_readably():
+    """A failure before actor auto-fill is diagnostically different.
+
+    Omitting the parameters entirely leaves them as the `_UNSET` sentinel. A raw
+    `object()` repr in a log line tells the reader nothing, so it renders as
+    `<unset>` — which distinguishes "failed before we knew the actor" from
+    "actor was genuinely unknown" (the login-failure path, which passes None).
+    """
+    logger = AuditLogger(_ExplodingRepository(RuntimeError("db down")))
+    with capture_logs() as logs:
+        await logger.log(
+            action=AdminAction.LOGIN, domain="auth", result=AuditResult.FAILURE
+        )
+
+    entry = next(log for log in logs if log["event"] == "audit_write_failed")
+    assert entry["admin_user_id"] in ("<unset>", None)
+
+
+@pytest.mark.asyncio
+async def test_a_provider_is_resolved_lazily_not_at_construction():
+    """Regression guard for the ordering trap this wiring first fell into.
+
+    `bootstrap_admin` passes the container *provider*, not a resolved notifier.
+    Resolving at construction builds the shared `_noop_notification_client`
+    Singleton, which logs `notification_client_disabled` from `__init__` — so an
+    eager resolve consumed that one-time warning at boot and
+    `test_noop_notification_client_disabled_warning_emitted_once` observed zero
+    instead of one. `bootstrap.py` warns about exactly this for the database
+    provider; the notifier has the same hazard plus a side effect.
+    """
+    resolved: list[int] = []
+    notifier = _RecordingNotifier()
+
+    def provider():
+        resolved.append(1)
+        return notifier
+
+    logger = AuditLogger(_ExplodingRepository(RuntimeError("db down")), provider)
+    assert resolved == [], "provider was resolved at construction time"
+
+    with capture_logs():
+        await logger.log(
+            action=AdminAction.LOGIN, domain="auth", result=AuditResult.SUCCESS
+        )
+
+    assert resolved == [1]
+    assert len(notifier.dispatched) == 1


### PR DESCRIPTION
Closes #348. ADR: [057](docs/history/057-audit-actor-correlation-only.md).

`admin_audit_log.admin_user_id` carried `ForeignKey("user.id", ondelete="SET NULL")`
from `0007`, but since ADR 049 / #218 the value written there is an
`admin_identity.id`. On PostgreSQL and MySQL every authenticated admin action
failed the constraint and `AdminAuditLogger` swallowed it, so **the audit trail
recorded rejected logins and nothing else** — with no signal that anything was
missing.

Found by the PostgreSQL CI leg from #333, three days after it went in.

## Why the constraint was dropped and not repointed

The owner's instinct was to keep a relational constraint, which is usually
right. Two verified facts ruled it out.

**1. It can certify a falsehood.** `0009` copies admins with
`SELECT id, username, ... FROM "user" WHERE role = 'admin'` — preserving ids —
then advances only `admin_identity`'s sequence:

```sql
SELECT setval(pg_get_serial_sequence('admin_identity', 'id'), ...)
```

`user`'s sequence is untouched, so the two id spaces overlap. A constraint
against *either* table can be satisfied by the wrong row, recording that a
customer performed an admin action. Not hypothetical: the first version of
`test_audit_actor_fk.py` had to pin `_PROBE_ADMIN_ID = 900_001` because an
earlier test's `user` row satisfied the constraint.

**2. It breaks a documented extension point.** §17 IC-218-7 sanctions pointing
"the `admin_identity` repository at a separate database URL — no core change
required". Cross-database foreign keys do not exist, and `admin_audit_log` is
owned by `_core`. It would also be the only `_core`-owned FK in the tree.

The textbook answer — immutable actor dimension, `NO ACTION`, tombstones instead
of physical deletes — is recorded in ADR 057 as the deferred long-term shape,
not dismissed. It needs soft-delete plumbing through `delete_account`,
`count_accounts_permission_holders`, credential verification, `has_real_admin`
and the accounts UI, and it does not solve either fact above.

## What replaces the constraint

A FK asserted "this id exists somewhere" at write time and paid for it by being
able to reject — and, given the swallow, silently lose — the event. Integrity
moves to where it cannot destroy evidence:

- **Read-side reconciliation.** `test_audit_actor_fk.py` asserts a stored actor
  id resolves through the `admin_identity` repository — the access path §17
  IC-218-1 mandates — and does not collide with a `user` row. Its `xfail` is
  gone; these are positive assertions on both engines.
- **A schema comment**, so the next reader learns the semantics from the DDL:
  `admin_identity.id`, realm-scoped, correlation-only, never join to `user`.

## The swallow, which is the other half of this bug

The failure path still never raises — locking an operator out of the dashboard
over an audit hiccup is worse. But it stops being invisible. It previously logged
at `warning` with `action`/`domain`/`result`/`error_type` and claimed in its own
comment that the dropped event was "reconstructable from these non-sensitive
fields" while omitting the actor and the target. **That claim was false**, and it
is why a wrong foreign key went unnoticed for two releases.

Now: `error` level, with `admin_username` / `admin_user_id` / `record_id`
(`before_state` / `after_state` / `failure_reason` still excluded as unvetted), a
distinct `audit_write_rejected_by_constraint` event keyed off the
`DB_INTEGRITY_ERROR` code `Database.session()` translates `IntegrityError` into,
and a dispatch through `ErrorNotifier` at severity 500.

`bootstrap_admin` passes the container **provider**, not a resolved notifier.
Resolving eagerly builds the shared `_noop_notification_client` Singleton, which
logs its one-time `notification_client_disabled` from `__init__` — so the eager
version consumed that warning at boot and
`test_noop_notification_client_disabled_warning_emitted_once` saw zero instead of
one. `bootstrap.py` already warns about this for the database provider; I
reproduced the mistake it documents.

## Two things cross-review caught

**The sqlite rebuild silently dropped all four indexes.** `batch_alter_table`
rebuilds from `copy_from` metadata, so anything not declared there is lost. I had
already reported the sqlite path as verified — I had only checked that the
`FOREIGN KEY` was gone, not what else went with it. `sqlite_master` before/after:

```
0009 -> idx_audit_created_at, idx_audit_user_created,
        idx_audit_action_created, idx_audit_domain_created
0010 -> []
```

**The sqlite downgrade was not a downgrade** — it removed the comment and
returned, leaving the constraint dropped.

Also: the notifier-failure log used `exc_info=True`. The notifier is duck-typed,
so its exceptions can carry the webhook URL; `ErrorNotifier._safe_send` records
`exc_type` only for exactly this reason (security-checklist §13), and this now
matches.

## Verification

Migration round-tripped on both engines:

```
postgres  0009 FK=1 idx=4 | 0010 FK=0 idx=4 | down FK=1 idx=4 | re-up FK=0 idx=4
sqlite    0009 FK=1 idx=4 | 0010 FK=0 idx=4 | down FK=1 idx=4 | re-up FK=0 idx=4
```

sqlite column count 13 throughout; the PostgreSQL column comment reads back
correctly.

| | |
|---|---|
| SQLite full suite | **1812 passed, 42 skipped** |
| PostgreSQL full suite | **1812 passed, 42 skipped** |
| `uv run pyright` | 0 errors |
| `check_migration_safety.py` | 0 advisories |
| `pre-commit run --all-files` | clean |

## Out of scope

- **#351** (filed): the broker-factory test asserting the uninstalled path never
  simulates it, so it fails whenever the `rabbitmq` extra is installed — which
  the shipped image and the new `typecheck` job now both do. Pre-existing;
  reproduced on `main`.
- ADR 057 G4 records the tombstone design as the preferred long-term shape if
  admin deletion semantics are revisited.

## Governor Footer
- trigger: yes
- reviewer: codex-cli
- rounds: 1
- r-points-fixed: 3
- r-points-deferred: 0
- r-points-rejected: 0
- touched-adr-consequences: ADR057-G1, ADR057-G2, ADR057-G3, ADR057-G4
- pr-scope-notes: drop the admin-audit actor FK (ADR 057), move integrity to the read path, and make the swallowed audit-write failure loud
- final-verdict: merge-ready
- links: https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/352, n/a
