### PR TITLE
chore(worktree): add tool-independent worktree bootstrap

### DIFF
--- a/.claude/rules/commands.md
+++ b/.claude/rules/commands.md
@@ -11,6 +11,13 @@
 # Dev environment setup (includes admin + aws extras — #104)
 make setup
 
+# Bootstrap a fresh git worktree — copies gitignored _env/*.env from the main
+# checkout and installs the admin/aws extras (not in uv's default sync).
+# Idempotent and agent-agnostic. `paseo.json` calls it from its post-create
+# hook; tools that read `.worktreeinclude` (Claude Code, Conductor, Roo Code,
+# CodeBuddy) copy the env files themselves but still need the extras.
+make worktree-setup
+
 # Zero-config quickstart (SQLite + InMemory broker, no external infra)
 make quickstart
 make demo            # in a second terminal — curl CRUD walkthrough

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,17 @@
+# Gitignored files copied into a new git worktree, in .gitignore syntax.
+# Only files that match AND are already gitignored are copied — listing a file
+# here never makes it tracked.
+#
+# Read by worktree-creating tools that support the convention (Claude Code,
+# Conductor, Roo Code, CodeBuddy). Tools that do not read it — Paseo, plain
+# `git worktree add` — are covered by `make worktree-setup`, which copies the
+# same two files. Keep the two lists in sync.
+#
+# Dependencies are never installed by this file: a fresh worktree also needs
+# `make worktree-setup` for the admin/aws extras.
+#
+# `make quickstart` recreates quickstart.env from its .example, so only the
+# hand-edited local.env strictly needs carrying over. Both are listed so a
+# worktree also inherits any local quickstart tweaks.
+_env/local.env
+_env/quickstart.env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -358,7 +358,17 @@ make demo         # curl walkthrough against running quickstart
 make dev          # real local dev (PostgreSQL via docker-compose)
 make worker
 make diagrams     # regenerate SVGs under docs/assets/architecture/
+
+make worktree-setup  # bootstrap a fresh git worktree (copy gitignored env files
+                     # + install admin/aws extras). Idempotent; agent-agnostic.
 ```
+
+A git worktree is a fresh checkout: `_env/*.env` is gitignored and the
+`admin`/`aws` extras are not part of uv's default sync, so run
+`make worktree-setup` once in a new worktree. Worktree managers can call it from
+their post-create hook (`paseo.json` in this repo does). Tools that read
+`.worktreeinclude` — Claude Code, Conductor, Roo Code, CodeBuddy — copy the env
+files themselves when they create the worktree; the extras still need the target.
 
 ### Test
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup quickstart demo demo-rag dev worker langfuse-env observability-langfuse observability-langfuse-down test lint format check check-core check-full check-minimal smoke-examples perf-test clean diagrams demo-gif
+.PHONY: help setup worktree-setup quickstart demo demo-rag dev worker langfuse-env observability-langfuse observability-langfuse-down test lint format check check-core check-full check-minimal smoke-examples perf-test clean diagrams demo-gif
 
 LANGFUSE_ENV_FILE := _env/langfuse.env
 MINIMAL_UV_ENV := /tmp/fastapi-agent-blueprint-minimal-venv
@@ -14,6 +14,25 @@ help:
 ## Setup development environment (includes admin + aws extras for full dev coverage)
 setup:
 	uv venv && uv sync --group dev --extra admin --extra aws && uv run pre-commit install && uv run pre-commit install --hook-type commit-msg
+
+# Idempotent and tool-independent: worktree managers (Paseo, Orca) point their
+# post-create hook here, and it also works when run by hand. Tools that read
+# .worktreeinclude (Claude Code, Conductor, Roo Code, CodeBuddy) copy the env
+# files themselves; the extras still need this target. The copy list below
+# mirrors .worktreeinclude — keep the two in sync.
+## Bootstrap a fresh git worktree (copy gitignored env files + install extras)
+worktree-setup:
+	@main=$$(git worktree list --porcelain | sed -n '1s/^worktree //p'); \
+	here=$$(git rev-parse --show-toplevel); \
+	if [ -n "$$main" ] && [ "$$main" != "$$here" ]; then \
+		for f in local.env quickstart.env; do \
+			if [ ! -f "_env/$$f" ] && [ -f "$$main/_env/$$f" ]; then \
+				cp "$$main/_env/$$f" "_env/$$f" && echo "→ copied _env/$$f from $$main"; \
+			fi; \
+		done; \
+	fi
+	@echo "→ Syncing dependencies (dev group + admin/aws extras)"
+	uv sync --group dev --extra admin --extra aws
 
 ## Zero-config quickstart: SQLite + InMemory broker, no external infra
 quickstart:

--- a/paseo.json
+++ b/paseo.json
@@ -1,0 +1,14 @@
+{
+  "worktree": {
+    "setup": "make worktree-setup"
+  },
+  "scripts": {
+    "quickstart": {
+      "command": "PORT=$PASEO_PORT uv run python run_server_local.py --env quickstart",
+      "type": "service"
+    },
+    "check": {
+      "command": "make check"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

A fresh git worktree cannot run this project. `_env/*.env` is gitignored, and the `admin` / `aws` extras are not part of uv's default sync, so `make dev` and every extra-dependent check fail until the worktree is initialised by hand. Contributors running parallel agent sessions (Paseo, Conductor, `claude --worktree`, plain `git worktree add`) each hit this and each solve it privately.

This adds one agent-agnostic entry point and wires the two conventions that call it.

## Changes

| File | Change |
|---|---|
| `Makefile` | New `worktree-setup` target — copies gitignored `_env/*.env` from the main checkout, then `uv sync --group dev --extra admin --extra aws` |
| `paseo.json` | New — Paseo post-create hook calls `make worktree-setup`; adds a port-aware quickstart service and a `check` script |
| `.worktreeinclude` | New — cross-tool convention (Claude Code, Conductor, Roo Code, CodeBuddy) for copying the same two env files at worktree creation |
| `AGENTS.md` | Common Commands → `make worktree-setup` + why a fresh worktree needs it |
| `.claude/rules/commands.md` | Same target in the Run section |

Design notes:

- `worktree-setup` resolves the main checkout itself via `git worktree list --porcelain`, so it takes no arguments and is not coupled to any worktree manager. Running it in the main checkout is a no-op for the copy step.
- The quickstart service uses `$PASEO_PORT`; `run_server_local.py` already honours `PORT` (default 8001), so parallel worktrees do not collide.
- `.worktreeinclude` only fires for tools that create the worktree themselves. It never covers the extras, so the make target remains the single complete path. The copy list is duplicated in both files with a cross-reference comment in each.

## Verification

- Created a real throwaway worktree, ran the copy logic: both env files copied, re-run is a no-op (idempotent), worktree removed cleanly
- Main-checkout guard confirmed (`main == here` → copy skipped)
- `make -n worktree-setup` parses; `make help` renders the description correctly (first draft used four `##` lines and the help awk picked the last one — fixed to one `##` line plus plain `#` notes)
- `paseo.json` validates as JSON
- `git check-ignore` confirms both `.worktreeinclude` entries are genuinely gitignored, so the file can never promote a tracked file
- `pre-commit run --all-files`: all hooks pass (migration-safety advisories are pre-existing and advisory-only per ADR056-G1)

Not run: `uv sync` itself, to avoid mutating the working `.venv`. It is the same invocation `make setup` already uses.

## Self-structured review checklist

- [x] Scope — no `src/` change, no runtime behaviour change; build/tooling only
- [x] Absolute Prohibitions — none touched (no layer imports, no Mapper, no Entity)
- [x] Secrets — `.worktreeinclude` copies gitignored files only and cannot make them tracked; no env values committed; `detect-secrets` hook passes
- [x] Language Policy — Tier 1 additions (`AGENTS.md`, `.claude/rules/commands.md`) are English-only; hook passes
- [x] Rebased onto `origin/main` after #362/#363; the originally-planned `.gitignore` entry for `.claude/worktrees/` landed there independently, so it was dropped from this PR rather than duplicated
- [x] Docs sync — new Makefile target reflected in both `AGENTS.md` Common Commands and `.claude/rules/commands.md`
- [x] Idempotency — verified by re-running in a real worktree
- [ ] Deferred: single-sourcing the copy list (Makefile parsing `.worktreeinclude`). Two entries with cross-reference comments in both files is more readable for contributors than the parsing it would require; revisit if the list grows.

## Governor Footer

- trigger: yes
- reviewer: self-structured
- rounds: 1
- r-points-fixed: 1
- r-points-deferred: 1
- r-points-rejected: 0
- touched-adr-consequences: none
- pr-scope-notes: build/tooling only; no src or runtime change; copy list intentionally duplicated across Makefile and .worktreeinclude
- final-verdict: merge-ready
- links: n/a
