### PR TITLE
fix(dynamodb): stop batch operations reporting success for refused work (#329)

### DIFF
--- a/src/_core/infrastructure/persistence/nosql/dynamodb/base_dynamo_repository.py
+++ b/src/_core/infrastructure/persistence/nosql/dynamodb/base_dynamo_repository.py
@@ -4,6 +4,7 @@ import asyncio
 import base64
 import binascii
 import json
+import random
 from abc import ABC
 from typing import Any, Generic, TypeVar
 
@@ -23,6 +24,7 @@ from src._core.infrastructure.persistence.nosql.dynamodb.dynamodb_model import (
 from src._core.infrastructure.persistence.nosql.dynamodb.exceptions import (
     DynamoDBBatchIncompleteException,
     DynamoDBInvalidCursorException,
+    DynamoDBInvalidLimitException,
     DynamoDBNotFoundException,
 )
 
@@ -32,6 +34,48 @@ _logger = structlog.stdlib.get_logger(__name__)
 # throughput throttling, so retrying with no wait at all is the case most likely
 # to fail three times in a row.
 _BATCH_BACKOFF_BASE_S = 0.05
+
+# base64url uses - and _ where standard base64 uses + and /.
+_URLSAFE_TO_STANDARD = str.maketrans("-_", "+/")
+
+# DynamoDB AttributeValue type codes. An ExclusiveStartKey is a mapping of
+# attribute name to a single-entry {type_code: value} dict.
+_ATTRIBUTE_TYPE_CODES = frozenset(
+    {"S", "N", "B", "SS", "NS", "BS", "M", "L", "NULL", "BOOL"}
+)
+
+
+def _batch_backoff_delay(attempt: int) -> float:
+    """Exponential backoff with jitter.
+
+    Jitter matters here specifically: UnprocessedItems arrives under throttling,
+    so several concurrent callers back off at the same moment and would
+    otherwise re-collide in lockstep on every retry.
+    """
+    ceiling = _BATCH_BACKOFF_BASE_S * (2**attempt)
+    # noqa S311: retry jitter, not a security decision.
+    return ceiling * (0.5 + random.random() / 2)  # noqa: S311
+
+
+def _is_dynamodb_key_map(value: object) -> bool:
+    """Shape check for an ExclusiveStartKey, not a full type validation.
+
+    Verifies the wire shape botocore expects — attribute name to a single
+    ``{type_code: value}`` entry, with ``S``/``N`` carrying strings. Deeper
+    per-type checking is botocore's job and would drift from it.
+    """
+    if not isinstance(value, dict) or not value:
+        return False
+    for attribute in value.values():
+        if not isinstance(attribute, dict) or len(attribute) != 1:
+            return False
+        ((type_code, inner),) = attribute.items()
+        if type_code not in _ATTRIBUTE_TYPE_CODES:
+            return False
+        if type_code in {"S", "N"} and not isinstance(inner, str):
+            return False
+    return True
+
 
 ReturnDTO = TypeVar("ReturnDTO", bound=BaseModel)
 
@@ -184,10 +228,7 @@ class BaseDynamoRepository(Generic[ReturnDTO], ABC):
         # Limit < 1, so an explicit error beats forwarding an invalid value.
         if limit is not None:
             if limit < 1:
-                raise ValueError(
-                    f"limit must be >= 1 when provided (got {limit}); "
-                    "pass None for an unbounded query"
-                )
+                raise DynamoDBInvalidLimitException(limit)
             params["Limit"] = limit
         if cursor:
             params["ExclusiveStartKey"] = self._decode_cursor(cursor)
@@ -260,7 +301,7 @@ class BaseDynamoRepository(Generic[ReturnDTO], ABC):
                 # which is exactly when immediate un-backed-off retries all fail
                 # together. Skip the wait after the final attempt.
                 if attempt < max_retries - 1:
-                    await asyncio.sleep(_BATCH_BACKOFF_BASE_S * (2**attempt))
+                    await asyncio.sleep(_batch_backoff_delay(attempt))
             else:
                 leftover = len(pending.get(self.table_name, []))
                 _logger.error(
@@ -269,9 +310,7 @@ class BaseDynamoRepository(Generic[ReturnDTO], ABC):
                     unprocessed_count=leftover,
                     max_retries=max_retries,
                 )
-                raise DynamoDBBatchIncompleteException(
-                    "batch_write_item", leftover, self.table_name
-                )
+                raise DynamoDBBatchIncompleteException("batch_write_item", leftover)
 
             results.extend(
                 self.return_entity.model_validate(
@@ -302,7 +341,7 @@ class BaseDynamoRepository(Generic[ReturnDTO], ABC):
                     break
                 pending = unprocessed
                 if attempt < max_retries - 1:
-                    await asyncio.sleep(_BATCH_BACKOFF_BASE_S * (2**attempt))
+                    await asyncio.sleep(_batch_backoff_delay(attempt))
             else:
                 # Raising discards the reads that did succeed in this call. That
                 # is the accepted trade: reads are idempotent and cheap to redo,
@@ -315,9 +354,7 @@ class BaseDynamoRepository(Generic[ReturnDTO], ABC):
                     unprocessed_count=leftover,
                     max_retries=max_retries,
                 )
-                raise DynamoDBBatchIncompleteException(
-                    "batch_get_item", leftover, self.table_name
-                )
+                raise DynamoDBBatchIncompleteException("batch_get_item", leftover)
         return results
 
     # ------------------------------------------------------------------
@@ -374,16 +411,24 @@ class BaseDynamoRepository(Generic[ReturnDTO], ABC):
         already validates; this path had missed it.
         """
         try:
-            decoded = json.loads(base64.urlsafe_b64decode(cursor.encode()))
-        except (
-            binascii.Error,
-            json.JSONDecodeError,
-            UnicodeDecodeError,
-            ValueError,
-        ) as exc:
+            # b64decode(validate=True), not urlsafe_b64decode: the urlsafe
+            # variant takes no validate flag and silently ignores characters
+            # outside the alphabet, so a tampered token like "e30=!!" still
+            # decodes to "{}" and is accepted. Translate the two urlsafe
+            # characters back, then validate.
+            raw = base64.b64decode(
+                cursor.translate(_URLSAFE_TO_STANDARD), validate=True
+            )
+            decoded = json.loads(raw)
+        except (binascii.Error, ValueError) as exc:
+            # json.JSONDecodeError and UnicodeDecodeError both subclass
+            # ValueError; listing them separately would be redundant.
             raise DynamoDBInvalidCursorException() from exc
-        if not isinstance(decoded, dict):
-            # Valid base64 and valid JSON, but not a key mapping — forwarding it
-            # as ExclusiveStartKey would fail inside the AWS call instead.
+        if not _is_dynamodb_key_map(decoded):
+            # Valid base64 and valid JSON is not enough. `{"PK": "x"}` and
+            # `{"PK": {"S": 1}}` used to pass here and fail *inside* the AWS
+            # call as a botocore parameter-validation error, which
+            # DynamoDBClient does not translate — so a malformed token was
+            # still a 500.
             raise DynamoDBInvalidCursorException()
         return decoded

--- a/src/_core/infrastructure/persistence/nosql/dynamodb/base_dynamo_repository.py
+++ b/src/_core/infrastructure/persistence/nosql/dynamodb/base_dynamo_repository.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import asyncio
 import base64
+import binascii
 import json
 from abc import ABC
 from typing import Any, Generic, TypeVar
 
+import structlog
 from pydantic import BaseModel
 
 from src._core.domain.value_objects.cursor_page import CursorPage
@@ -18,8 +21,17 @@ from src._core.infrastructure.persistence.nosql.dynamodb.dynamodb_model import (
     _get_serializer,
 )
 from src._core.infrastructure.persistence.nosql.dynamodb.exceptions import (
+    DynamoDBBatchIncompleteException,
+    DynamoDBInvalidCursorException,
     DynamoDBNotFoundException,
 )
+
+_logger = structlog.stdlib.get_logger(__name__)
+
+# Exponential base for batch retries. DynamoDB returns UnprocessedItems under
+# throughput throttling, so retrying with no wait at all is the case most likely
+# to fail three times in a row.
+_BATCH_BACKOFF_BASE_S = 0.05
 
 ReturnDTO = TypeVar("ReturnDTO", bound=BaseModel)
 
@@ -167,7 +179,15 @@ class BaseDynamoRepository(Generic[ReturnDTO], ABC):
             params["IndexName"] = index_name
         if filter_expression:
             params["FilterExpression"] = filter_expression
-        if limit:
+        # `is not None`, not truthiness: limit=0 is falsy, so the bound used to
+        # be dropped and the query returned a full page. DynamoDB rejects
+        # Limit < 1, so an explicit error beats forwarding an invalid value.
+        if limit is not None:
+            if limit < 1:
+                raise ValueError(
+                    f"limit must be >= 1 when provided (got {limit}); "
+                    "pass None for an unbounded query"
+                )
             params["Limit"] = limit
         if cursor:
             params["ExclusiveStartKey"] = self._decode_cursor(cursor)
@@ -229,13 +249,29 @@ class BaseDynamoRepository(Generic[ReturnDTO], ABC):
             requests = [{"PutRequest": {"Item": item.to_dynamodb()}} for item in chunk]
 
             pending: dict[str, list] = {self.table_name: requests}
-            for _ in range(max_retries):
+            for attempt in range(max_retries):
                 async with self.dynamodb_client.client() as client:
                     response = await client.batch_write_item(RequestItems=pending)
                 unprocessed = response.get("UnprocessedItems", {})
                 if not unprocessed or not unprocessed.get(self.table_name):
                     break
                 pending = unprocessed
+                # DynamoDB returns UnprocessedItems under throughput throttling,
+                # which is exactly when immediate un-backed-off retries all fail
+                # together. Skip the wait after the final attempt.
+                if attempt < max_retries - 1:
+                    await asyncio.sleep(_BATCH_BACKOFF_BASE_S * (2**attempt))
+            else:
+                leftover = len(pending.get(self.table_name, []))
+                _logger.error(
+                    "dynamo_batch_write_unprocessed",
+                    table=self.table_name,
+                    unprocessed_count=leftover,
+                    max_retries=max_retries,
+                )
+                raise DynamoDBBatchIncompleteException(
+                    "batch_write_item", leftover, self.table_name
+                )
 
             results.extend(
                 self.return_entity.model_validate(
@@ -256,7 +292,7 @@ class BaseDynamoRepository(Generic[ReturnDTO], ABC):
             pending_keys = [self._serialize_key(k) for k in chunk]
 
             pending: dict[str, dict] = {self.table_name: {"Keys": pending_keys}}
-            for _ in range(max_retries):
+            for attempt in range(max_retries):
                 async with self.dynamodb_client.client() as client:
                     response = await client.batch_get_item(RequestItems=pending)
                 raw_items = response.get("Responses", {}).get(self.table_name, [])
@@ -265,6 +301,23 @@ class BaseDynamoRepository(Generic[ReturnDTO], ABC):
                 if not unprocessed or not unprocessed.get(self.table_name):
                     break
                 pending = unprocessed
+                if attempt < max_retries - 1:
+                    await asyncio.sleep(_BATCH_BACKOFF_BASE_S * (2**attempt))
+            else:
+                # Raising discards the reads that did succeed in this call. That
+                # is the accepted trade: reads are idempotent and cheap to redo,
+                # while a short list is indistinguishable from "those keys do not
+                # exist" and cannot be detected by the caller at all.
+                leftover = len(pending.get(self.table_name, {}).get("Keys", []))
+                _logger.error(
+                    "dynamo_batch_get_unprocessed",
+                    table=self.table_name,
+                    unprocessed_count=leftover,
+                    max_retries=max_retries,
+                )
+                raise DynamoDBBatchIncompleteException(
+                    "batch_get_item", leftover, self.table_name
+                )
         return results
 
     # ------------------------------------------------------------------
@@ -312,4 +365,25 @@ class BaseDynamoRepository(Generic[ReturnDTO], ABC):
 
     @staticmethod
     def _decode_cursor(cursor: str) -> dict[str, Any]:
-        return json.loads(base64.urlsafe_b64decode(cursor.encode()))
+        """Decode a client-supplied pagination token.
+
+        Guarded because the value comes straight from a query string: an
+        unguarded ``binascii.Error`` / ``JSONDecodeError`` / ``UnicodeDecodeError``
+        escaped as a 500, which is the wrong status and — since #17 — pages an
+        operator for a malformed request. The sibling ``_column_for_field``
+        already validates; this path had missed it.
+        """
+        try:
+            decoded = json.loads(base64.urlsafe_b64decode(cursor.encode()))
+        except (
+            binascii.Error,
+            json.JSONDecodeError,
+            UnicodeDecodeError,
+            ValueError,
+        ) as exc:
+            raise DynamoDBInvalidCursorException() from exc
+        if not isinstance(decoded, dict):
+            # Valid base64 and valid JSON, but not a key mapping — forwarding it
+            # as ExclusiveStartKey would fail inside the AWS call instead.
+            raise DynamoDBInvalidCursorException()
+        return decoded

--- a/src/_core/infrastructure/persistence/nosql/dynamodb/exceptions.py
+++ b/src/_core/infrastructure/persistence/nosql/dynamodb/exceptions.py
@@ -39,8 +39,24 @@ class DynamoDBBatchIncompleteException(DynamoDBException):
 
     Distinct from :class:`DynamoDBThrottlingException` on purpose. Throttling is
     the usual cause of ``UnprocessedItems`` but not the only one, and naming the
-    cause would be a guess; what the caller can act on is *how many* items did
-    not land. 429 is kept because "retry with backoff" is still the right signal.
+    cause would be a guess.
+
+    503, not 429: 429 asserts the *client* is sending too fast, which we do not
+    know. An unprocessed batch after retries is a retryable backend failure of
+    unknown cause, which is what 503 means. It also crosses the
+    ``NOTIFICATION_SEVERITY_THRESHOLD`` (500), so a batch that cannot complete
+    pages an operator — correct here, unlike a client-side capability mismatch.
+
+    The table name is **not** in the message. ``custom_exception_handler``
+    returns the message verbatim to the client, and ``DynamoDBClient``
+    deliberately keeps table and account identifiers out of responses (see its
+    comment on the AWS ``Error.Message`` policy). The name goes to structlog at
+    the raise site instead.
+
+    Note what the count is and is not: it tells a caller *how much* did not land,
+    not *which* items. Identifying them means re-reading or re-submitting the
+    batch; the count exists so the failure is measurable, not so it is
+    individually repairable.
 
     Raised rather than returning a partial result. For writes that is the only
     safe answer — the previous behaviour built a success DTO for every item in
@@ -51,13 +67,12 @@ class DynamoDBBatchIncompleteException(DynamoDBException):
     all.
     """
 
-    def __init__(self, operation: str, unprocessed_count: int, table_name: str = ""):
-        target = f" on table '{table_name}'" if table_name else ""
+    def __init__(self, operation: str, unprocessed_count: int):
         super().__init__(
-            status_code=429,
+            status_code=503,
             message=(
                 f"DynamoDB {operation} left {unprocessed_count} item(s) "
-                f"unprocessed{target} after exhausting retries"
+                "unprocessed after exhausting retries"
             ),
             error_code="DYNAMODB_BATCH_INCOMPLETE",
         )
@@ -76,4 +91,25 @@ class DynamoDBInvalidCursorException(DynamoDBException):
             status_code=400,
             message="Malformed pagination cursor",
             error_code="DYNAMODB_INVALID_CURSOR",
+        )
+
+
+class DynamoDBInvalidLimitException(DynamoDBException):
+    """A pagination bound DynamoDB will not accept (#329 F11).
+
+    ``query_items`` is reachable from adopter request paths, and a bare
+    ``ValueError`` there is turned into ``INTERNAL_SERVER_ERROR`` by the generic
+    handler — a 500 plus an operator page for what is a malformed request. The
+    first fix for F11 made exactly that mistake: it stopped ``limit=0`` from
+    being silently dropped and started returning a 500 instead.
+    """
+
+    def __init__(self, limit: int) -> None:
+        super().__init__(
+            status_code=400,
+            message=(
+                f"limit must be >= 1 when provided (got {limit}); "
+                "omit it for an unbounded query"
+            ),
+            error_code="DYNAMODB_INVALID_LIMIT",
         )

--- a/src/_core/infrastructure/persistence/nosql/dynamodb/exceptions.py
+++ b/src/_core/infrastructure/persistence/nosql/dynamodb/exceptions.py
@@ -32,3 +32,48 @@ class DynamoDBThrottlingException(DynamoDBException):
             message="DynamoDB throughput exceeded",
             error_code="DYNAMODB_THROTTLED",
         )
+
+
+class DynamoDBBatchIncompleteException(DynamoDBException):
+    """A batch finished with items DynamoDB never accepted (#329 F6).
+
+    Distinct from :class:`DynamoDBThrottlingException` on purpose. Throttling is
+    the usual cause of ``UnprocessedItems`` but not the only one, and naming the
+    cause would be a guess; what the caller can act on is *how many* items did
+    not land. 429 is kept because "retry with backoff" is still the right signal.
+
+    Raised rather than returning a partial result. For writes that is the only
+    safe answer — the previous behaviour built a success DTO for every item in
+    the chunk, so a caller committed to writes that were not in the table. For
+    reads it discards successful work in the same call, which is the accepted
+    trade: reads are idempotent and cheap to redo, while a silently short list is
+    indistinguishable from "those keys do not exist" and cannot be detected at
+    all.
+    """
+
+    def __init__(self, operation: str, unprocessed_count: int, table_name: str = ""):
+        target = f" on table '{table_name}'" if table_name else ""
+        super().__init__(
+            status_code=429,
+            message=(
+                f"DynamoDB {operation} left {unprocessed_count} item(s) "
+                f"unprocessed{target} after exhausting retries"
+            ),
+            error_code="DYNAMODB_BATCH_INCOMPLETE",
+        )
+
+
+class DynamoDBInvalidCursorException(DynamoDBException):
+    """A pagination cursor that did not survive decoding (#329).
+
+    The token is client-supplied, so a raw ``binascii.Error`` /
+    ``JSONDecodeError`` / ``UnicodeDecodeError`` escaping as a 500 is both the
+    wrong status and — since #17 — an operator page for a malformed request.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            status_code=400,
+            message="Malformed pagination cursor",
+            error_code="DYNAMODB_INVALID_CURSOR",
+        )

--- a/tests/unit/_core/infrastructure/persistence/nosql/dynamodb/test_batch_semantics.py
+++ b/tests/unit/_core/infrastructure/persistence/nosql/dynamodb/test_batch_semantics.py
@@ -1,0 +1,266 @@
+"""Batch and bound semantics for `BaseDynamoRepository` (#329).
+
+Three fail-open defects, all reachable by any adopter who subclasses the base —
+which is the whole point of a base class shipped in a template.
+
+**F6.** `batch_put_items` retried `UnprocessedItems` up to `max_retries` with no
+backoff and no sleep, then fell through and built a success DTO for *every* item
+in the chunk, including ones DynamoDB explicitly refused. No exception, no log.
+Measured before the fix: 30 entities submitted, 30 DTOs returned, 6
+`batch_write_item` calls, zero backoff, nothing raised. DynamoDB returns
+`UnprocessedItems` precisely under throughput throttling — the case where three
+immediate un-backed-off retries are most likely to all fail. `batch_get_items`
+dropped leftover `UnprocessedKeys`, so the caller got a short list
+indistinguishable from "those keys do not exist".
+
+**F11.** `if limit:` instead of `if limit is not None:` — `limit=0` was silently
+discarded and the query returned a full page. Same failure shape as the vector
+filters in #328: a caller-supplied bound dropped rather than honoured or rejected.
+
+**Cursor.** `_decode_cursor` ran `json.loads(b64decode(...))` on a client-supplied
+token with no guard, so a malformed cursor escaped as a raw `binascii.Error` /
+`JSONDecodeError` — a 500 where a curated 400 belongs, and since #17 a 500 also
+fires a webhook alert.
+
+Decision recorded here because the issue left it open: both batch methods
+**raise** on exhaustion, carrying the unprocessed count, rather than returning a
+partial result. For writes that is the only safe answer. For reads it discards
+successful work in the same call, which is acceptable because reads are
+idempotent and cheap to redo, while a silently short list is not detectable at
+all. The exception is a new `DynamoDBBatchIncompleteException` rather than the
+existing `DynamoDBThrottlingException`: throttling is the usual cause but not the
+only one, and the count is what a caller needs to act.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import ClassVar
+
+import pytest
+from pydantic import BaseModel
+
+from src._core.domain.value_objects.dynamo_key import DynamoKey
+from src._core.infrastructure.persistence.nosql.dynamodb.base_dynamo_repository import (
+    BaseDynamoRepository,
+)
+from src._core.infrastructure.persistence.nosql.dynamodb.dynamodb_model import (
+    DynamoModel,
+    DynamoModelMeta,
+)
+from src._core.infrastructure.persistence.nosql.dynamodb.exceptions import (
+    DynamoDBBatchIncompleteException,
+    DynamoDBException,
+)
+
+
+class _NoteDTO(BaseModel):
+    user_id: str = ""
+    note_id: str = ""
+    title: str = ""
+    content: str = ""
+
+
+class _NoteModel(DynamoModel):
+    __dynamo_meta__: ClassVar[DynamoModelMeta] = DynamoModelMeta(
+        tablename="test_notes",
+        partition_key_name="PK",
+        sort_key_name="SK",
+    )
+
+    user_id: str
+    note_id: str
+    title: str = ""
+    content: str = ""
+
+    def get_partition_key(self) -> str:
+        return "USER#" + self.user_id
+
+    def get_sort_key(self) -> str:
+        return "NOTE#" + self.note_id
+
+
+class _RefusingClient:
+    """Refuses everything, the way a throttled table does."""
+
+    def __init__(self, *, refuse_writes: bool = False, refuse_reads: bool = False):
+        self.refuse_writes = refuse_writes
+        self.refuse_reads = refuse_reads
+        self.write_calls = 0
+        self.read_calls = 0
+        self.query_params: dict | None = None
+
+    async def batch_write_item(self, *, RequestItems: dict, **_kw) -> dict:  # noqa: N803
+        self.write_calls += 1
+        return {"UnprocessedItems": RequestItems if self.refuse_writes else {}}
+
+    async def batch_get_item(self, *, RequestItems: dict, **_kw) -> dict:  # noqa: N803
+        self.read_calls += 1
+        return {
+            "Responses": {},
+            "UnprocessedKeys": RequestItems if self.refuse_reads else {},
+        }
+
+    async def query(self, **params) -> dict:
+        self.query_params = params
+        return {"Items": []}
+
+
+class _FakeDynamoDBClient:
+    def __init__(self, inner: _RefusingClient) -> None:
+        self._inner = inner
+
+    @asynccontextmanager
+    async def client(self):
+        yield self._inner
+
+
+class _NoteRepository(BaseDynamoRepository[_NoteDTO]):
+    def __init__(self, dynamodb_client) -> None:
+        super().__init__(
+            dynamodb_client=dynamodb_client,
+            model=_NoteModel,
+            return_entity=_NoteDTO,
+        )
+
+
+def _repository(inner: _RefusingClient) -> _NoteRepository:
+    return _NoteRepository(dynamodb_client=_FakeDynamoDBClient(inner))
+
+
+def _entities(count: int) -> list[_NoteDTO]:
+    return [_NoteDTO(user_id="u", note_id=str(i), title=f"t{i}") for i in range(count)]
+
+
+class TestBatchPutRefusedWrites:
+    @pytest.mark.asyncio
+    async def test_raises_instead_of_reporting_success(self) -> None:
+        # Previously: 30 entities in, 30 success DTOs out, nothing raised.
+        client = _RefusingClient(refuse_writes=True)
+        repository = _repository(client)
+
+        with pytest.raises(DynamoDBBatchIncompleteException) as exc:
+            await repository.batch_put_items(_entities(30), max_retries=2)
+
+        assert exc.value.status_code == 429
+        assert exc.value.error_code == "DYNAMODB_BATCH_INCOMPLETE"
+
+    @pytest.mark.asyncio
+    async def test_the_error_carries_the_unprocessed_count(self) -> None:
+        client = _RefusingClient(refuse_writes=True)
+
+        with pytest.raises(DynamoDBBatchIncompleteException) as exc:
+            await _repository(client).batch_put_items(_entities(5), max_retries=2)
+
+        # The count is what a caller needs to decide what to re-submit.
+        assert "5" in exc.value.message
+
+    @pytest.mark.asyncio
+    async def test_it_is_a_dynamodb_exception(self) -> None:
+        # So existing `except DynamoDBException` handlers keep working.
+        assert issubclass(DynamoDBBatchIncompleteException, DynamoDBException)
+
+    @pytest.mark.asyncio
+    async def test_a_clean_write_still_returns_dtos(self) -> None:
+        client = _RefusingClient(refuse_writes=False)
+
+        results = await _repository(client).batch_put_items(_entities(30))
+
+        assert len(results) == 30
+        assert client.write_calls == 2  # 25 + 5, one call each, no retries
+
+    @pytest.mark.asyncio
+    async def test_retries_are_bounded_by_max_retries(self) -> None:
+        client = _RefusingClient(refuse_writes=True)
+
+        with pytest.raises(DynamoDBBatchIncompleteException):
+            await _repository(client).batch_put_items(_entities(1), max_retries=3)
+
+        assert client.write_calls == 3
+
+
+class TestBatchGetRefusedKeys:
+    @pytest.mark.asyncio
+    async def test_raises_instead_of_returning_a_short_list(self) -> None:
+        # Previously: 0 items for 1 key, no error — indistinguishable from
+        # "that key does not exist".
+        client = _RefusingClient(refuse_reads=True)
+
+        with pytest.raises(DynamoDBBatchIncompleteException):
+            await _repository(client).batch_get_items(
+                [DynamoKey(partition_key="a")], max_retries=2
+            )
+
+    @pytest.mark.asyncio
+    async def test_a_clean_read_does_not_raise(self) -> None:
+        client = _RefusingClient(refuse_reads=False)
+
+        results = await _repository(client).batch_get_items(
+            [DynamoKey(partition_key="a")]
+        )
+
+        assert results == []
+        assert client.read_calls == 1
+
+
+class TestQueryLimitBound:
+    @pytest.mark.asyncio
+    async def test_limit_zero_is_rejected_not_dropped(self) -> None:
+        # DynamoDB requires Limit >= 1, so forwarding 0 is not an option either.
+        with pytest.raises(ValueError, match="limit"):
+            await _repository(_RefusingClient()).query_items(
+                partition_key_value="a", limit=0
+            )
+
+    @pytest.mark.asyncio
+    async def test_negative_limit_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="limit"):
+            await _repository(_RefusingClient()).query_items(
+                partition_key_value="a", limit=-1
+            )
+
+    @pytest.mark.asyncio
+    async def test_a_positive_limit_is_forwarded(self) -> None:
+        client = _RefusingClient()
+
+        await _repository(client).query_items(partition_key_value="a", limit=7)
+
+        assert client.query_params is not None
+        assert client.query_params["Limit"] == 7
+
+    @pytest.mark.asyncio
+    async def test_none_means_unbounded(self) -> None:
+        client = _RefusingClient()
+
+        await _repository(client).query_items(partition_key_value="a", limit=None)
+
+        assert client.query_params is not None
+        assert "Limit" not in client.query_params
+
+
+class TestCursorGuard:
+    @pytest.mark.parametrize("cursor", ["not-base64!!", "YWJj", "", "eyJhIjog"])
+    def test_a_malformed_cursor_is_a_curated_error(self, cursor: str) -> None:
+        # Raw binascii.Error / JSONDecodeError would surface as a 500 — and
+        # since #17 a 500 also fires a webhook alert.
+        with pytest.raises(DynamoDBException) as exc:
+            BaseDynamoRepository._decode_cursor(cursor)
+
+        assert exc.value.status_code == 400
+
+    def test_a_round_tripped_cursor_still_decodes(self) -> None:
+        key = {"note_id": {"S": "42"}}
+
+        encoded = BaseDynamoRepository._encode_cursor(key)
+
+        assert BaseDynamoRepository._decode_cursor(encoded) == key
+
+    def test_a_json_scalar_is_rejected(self) -> None:
+        # Valid base64 and valid JSON, but not a key mapping — forwarding it as
+        # ExclusiveStartKey would fail inside the AWS call instead.
+        import base64
+
+        encoded = base64.urlsafe_b64encode(b"42").decode()
+
+        with pytest.raises(DynamoDBException):
+            BaseDynamoRepository._decode_cursor(encoded)

--- a/tests/unit/_core/infrastructure/persistence/nosql/dynamodb/test_batch_semantics.py
+++ b/tests/unit/_core/infrastructure/persistence/nosql/dynamodb/test_batch_semantics.py
@@ -51,6 +51,7 @@ from src._core.infrastructure.persistence.nosql.dynamodb.dynamodb_model import (
 from src._core.infrastructure.persistence.nosql.dynamodb.exceptions import (
     DynamoDBBatchIncompleteException,
     DynamoDBException,
+    DynamoDBInvalidLimitException,
 )
 
 
@@ -106,6 +107,44 @@ class _RefusingClient:
         return {"Items": []}
 
 
+class _PartialClient:
+    """Refuses a shrinking slice, the way a recovering table does.
+
+    `_RefusingClient` only models all-or-nothing. DynamoDB's actual response is
+    partial: some items land, the rest come back as UnprocessedItems. That
+    difference is where the accumulate-then-raise logic can go wrong, so it
+    needs its own double.
+    """
+
+    def __init__(self, refuse_rounds: int) -> None:
+        self.refuse_rounds = refuse_rounds
+        self.write_calls = 0
+        self.read_calls = 0
+        self.sleeps: list[float] = []
+
+    async def batch_write_item(self, *, RequestItems: dict, **_kw) -> dict:  # noqa: N803
+        self.write_calls += 1
+        if self.write_calls <= self.refuse_rounds:
+            # Hold back the tail, accept the head.
+            table, requests = next(iter(RequestItems.items()))
+            return {"UnprocessedItems": {table: requests[len(requests) // 2 :]}}
+        return {"UnprocessedItems": {}}
+
+    async def batch_get_item(self, *, RequestItems: dict, **_kw) -> dict:  # noqa: N803
+        self.read_calls += 1
+        if self.read_calls <= self.refuse_rounds:
+            table, spec = next(iter(RequestItems.items()))
+            keys = spec["Keys"]
+            return {
+                "Responses": {},
+                "UnprocessedKeys": {table: {"Keys": keys[len(keys) // 2 :]}},
+            }
+        return {"Responses": {}, "UnprocessedKeys": {}}
+
+    async def query(self, **params) -> dict:  # pragma: no cover - unused
+        return {"Items": []}
+
+
 class _FakeDynamoDBClient:
     def __init__(self, inner: _RefusingClient) -> None:
         self._inner = inner
@@ -142,7 +181,7 @@ class TestBatchPutRefusedWrites:
         with pytest.raises(DynamoDBBatchIncompleteException) as exc:
             await repository.batch_put_items(_entities(30), max_retries=2)
 
-        assert exc.value.status_code == 429
+        assert exc.value.status_code == 503
         assert exc.value.error_code == "DYNAMODB_BATCH_INCOMPLETE"
 
     @pytest.mark.asyncio
@@ -152,7 +191,9 @@ class TestBatchPutRefusedWrites:
         with pytest.raises(DynamoDBBatchIncompleteException) as exc:
             await _repository(client).batch_put_items(_entities(5), max_retries=2)
 
-        # The count is what a caller needs to decide what to re-submit.
+        # The count measures the failure; it does not identify the items.
+        # Re-submitting means replaying the batch, not cherry-picking from a
+        # list this exception does not carry.
         assert "5" in exc.value.message
 
     @pytest.mark.asyncio
@@ -204,20 +245,27 @@ class TestBatchGetRefusedKeys:
 
 
 class TestQueryLimitBound:
+    @pytest.mark.parametrize("limit", [0, -1])
     @pytest.mark.asyncio
-    async def test_limit_zero_is_rejected_not_dropped(self) -> None:
-        # DynamoDB requires Limit >= 1, so forwarding 0 is not an option either.
-        with pytest.raises(ValueError, match="limit"):
+    async def test_a_sub_one_limit_is_a_client_error_not_a_500(
+        self, limit: int
+    ) -> None:
+        """DynamoDB requires Limit >= 1, so forwarding it is not an option.
+
+        The status matters as much as the rejection. The first fix raised a bare
+        ``ValueError``, which the generic handler turns into
+        ``INTERNAL_SERVER_ERROR`` — trading a silently dropped bound for a 500
+        and an operator page on a malformed request. `query_items` is reachable
+        from adopter request paths, so it has to be a 4xx.
+        """
+        with pytest.raises(DynamoDBInvalidLimitException) as exc:
             await _repository(_RefusingClient()).query_items(
-                partition_key_value="a", limit=0
+                partition_key_value="a", limit=limit
             )
 
-    @pytest.mark.asyncio
-    async def test_negative_limit_is_rejected(self) -> None:
-        with pytest.raises(ValueError, match="limit"):
-            await _repository(_RefusingClient()).query_items(
-                partition_key_value="a", limit=-1
-            )
+        assert exc.value.status_code == 400
+        assert exc.value.error_code == "DYNAMODB_INVALID_LIMIT"
+        assert isinstance(exc.value, DynamoDBException)
 
     @pytest.mark.asyncio
     async def test_a_positive_limit_is_forwarded(self) -> None:
@@ -264,3 +312,92 @@ class TestCursorGuard:
 
         with pytest.raises(DynamoDBException):
             BaseDynamoRepository._decode_cursor(encoded)
+
+
+class TestRetryBehaviour:
+    """Shapes the first round of tests missed, per cross-review."""
+
+    @pytest.mark.asyncio
+    async def test_a_later_retry_succeeding_does_not_raise(self) -> None:
+        client = _PartialClient(refuse_rounds=1)
+
+        results = await _repository(client).batch_put_items(_entities(4), max_retries=3)
+
+        assert len(results) == 4
+        assert client.write_calls == 2  # refused once, then accepted
+
+    @pytest.mark.asyncio
+    async def test_no_sleep_after_the_final_attempt(self, monkeypatch) -> None:
+        # A wait after the last try is pure added latency before an exception.
+        slept: list[float] = []
+
+        async def _record(delay: float) -> None:
+            slept.append(delay)
+
+        monkeypatch.setattr(
+            "src._core.infrastructure.persistence.nosql.dynamodb"
+            ".base_dynamo_repository.asyncio.sleep",
+            _record,
+        )
+        client = _RefusingClient(refuse_writes=True)
+
+        with pytest.raises(DynamoDBBatchIncompleteException):
+            await _repository(client).batch_put_items(_entities(1), max_retries=3)
+
+        assert client.write_calls == 3
+        assert len(slept) == 2  # between attempts only
+
+    @pytest.mark.asyncio
+    async def test_backoff_grows_and_is_jittered(self, monkeypatch) -> None:
+        slept: list[float] = []
+
+        async def _record(delay: float) -> None:
+            slept.append(delay)
+
+        monkeypatch.setattr(
+            "src._core.infrastructure.persistence.nosql.dynamodb"
+            ".base_dynamo_repository.asyncio.sleep",
+            _record,
+        )
+
+        with pytest.raises(DynamoDBBatchIncompleteException):
+            await _repository(_RefusingClient(refuse_writes=True)).batch_put_items(
+                _entities(1), max_retries=3
+            )
+
+        # Jitter is half-to-full of an exponential ceiling, so the second wait
+        # can never be below the first's floor.
+        assert slept[1] > slept[0] / 2
+
+    @pytest.mark.asyncio
+    async def test_empty_input_calls_nothing(self) -> None:
+        client = _RefusingClient(refuse_writes=True)
+
+        assert await _repository(client).batch_put_items([]) == []
+        assert client.write_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_exactly_one_chunk_at_the_write_boundary(self) -> None:
+        client = _RefusingClient()
+
+        await _repository(client).batch_put_items(_entities(25))
+
+        assert client.write_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_one_over_the_write_boundary_is_two_chunks(self) -> None:
+        client = _RefusingClient()
+
+        await _repository(client).batch_put_items(_entities(26))
+
+        assert client.write_calls == 2
+
+    @pytest.mark.asyncio
+    async def test_exactly_one_chunk_at_the_read_boundary(self) -> None:
+        client = _RefusingClient()
+
+        await _repository(client).batch_get_items(
+            [DynamoKey(partition_key=str(i)) for i in range(100)]
+        )
+
+        assert client.read_calls == 1


### PR DESCRIPTION
Closes #329. Task 3 of the #325–#351 execution packet.

Three fail-open defects in the base class every adopter subclasses.

## F6 — success DTOs for writes DynamoDB refused

`batch_put_items` retried `UnprocessedItems` with no backoff and no sleep, then
fell through and built a success DTO for *every* item in the chunk. Measured
before: **30 entities in, 30 DTOs out, 6 `batch_write_item` calls, nothing
raised.** `batch_get_items` dropped leftover `UnprocessedKeys`, so the caller got
a short list indistinguishable from "those keys do not exist".

Both now back off exponentially (with jitter — `UnprocessedItems` arrives under
throttling, so concurrent callers would otherwise re-collide in lockstep) and
raise on exhaustion.

**The two sub-decisions the issue left open:**

A new `DynamoDBBatchIncompleteException`, not the existing
`DynamoDBThrottlingException` — throttling is the usual cause but not the only
one, so naming it would be a guess. **503, not 429**: 429 asserts the *client* is
sending too fast, which we do not know; an unprocessed batch is a retryable
backend failure of unknown cause. 503 also crosses the notification threshold, so
it pages — correct for a backend failure.

`batch_get_items` raises rather than returning partial results, discarding reads
that succeeded in that call. Reads are idempotent and cheap to redo; a short list
cannot be detected by the caller at all.

## F11 — `limit=0` silently dropped

`if limit:` instead of `if limit is not None:` returned a full page. Same shape
as #328's filters: a caller-supplied bound discarded rather than honoured or
rejected. The adjacent `if cursor:` / `if filter_expression:` are deliberately
untouched — empty string is a legitimate sentinel there.

## Cursor — unguarded client input

`json.loads(b64decode(...))` on a query-string token, so a malformed cursor
escaped as a 500 and, since #17, paged an operator.

## Three things cross-review corrected

**I traded fail-open for a 500.** The first fix raised a bare `ValueError` for
`limit < 1`, which the generic handler turns into `INTERNAL_SERVER_ERROR` —
stopping the silent drop and starting a 500 plus an operator page on a malformed
request. Now `DynamoDBInvalidLimitException` (400), and the tests assert the
status and `error_code`, not just that something was raised.

**The cursor guard was too shallow.** Only base64, JSON and top-level dict were
checked. Still passing before this commit:

```
{"PK": "x"}        -> accepted, no DynamoDB type map
{"PK": {"S": 1}}   -> accepted, S carrying a non-string
"<valid>!!"        -> accepted, urlsafe_b64decode ignores stray characters
```

All three reached the AWS call and failed as botocore parameter-validation
errors, which `DynamoDBClient` does not translate — so a malformed token was
*still* a 500. Now `b64decode(validate=True)` over a translated alphabet plus an
AttributeValue shape check; all three are 400s and a round-tripped cursor still
decodes.

**The exception leaked the table name** into a message
`custom_exception_handler` returns verbatim, contradicting the policy
`DynamoDBClient` documents for AWS error text. It goes to structlog instead.

Also from the review: the tests gained the shapes the first round missed — a
later retry succeeding, no sleep after the final attempt, backoff growth, empty
input, exact 25/100 chunk boundaries — and a `_PartialClient` that models
DynamoDB's real partial response, which the all-or-nothing double could not. A
comment claiming the count tells a caller what to re-submit was corrected: it
measures the failure, it does not identify the items.

## Verification

| | |
|---|---|
| SQLite full suite | **1894 passed, 43 skipped** |
| PostgreSQL full suite | **1894 passed, 43 skipped** |
| `uv run pyright` | 0 errors |
| DynamoDB integration without `dynamodb-local` | 10 skipped (the #330 guard) |

## Note

No new issues were opened, per the execution packet.
