### PR TITLE
fix(vectors): enforce the vector store contract at boot and at query time (#328)

### DIFF
--- a/src/_core/config.py
+++ b/src/_core/config.py
@@ -18,6 +18,11 @@ KNOWN_EMBEDDING_PROVIDERS = (
 KNOWN_STORAGE_TYPES = ("s3", "minio")
 KNOWN_LLM_PROVIDERS = ("openai", "anthropic", "bedrock")
 KNOWN_NOTIFICATION_PROVIDERS = ("slack", "discord")
+# The only Selector key that had no tuple and no boot check until #328.
+# `s3` is the natural typo — it is the correct spelling for STORAGE_TYPE —
+# and it used to boot clean in prod, then 500 on the first docs request
+# with `Selector has no "s3" provider`.
+KNOWN_VECTOR_STORE_TYPES = ("inmemory", "s3vectors")
 STRICT_ENVS = frozenset({"stg", "prod"})
 
 _OPENAI_DIMENSIONS: dict[str, int] = {
@@ -686,6 +691,13 @@ class Settings(BaseSettings):
                 f"[storage_type] Unknown storage type '{self.storage_type}'. "
                 f"Expected one of: {', '.join(KNOWN_STORAGE_TYPES)}"
             )
+        vector_store = (self.vector_store_type or "").lower().strip()
+        if vector_store and vector_store not in KNOWN_VECTOR_STORE_TYPES:
+            errors.append(
+                f"[vector_store_type] Unknown vector store "
+                f"'{self.vector_store_type}'. "
+                f"Expected one of: {', '.join(KNOWN_VECTOR_STORE_TYPES)}"
+            )
         if storage == "s3" and s3_set != set(s3_fields):
             missing = sorted(set(s3_fields) - s3_set)
             errors.append(
@@ -718,6 +730,19 @@ class Settings(BaseSettings):
             "s3vectors_bucket_name": self.s3vectors_bucket_name,
         }
         s3vectors_set = {k for k, v in s3vectors_fields.items() if v is not None}
+
+        # Couple the selector to the credential group it actually needs. The
+        # s3vectors branch injects core_container.s3vector_client, whose own
+        # Selector is gated on s3vectors_access_key — a different field — so
+        # without this the two disagree and the docs domain receives a store
+        # with s3vector_client=None that raises AttributeError per request.
+        if vector_store == "s3vectors" and s3vectors_set != set(s3vectors_fields):
+            missing = sorted(set(s3vectors_fields) - s3vectors_set)
+            errors.append(
+                f"[S3Vectors] VECTOR_STORE_TYPE=s3vectors requires: "
+                f"{', '.join(missing)} missing"
+            )
+
         if s3vectors_set and s3vectors_set != set(s3vectors_fields):
             missing = sorted(set(s3vectors_fields) - s3vectors_set)
             errors.append(

--- a/src/_core/config.py
+++ b/src/_core/config.py
@@ -743,7 +743,14 @@ class Settings(BaseSettings):
                 f"{', '.join(missing)} missing"
             )
 
-        if s3vectors_set and s3vectors_set != set(s3vectors_fields):
+        # Skipped when the selector-specific error above already fired: the two
+        # describe the same missing values, and one cause should not produce two
+        # messages for an operator to reconcile.
+        if (
+            vector_store != "s3vectors"
+            and s3vectors_set
+            and s3vectors_set != set(s3vectors_fields)
+        ):
             missing = sorted(set(s3vectors_fields) - s3vectors_set)
             errors.append(
                 f"[S3Vectors] Partial configuration: "

--- a/src/_core/domain/value_objects/vector_query.py
+++ b/src/_core/domain/value_objects/vector_query.py
@@ -11,9 +11,19 @@ class VectorQuery(ValueObject):
     ``DynamoKey`` counterpart — encapsulates search parameters.
 
     ``filters`` follows S3 Vectors native filter syntax:
-    - Equality: ``{"category": "tech"}``
+    - Equality: ``{"category": "tech"}`` or ``{"category": {"$eq": "tech"}}``
+    - Membership: ``{"category": {"$in": ["tech", "sci"]}}``
+    - Negation: ``{"category": {"$ne": "tech"}}``
     - Comparison: ``{"year": {"$gte": 2020}}``
     - Compound: ``{"$and": [{"category": "tech"}, {"year": {"$gte": 2020}}]}``
+
+    **Backend support is not uniform.** The in-memory store implements only the
+    equality / membership / negation subset above and raises
+    ``NotImplementedError`` for comparison and compound operators — it does not
+    silently ignore them (#328 F10). Since ``inmemory`` is the default whenever
+    ``VECTOR_STORE_TYPE`` is unset, code written against the full syntax will
+    fail loudly on the default backend rather than returning unfiltered results.
+    Check the concrete store before relying on an operator outside the subset.
     """
 
     vector: list[float]

--- a/src/_core/infrastructure/vectors/in_memory/base_store.py
+++ b/src/_core/infrastructure/vectors/in_memory/base_store.py
@@ -21,8 +21,12 @@ class BaseInMemoryVectorStore(Generic[ReturnDTO], ABC):
     demos, unit tests, and zero-config local development. Vectors live
     in a plain dict and are lost on process restart.
 
-    Filter semantics support the S3 Vectors ``$eq`` / ``$in`` subset
-    so domain code written against the S3 backend remains portable.
+    Filter semantics support the S3 Vectors ``$eq`` / ``$in`` / ``$ne``
+    subset so domain code written against the S3 backend remains
+    portable. Operators outside that subset — ``$gte``, ``$lt``,
+    ``$and`` and friends — raise ``NotImplementedError`` rather than
+    being ignored; see ``_matches_filters`` for why the previous silent
+    behaviour was unsafe in both directions (#328 F10).
     """
 
     def __init__(
@@ -79,10 +83,47 @@ class BaseInMemoryVectorStore(Generic[ReturnDTO], ABC):
         return True
 
 
+# The operator subset this store implements, matching the S3 Vectors subset the
+# class docstring promises. Deliberately not extended: making the stand-in more
+# capable than the backend it stands in for is how portable domain code stops
+# being portable.
+_SUPPORTED_OPERATORS = frozenset({"$eq", "$in", "$ne"})
+
+
 def _matches_filters(metadata: dict[str, Any], filters: dict[str, Any]) -> bool:
+    """Evaluate a `VectorQuery.filters` mapping against one record's metadata.
+
+    Raises ``NotImplementedError`` for anything outside
+    :data:`_SUPPORTED_OPERATORS` rather than ignoring it (#328 F10). The two
+    silent behaviours this replaces went in opposite directions and the
+    fail-open one is the dangerous half:
+
+    - ``{"year": {"$gte": 2020}}`` fell through every branch and the loop
+      continued to ``return True`` — an unsupported operator silently
+      *discarded*, so a tenant or ACL filter written against the documented
+      ``VectorQuery`` contract returned other tenants' rows.
+    - ``{"$and": [...]}`` is not a dict-valued *field* condition, so it took the
+      bare-equality branch, compared ``metadata.get("$and")`` (None) against a
+      list, and matched nothing at all.
+    """
     for field, condition in filters.items():
+        if field.startswith("$"):
+            # Compound/top-level operators ($and, $or, $not). Not field names,
+            # so the bare-equality branch below would silently match nothing.
+            raise NotImplementedError(
+                f"In-memory vector store does not support the compound operator "
+                f"'{field}'; supported field operators: "
+                f"{sorted(_SUPPORTED_OPERATORS)}"
+            )
         value = metadata.get(field)
         if isinstance(condition, dict):
+            unsupported = set(condition) - _SUPPORTED_OPERATORS
+            if unsupported:
+                raise NotImplementedError(
+                    f"In-memory vector store does not support "
+                    f"{sorted(unsupported)} on field '{field}'; supported: "
+                    f"{sorted(_SUPPORTED_OPERATORS)}"
+                )
             if "$eq" in condition and value != condition["$eq"]:
                 return False
             if "$in" in condition and value not in condition["$in"]:

--- a/src/_core/infrastructure/vectors/in_memory/base_store.py
+++ b/src/_core/infrastructure/vectors/in_memory/base_store.py
@@ -9,6 +9,9 @@ from pydantic import BaseModel
 
 from src._core.domain.value_objects.vector_query import VectorQuery
 from src._core.domain.value_objects.vector_search_result import VectorSearchResult
+from src._core.infrastructure.vectors.in_memory.exceptions import (
+    VectorFilterUnsupportedException,
+)
 from src._core.infrastructure.vectors.vector_model import VectorModel
 
 ReturnDTO = TypeVar("ReturnDTO", bound=BaseModel)
@@ -54,6 +57,10 @@ class BaseInMemoryVectorStore(Generic[ReturnDTO], ABC):
         return len(entities)
 
     async def search(self, query: VectorQuery) -> VectorSearchResult[ReturnDTO]:
+        # Before the scan, so the rejection does not depend on how many records
+        # happen to be stored or on which condition eliminates them first.
+        validate_filters(query.filters)
+
         scored: list[tuple[float, dict[str, Any]]] = []
         for record in self._store.values():
             if query.filters and not _matches_filters(
@@ -83,47 +90,58 @@ class BaseInMemoryVectorStore(Generic[ReturnDTO], ABC):
         return True
 
 
-# The operator subset this store implements, matching the S3 Vectors subset the
-# class docstring promises. Deliberately not extended: making the stand-in more
-# capable than the backend it stands in for is how portable domain code stops
-# being portable.
+# The operator subset this store implements. S3 Vectors itself supports
+# $eq/$ne/$gt/$gte/$lt/$lte/$in/$nin/$exists/$and/$or, and this repo's S3 store
+# passes `query.filters` through to `query_vectors` untouched — so the gap here
+# is an unimplemented subset of the backend, not a deliberate ceiling. Widening
+# it is a fine follow-up; silently ignoring what is missing is not.
 _SUPPORTED_OPERATORS = frozenset({"$eq", "$in", "$ne"})
 
 
-def _matches_filters(metadata: dict[str, Any], filters: dict[str, Any]) -> bool:
-    """Evaluate a `VectorQuery.filters` mapping against one record's metadata.
+def validate_filters(filters: dict[str, Any] | None) -> None:
+    """Reject filter operators this store cannot honour, before any scanning.
 
-    Raises ``NotImplementedError`` for anything outside
-    :data:`_SUPPORTED_OPERATORS` rather than ignoring it (#328 F10). The two
-    silent behaviours this replaces went in opposite directions and the
-    fail-open one is the dangerous half:
+    Called once at :meth:`search` entry rather than per record. Inside the
+    record loop the check is data-dependent and therefore not a guarantee: an
+    empty store never evaluates a filter at all, and an earlier condition that
+    eliminates every record short-circuits before a later unsupported operator
+    is ever seen. ``{"category": "missing", "year": {"$gte": 2020}}`` returned an
+    empty result set instead of raising (#328 F10 follow-up).
 
-    - ``{"year": {"$gte": 2020}}`` fell through every branch and the loop
-      continued to ``return True`` — an unsupported operator silently
-      *discarded*, so a tenant or ACL filter written against the documented
-      ``VectorQuery`` contract returned other tenants' rows.
-    - ``{"$and": [...]}`` is not a dict-valued *field* condition, so it took the
-      bare-equality branch, compared ``metadata.get("$and")`` (None) against a
-      list, and matched nothing at all.
+    Raises :class:`VectorFilterUnsupportedException` (a curated 400), never a
+    bare ``NotImplementedError`` — the filter arrives from a public request body
+    and an untranslated error would surface as a 500.
     """
+    if not filters:
+        return
+    supported = sorted(_SUPPORTED_OPERATORS)
     for field, condition in filters.items():
         if field.startswith("$"):
-            # Compound/top-level operators ($and, $or, $not). Not field names,
-            # so the bare-equality branch below would silently match nothing.
-            raise NotImplementedError(
-                f"In-memory vector store does not support the compound operator "
-                f"'{field}'; supported field operators: "
-                f"{sorted(_SUPPORTED_OPERATORS)}"
-            )
-        value = metadata.get(field)
+            # Compound/top-level operators ($and, $or, $not) are not field
+            # names, so the bare-equality branch would compare None against a
+            # list and silently match nothing.
+            raise VectorFilterUnsupportedException([field], supported)
         if isinstance(condition, dict):
             unsupported = set(condition) - _SUPPORTED_OPERATORS
             if unsupported:
-                raise NotImplementedError(
-                    f"In-memory vector store does not support "
-                    f"{sorted(unsupported)} on field '{field}'; supported: "
-                    f"{sorted(_SUPPORTED_OPERATORS)}"
+                raise VectorFilterUnsupportedException(
+                    sorted(unsupported), supported, field=field
                 )
+
+
+def _matches_filters(metadata: dict[str, Any], filters: dict[str, Any]) -> bool:
+    """Evaluate a validated filter mapping against one record's metadata.
+
+    Assumes :func:`validate_filters` has already run — it handles only the
+    supported subset and does not re-check. The two silent behaviours this
+    replaced went in opposite directions, and the fail-open one was the
+    dangerous half: an unsupported operator was *discarded*, so a tenant or ACL
+    filter written against the documented ``VectorQuery`` contract returned
+    other tenants' rows.
+    """
+    for field, condition in filters.items():
+        value = metadata.get(field)
+        if isinstance(condition, dict):
             if "$eq" in condition and value != condition["$eq"]:
                 return False
             if "$in" in condition and value not in condition["$in"]:

--- a/src/_core/infrastructure/vectors/in_memory/exceptions.py
+++ b/src/_core/infrastructure/vectors/in_memory/exceptions.py
@@ -1,0 +1,39 @@
+from src._core.exceptions.base_exception import BaseCustomException
+
+
+class InMemoryVectorException(BaseCustomException):
+    """Base exception for the in-memory vector store."""
+
+    pass
+
+
+class VectorFilterUnsupportedException(InMemoryVectorException):
+    """A filter operator this backend does not implement (#328 F10).
+
+    A curated 400 rather than a bare ``NotImplementedError``. The filter dict
+    reaches the store straight from ``POST /v1/docs/query`` (`QueryRequest.filters`
+    is an open ``dict[str, Any]`` described as "S3-Vectors-compatible"), so an
+    untranslated exception becomes a generic 500 — and a filter that is valid
+    against the S3 backend would then return 200 or 500 depending purely on which
+    backend the deployment selected.
+
+    400, not 5xx: the request is the actionable thing, the caller can change the
+    filter, and a 5xx would also page an operator through ``ErrorNotifier``
+    (severity threshold 500) for what is a client-side capability mismatch.
+
+    ``details`` carries the offending operators and the supported subset so the
+    caller learns what to send instead without reading the source.
+    """
+
+    def __init__(
+        self, unsupported: list[str], supported: list[str], field: str | None = None
+    ):
+        target = f" on field '{field}'" if field else ""
+        super().__init__(
+            status_code=400,
+            message=(
+                f"In-memory vector store does not support "
+                f"{sorted(unsupported)}{target}. Supported: {sorted(supported)}"
+            ),
+            error_code="VECTOR_FILTER_UNSUPPORTED",
+        )

--- a/tests/unit/_core/infrastructure/vectors/test_in_memory_filters.py
+++ b/tests/unit/_core/infrastructure/vectors/test_in_memory_filters.py
@@ -19,17 +19,36 @@ tenant or ACL scoping against it would get unfiltered results on the default
 backend, with no error. `inmemory` is the default whenever `VECTOR_STORE_TYPE`
 is unset, including in prod.
 
-The fix is to be loud, not to implement the operators: `NotImplementedError`
-names what is unsupported. Implementing `$gte`/`$and` here would make the
-in-memory store *more* capable than the S3 Vectors backend it exists to stand in
-for, which is the portability the class docstring promises.
+The fix is to be loud, not to implement the operators. That is a scope choice,
+not a ceiling: S3 Vectors supports
+`$eq/$ne/$gt/$gte/$lt/$lte/$in/$nin/$exists/$and/$or`, and this repo's S3 store
+passes `query.filters` through to `query_vectors` untouched — so the in-memory
+store implements 3 of 11 and is the *less* capable backend. Widening it later is
+fine; silently discarding what is missing is not.
+
+Two things the first attempt got wrong, both caught in review:
+
+- The check lived inside the per-record loop, so "fails loudly" depended on the
+  data. An empty store never evaluates a filter, and an earlier condition that
+  eliminates every record short-circuits before a later unsupported operator is
+  reached. Validation now runs once at `search()` entry.
+- It raised `NotImplementedError`, which the generic handler turns into a 500 on
+  the public `POST /v1/docs/query`. It is now a curated 400
+  (`VECTOR_FILTER_UNSUPPORTED`), so a filter valid against the S3 backend does
+  not become a server error purely because of which backend is deployed.
 """
 
 from __future__ import annotations
 
 import pytest
 
-from src._core.infrastructure.vectors.in_memory.base_store import _matches_filters
+from src._core.infrastructure.vectors.in_memory.base_store import (
+    _matches_filters,
+    validate_filters,
+)
+from src._core.infrastructure.vectors.in_memory.exceptions import (
+    VectorFilterUnsupportedException,
+)
 
 _METADATA = {"category": "tech", "year": 2015, "tenant": "acme"}
 
@@ -66,15 +85,15 @@ class TestUnsupportedOperatorsAreLoud:
         self, operator: str
     ) -> None:
         # Previously: returned True for year=2015 against {"$gte": 2020}.
-        with pytest.raises(NotImplementedError) as exc:
-            _matches_filters(_METADATA, {"year": {operator: 2020}})
+        with pytest.raises(VectorFilterUnsupportedException) as exc:
+            validate_filters({"year": {operator: 2020}})
 
         assert operator in str(exc.value)
         assert "year" in str(exc.value)
 
     def test_the_error_names_what_is_supported(self) -> None:
-        with pytest.raises(NotImplementedError) as exc:
-            _matches_filters(_METADATA, {"year": {"$gte": 2020}})
+        with pytest.raises(VectorFilterUnsupportedException) as exc:
+            validate_filters({"year": {"$gte": 2020}})
 
         message = str(exc.value)
         for supported in ("$eq", "$in", "$ne"):
@@ -83,8 +102,8 @@ class TestUnsupportedOperatorsAreLoud:
     def test_a_supported_operator_beside_an_unsupported_one_still_raises(self) -> None:
         # Silently honouring the half it understands is the same fail-open bug
         # wearing a disguise.
-        with pytest.raises(NotImplementedError):
-            _matches_filters(_METADATA, {"year": {"$eq": 2015, "$gte": 2020}})
+        with pytest.raises(VectorFilterUnsupportedException):
+            validate_filters({"year": {"$eq": 2015, "$gte": 2020}})
 
     @pytest.mark.parametrize("operator", ["$and", "$or", "$not"])
     def test_compound_operators_raise_instead_of_matching_nothing(
@@ -93,10 +112,8 @@ class TestUnsupportedOperatorsAreLoud:
         # Previously: {"$and": [...]} took the bare-equality branch, compared
         # None against a list, and matched nothing — a filter that silently
         # empties every result set.
-        with pytest.raises(NotImplementedError) as exc:
-            _matches_filters(
-                _METADATA, {operator: [{"category": "tech"}, {"year": 2015}]}
-            )
+        with pytest.raises(VectorFilterUnsupportedException) as exc:
+            validate_filters({operator: [{"category": "tech"}, {"year": 2015}]})
 
         assert operator in str(exc.value)
 
@@ -108,9 +125,83 @@ class TestFailureDirection:
         A tenant-scoping filter that is silently dropped returns other tenants'
         rows. Raising is acceptable; matching more than asked is not.
         """
-        with pytest.raises(NotImplementedError):
-            _matches_filters(_METADATA, {"tenant": {"$gte": "zzz"}})
+        with pytest.raises(VectorFilterUnsupportedException):
+            validate_filters({"tenant": {"$gte": "zzz"}})
 
     def test_an_empty_filter_matches(self) -> None:
         # No filter is not an unsupported filter.
         assert _matches_filters(_METADATA, {}) is True
+        validate_filters({})
+        validate_filters(None)
+
+    def test_the_error_is_a_400_not_a_500(self) -> None:
+        # It reaches the store from a public request body; an untranslated
+        # error would surface as INTERNAL_SERVER_ERROR.
+        with pytest.raises(VectorFilterUnsupportedException) as exc:
+            validate_filters({"year": {"$gte": 2020}})
+
+        assert exc.value.status_code == 400
+        assert exc.value.error_code == "VECTOR_FILTER_UNSUPPORTED"
+
+
+class TestSearchLevelGuarantee:
+    """The rejection must not depend on what happens to be stored.
+
+    These are the two shapes that slipped past the first attempt, where the
+    check lived inside the per-record loop.
+    """
+
+    @pytest.fixture
+    def store(self):
+        from pydantic import BaseModel
+
+        from src._core.domain.value_objects.vector_query import VectorQuery
+        from src._core.infrastructure.vectors.in_memory.base_store import (
+            BaseInMemoryVectorStore,
+        )
+
+        class _Meta(BaseModel):
+            category: str = ""
+            year: int = 0
+
+        class _Model:
+            __vector_meta__ = None
+
+        class _Store(BaseInMemoryVectorStore):
+            def _to_model(self, entity):  # pragma: no cover - unused here
+                raise NotImplementedError
+
+        return _Store, _Meta, VectorQuery
+
+    @pytest.mark.asyncio
+    async def test_empty_store_still_rejects(self, store) -> None:
+        # Nothing to iterate, so a per-record check never runs at all.
+        _Store, _Meta, VectorQuery = store
+        subject = _Store(model=object, return_entity=_Meta)
+
+        with pytest.raises(VectorFilterUnsupportedException):
+            await subject.search(
+                VectorQuery(vector=[0.1, 0.2], filters={"year": {"$gte": 2020}})
+            )
+
+    @pytest.mark.asyncio
+    async def test_rejects_even_when_an_earlier_condition_excludes_everything(
+        self, store
+    ) -> None:
+        # `category: missing` eliminates every record before the loop reaches
+        # `$gte`, so the per-record check short-circuited and returned an empty
+        # result set instead of raising.
+        _Store, _Meta, VectorQuery = store
+        subject = _Store(model=object, return_entity=_Meta)
+        subject._store["a"] = {
+            "vector": [0.1, 0.2],
+            "metadata": {"category": "tech", "year": 2015},
+        }
+
+        with pytest.raises(VectorFilterUnsupportedException):
+            await subject.search(
+                VectorQuery(
+                    vector=[0.1, 0.2],
+                    filters={"category": "missing", "year": {"$gte": 2020}},
+                )
+            )

--- a/tests/unit/_core/infrastructure/vectors/test_in_memory_filters.py
+++ b/tests/unit/_core/infrastructure/vectors/test_in_memory_filters.py
@@ -1,0 +1,116 @@
+"""In-memory vector filter semantics (#328 F10).
+
+`_matches_filters` handled `$eq`, `$in`, `$ne` and bare equality. Anything else
+fell through every branch and the loop continued to `return True`, so an
+unsupported operator was **silently discarded**:
+
+    {"year": {"$gte": 2020}} matched a record with year=2015     # fails OPEN
+
+A top-level `$and` is not a dict-valued *field* condition, so it took the bare
+equality branch, compared `metadata.get("$and")` (None) against a list, and
+matched nothing:
+
+    {"$and": [...]} matched no record at all                     # fails CLOSED
+
+Fail-open is the dangerous direction. `VectorQuery`'s docstring — the shared VO
+both backends consume — advertises `{"year": {"$gte": 2020}}` and `{"$and": [...]}`
+as *the* filter contract with no backend qualification, so a consumer writing
+tenant or ACL scoping against it would get unfiltered results on the default
+backend, with no error. `inmemory` is the default whenever `VECTOR_STORE_TYPE`
+is unset, including in prod.
+
+The fix is to be loud, not to implement the operators: `NotImplementedError`
+names what is unsupported. Implementing `$gte`/`$and` here would make the
+in-memory store *more* capable than the S3 Vectors backend it exists to stand in
+for, which is the portability the class docstring promises.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src._core.infrastructure.vectors.in_memory.base_store import _matches_filters
+
+_METADATA = {"category": "tech", "year": 2015, "tenant": "acme"}
+
+
+class TestSupportedOperators:
+    def test_bare_equality_matches(self) -> None:
+        assert _matches_filters(_METADATA, {"category": "tech"}) is True
+
+    def test_bare_equality_rejects(self) -> None:
+        assert _matches_filters(_METADATA, {"category": "sci"}) is False
+
+    def test_eq(self) -> None:
+        assert _matches_filters(_METADATA, {"category": {"$eq": "tech"}}) is True
+        assert _matches_filters(_METADATA, {"category": {"$eq": "sci"}}) is False
+
+    def test_in(self) -> None:
+        assert (
+            _matches_filters(_METADATA, {"category": {"$in": ["tech", "sci"]}}) is True
+        )
+        assert _matches_filters(_METADATA, {"category": {"$in": ["sci"]}}) is False
+
+    def test_ne(self) -> None:
+        assert _matches_filters(_METADATA, {"category": {"$ne": "tech"}}) is False
+        assert _matches_filters(_METADATA, {"category": {"$ne": "sci"}}) is True
+
+    def test_multiple_fields_are_conjunctive(self) -> None:
+        assert _matches_filters(_METADATA, {"category": "tech", "year": 2015}) is True
+        assert _matches_filters(_METADATA, {"category": "tech", "year": 2020}) is False
+
+
+class TestUnsupportedOperatorsAreLoud:
+    @pytest.mark.parametrize("operator", ["$gte", "$gt", "$lte", "$lt"])
+    def test_comparison_operators_raise_instead_of_matching_everything(
+        self, operator: str
+    ) -> None:
+        # Previously: returned True for year=2015 against {"$gte": 2020}.
+        with pytest.raises(NotImplementedError) as exc:
+            _matches_filters(_METADATA, {"year": {operator: 2020}})
+
+        assert operator in str(exc.value)
+        assert "year" in str(exc.value)
+
+    def test_the_error_names_what_is_supported(self) -> None:
+        with pytest.raises(NotImplementedError) as exc:
+            _matches_filters(_METADATA, {"year": {"$gte": 2020}})
+
+        message = str(exc.value)
+        for supported in ("$eq", "$in", "$ne"):
+            assert supported in message
+
+    def test_a_supported_operator_beside_an_unsupported_one_still_raises(self) -> None:
+        # Silently honouring the half it understands is the same fail-open bug
+        # wearing a disguise.
+        with pytest.raises(NotImplementedError):
+            _matches_filters(_METADATA, {"year": {"$eq": 2015, "$gte": 2020}})
+
+    @pytest.mark.parametrize("operator", ["$and", "$or", "$not"])
+    def test_compound_operators_raise_instead_of_matching_nothing(
+        self, operator: str
+    ) -> None:
+        # Previously: {"$and": [...]} took the bare-equality branch, compared
+        # None against a list, and matched nothing — a filter that silently
+        # empties every result set.
+        with pytest.raises(NotImplementedError) as exc:
+            _matches_filters(
+                _METADATA, {operator: [{"category": "tech"}, {"year": 2015}]}
+            )
+
+        assert operator in str(exc.value)
+
+
+class TestFailureDirection:
+    def test_an_unsupported_filter_never_widens_a_result_set(self) -> None:
+        """The property that matters, stated directly.
+
+        A tenant-scoping filter that is silently dropped returns other tenants'
+        rows. Raising is acceptable; matching more than asked is not.
+        """
+        with pytest.raises(NotImplementedError):
+            _matches_filters(_METADATA, {"tenant": {"$gte": "zzz"}})
+
+    def test_an_empty_filter_matches(self) -> None:
+        # No filter is not an unsupported filter.
+        assert _matches_filters(_METADATA, {}) is True

--- a/tests/unit/_core/test_config_vector_store.py
+++ b/tests/unit/_core/test_config_vector_store.py
@@ -1,0 +1,131 @@
+"""`VECTOR_STORE_TYPE` boot validation (#328 F8).
+
+It was the only Selector key with no allowed-value tuple and no boot check.
+`config.py` declares `KNOWN_ENVS`, `KNOWN_ENGINES`, `KNOWN_BROKER_TYPES`,
+`KNOWN_STORAGE_TYPES`, `KNOWN_LLM_PROVIDERS`, `KNOWN_EMBEDDING_PROVIDERS` and
+`KNOWN_NOTIFICATION_PROVIDERS`, each with a matching validator — there was no
+vector-store tuple.
+
+Two silent misconfigurations followed, both verified before the fix:
+
+- `VECTOR_STORE_TYPE=s3` — the natural typo, since `s3` is the correct spelling
+  for `STORAGE_TYPE` in every env example — booted clean in **prod** and raised
+  `Selector has no "s3" provider` on the first docs request. A 500 in traffic
+  instead of a boot failure.
+- `VECTOR_STORE_TYPE=s3vectors` with no credentials booted clean and handed the
+  docs domain a `DocumentChunkS3VectorStore(s3vector_client=None, bucket_name='')`,
+  so every ingest and query raised `AttributeError` against `None`.
+
+The second is the coupling half: the `s3vectors` branch injects
+`core_container.s3vector_client`, whose own Selector is gated on
+`settings.s3vectors_access_key` — a *different* field — so the two selectors
+could disagree.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+_BASE = {
+    "ENV": "local",
+    "DATABASE_ENGINE": "sqlite",
+    "DATABASE_NAME": ":memory:",
+    "DATABASE_USER": "u",
+    "DATABASE_PASSWORD": "p",
+    "DATABASE_HOST": "h",
+    "DATABASE_PORT": "0",
+}
+
+_S3VECTORS_CREDENTIALS = {
+    "S3VECTORS_REGION": "ap-northeast-2",
+    "S3VECTORS_ACCESS_KEY": "key",
+    "S3VECTORS_SECRET_KEY": "secret",
+    "S3VECTORS_BUCKET_NAME": "bucket",
+}
+
+
+def _settings(**env: str):
+    from src._core.config import Settings
+
+    with patch.dict(os.environ, {**_BASE, **env}, clear=True):
+        return Settings()
+
+
+class TestKnownValues:
+    def test_unset_is_accepted(self) -> None:
+        # inmemory is the documented default; absence must stay valid.
+        assert _settings().vector_store_type is None
+
+    @pytest.mark.parametrize("value", ["inmemory", "s3vectors"])
+    def test_known_values_are_accepted(self, value: str) -> None:
+        assert (
+            _settings(
+                VECTOR_STORE_TYPE=value, **_S3VECTORS_CREDENTIALS
+            ).vector_store_type
+            == value
+        )
+
+    @pytest.mark.parametrize("value", ["S3Vectors", "  INMEMORY  "])
+    def test_case_and_whitespace_are_tolerated(self, value: str) -> None:
+        # `_vector_store_selector` lowers and strips, so validation must accept
+        # exactly what the selector would.
+        _settings(VECTOR_STORE_TYPE=value, **_S3VECTORS_CREDENTIALS)
+
+    def test_the_s3_typo_is_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="vector_store_type"):
+            _settings(VECTOR_STORE_TYPE="s3")
+
+    def test_the_s3_typo_is_rejected_in_prod_too(self) -> None:
+        # The case that mattered: it used to boot clean here and 500 later.
+        with pytest.raises(ValidationError, match="vector_store_type"):
+            _settings(
+                ENV="prod",
+                VECTOR_STORE_TYPE="s3",
+                DATABASE_ENGINE="postgresql",
+                DATABASE_NAME="d",
+                DATABASE_PORT="5432",
+                JWT_SECRET_KEY="x" * 40,
+                ADMIN_JWT_SECRET_KEY="y" * 40,
+                ADMIN_JWT_AUDIENCE="admin-aud",
+                ADMIN_STORAGE_SECRET="z" * 40,
+                ADMIN_BOOTSTRAP_ENABLED="false",
+                BROKER_TYPE="rabbitmq",
+                RABBITMQ_URL="amqp://x",
+                ALLOW_ORIGINS='["https://app.example.com"]',
+                ALLOWED_HOSTS='["app.example.com"]',
+            )
+
+
+class TestCredentialCoupling:
+    def test_s3vectors_without_credentials_is_rejected(self) -> None:
+        # Otherwise the docs domain gets a store with s3vector_client=None and
+        # fails at request time instead of boot.
+        with pytest.raises(
+            ValidationError, match="VECTOR_STORE_TYPE=s3vectors requires"
+        ):
+            _settings(VECTOR_STORE_TYPE="s3vectors")
+
+    def test_s3vectors_with_partial_credentials_is_rejected(self) -> None:
+        with pytest.raises(
+            ValidationError, match="VECTOR_STORE_TYPE=s3vectors requires"
+        ):
+            _settings(
+                VECTOR_STORE_TYPE="s3vectors",
+                S3VECTORS_REGION="ap-northeast-2",
+                S3VECTORS_ACCESS_KEY="key",
+            )
+
+    def test_s3vectors_with_full_credentials_is_accepted(self) -> None:
+        assert (
+            _settings(
+                VECTOR_STORE_TYPE="s3vectors", **_S3VECTORS_CREDENTIALS
+            ).vector_store_type
+            == "s3vectors"
+        )
+
+    def test_inmemory_does_not_require_credentials(self) -> None:
+        assert _settings(VECTOR_STORE_TYPE="inmemory").vector_store_type == "inmemory"


### PR DESCRIPTION
Closes #328. Task 2 of the #325–#351 execution packet.

Both findings are the same shape — the vector subsystem promising something it
does not check — one at boot, one at query time.

## F8 — `VECTOR_STORE_TYPE` had no validation and no coupling

It was the only Selector key with neither an allowed-value tuple nor a boot
check, while six siblings (`KNOWN_ENVS`, `KNOWN_ENGINES`, `KNOWN_BROKER_TYPES`,
`KNOWN_STORAGE_TYPES`, `KNOWN_LLM_PROVIDERS`, `KNOWN_EMBEDDING_PROVIDERS`,
`KNOWN_NOTIFICATION_PROVIDERS`) had both. Reproduced before fixing:

```
VECTOR_STORE_TYPE=s3        -> prod BOOT OK, then 'Selector has no "s3" provider'
                               on the first docs request
VECTOR_STORE_TYPE=s3vectors -> boots with DocumentChunkS3VectorStore(
                               s3vector_client=None, bucket_name='')
```

`s3` is the natural typo — it is the correct spelling for `STORAGE_TYPE` in every
env example. The second is a coupling gap: the `s3vectors` branch injects
`core_container.s3vector_client`, whose own Selector is gated on
`s3vectors_access_key`, a *different* field.

Both now fail at boot:

```
[vector_store_type] Unknown vector store 's3'. Expected one of: inmemory, s3vectors
[S3Vectors] VECTOR_STORE_TYPE=s3vectors requires: s3vectors_bucket_name, ... missing
```

## F10 — in-memory filters failed open in one direction, closed in the other

```
$gte 2020 against year=2015   -> True    FAILS OPEN
$lt 2000 against year=2015    -> True    FAILS OPEN
$and [both true]              -> False   FAILS CLOSED
```

Fail-open is the dangerous half: a tenant or ACL filter written against the
documented `VectorQuery` contract returned other tenants' rows, silently, on the
backend that is the default whenever `VECTOR_STORE_TYPE` is unset.

`VectorQuery`'s docstring is why this was reachable — the shared VO both backends
consume advertised `$gte` and `$and` as *the* contract with no backend
qualification. It now states the split, and the store docstring records `$ne`
(implemented but previously undocumented).

## Three things cross-review corrected

**The check was data-dependent.** It lived inside the per-record loop, so an
empty store never evaluated a filter and an earlier condition that eliminated
every record short-circuited before a later unsupported operator was reached —
`{"category": "missing", "year": {"$gte": 2020}}` returned an empty result set
instead of raising. Validation now runs once at `search()` entry, with regression
tests for both shapes.

**`NotImplementedError` surfaced as a 500** on the public `POST /v1/docs/query`,
where `QueryRequest.filters` is an open dict. A filter valid against the S3
backend became a server error purely because of which backend was deployed. Now
a curated 400 (`VECTOR_FILTER_UNSUPPORTED`) — 400 rather than 5xx because the
caller can fix the filter, and a 5xx would also page an operator through
`ErrorNotifier`.

**My reason for not implementing the operators was factually wrong.** I wrote
that widening the in-memory subset would make it "more capable than the S3
Vectors backend". S3 Vectors supports
`$eq/$ne/$gt/$gte/$lt/$lte/$in/$nin/$exists/$and/$or`
([AWS docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-vectors-metadata-filtering.html)),
and this repo's S3 store passes `query.filters` straight to `query_vectors`
untouched — so the in-memory store implements 3 of 11 and is the *less* capable
backend. The comments and test docstring now say that; widening the subset is a
reasonable follow-up, and silently discarding what is missing was the actual bug.

Also folded in: partial `s3vectors` credentials tripped both the new
selector-specific check and the pre-existing partial-configuration check, giving
an operator two messages for one cause. Now one.

## Verification

| | |
|---|---|
| SQLite full suite | **1870 passed, 43 skipped** |
| PostgreSQL full suite | **1870 passed, 43 skipped** |
| `uv run pyright` | 0 errors |
| `pre-commit run --all-files` | clean (migration-safety advisories are pre-existing) |

## Note

No new issues were opened, per the execution packet.
