### PR TITLE
fix: correct the README ADR count and the context7 MCP transport config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,9 @@
 {
   "mcpServers": {
     "context7": {
+      "type": "http",
       "url": "https://mcp.context7.com/mcp",
-      "env": {
+      "headers": {
         "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}"
       }
     }

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ from scratch.
 | AI workflow skills (Claude + Codex) | **15 + 15** | 0 | 0 | 0 |
 | Vector infrastructure (S3 Vectors) | **Yes** | No | No | No |
 | Multi-interface (API + Worker + Admin + MCP) | **3 + 1 planned** | 2 | 1 | 1 |
-| Architecture Decision Records | **27 active · 30 archived** | 0 | 0 | 0 |
+| Architecture Decision Records | **29 active · 30 archived** | 0 | 0 | 0 |
 | Type-safe generics across layers | **Yes** | Partial | Partial | No |
 | IoC container DI | **Yes** | No | No | No |
 
@@ -308,7 +308,7 @@ One business logic, multiple surfaces:
 | Adopt into an existing FastAPI project | [`docs/adoption.md`](docs/adoption.md) |
 | Check Python / FastAPI / tool version support | [`docs/compatibility.md`](docs/compatibility.md) |
 | See detailed env vars, tech stack, project tree | [`docs/reference.md`](docs/reference.md) |
-| Understand why a decision was made | [ADR index](docs/history/README.md) (27 active · 30 archived) |
+| Understand why a decision was made | [ADR index](docs/history/README.md) (29 active · 30 archived) |
 | Follow what's next | [Roadmap](docs/reference.md#roadmap) · [issue tracker](https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues) |
 
 ---


### PR DESCRIPTION
Two stale fixes that had been sitting uncommitted in the working tree.

## README said 27 active ADRs; there are 29

`057` (audit actor correlation-only) and `058` (`BaseRepository` engine guarantees) landed with the audit, and the two count references in `README.md` were never updated. `docs/README.md` already said 29, so the **public** README was the odd one out — and it is the one an outside reader sees first.

Counted directly: `docs/history/*.md` minus `README.md` is 29, `docs/history/archive/*.md` minus `README.md` is 30.

## `.mcp.json` never sent the context7 API key

The server was declared with `env`, which only applies to **stdio** servers. context7 is an HTTP server, so the key was silently dropped — anyone cloning the repo and following `CLAUDE.md` ("context7 is a project-required MCP server, configured via `.mcp.json`") got an unauthenticated client.

```diff
   "context7": {
+    "type": "http",
     "url": "https://mcp.context7.com/mcp",
-    "env": {
+    "headers": {
       "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}"
     }
   }
```

Verified rather than assumed: called `resolve-library-id` against the server with this config and got an authenticated response.

## Verification

- `pre-commit run --all-files` — passes (`check json` covers `.mcp.json`)
- No `src/` change, no test change; `README.md` and `.mcp.json` only
- No governor path touched, so no Governor Footer