### PR TITLE
fix(admin): size the dashboard activity grid to its rows

### DIFF
--- a/docs/ai/shared/admin-design-system.md
+++ b/docs/ai/shared/admin-design-system.md
@@ -136,7 +136,7 @@ Import surface: `from src._core.infrastructure.admin import components as c`.
 | `c.text_field / textarea_field / number_field / select_field` | leaf | Form inputs — always `outlined` |
 | `c.action_dialog(title, *, width=, subtitle=)` | context mgr | Dialog with arbitrary body; yields `(dialog, card)`; opens on exit |
 | `c.confirm_dialog(title, message, *, on_confirm, on_success=, danger=)` | async | Confirm-an-action; see contract below |
-| `c.data_grid(column_defs, row_data, *, compact=, row_click_to=, on_cell_click=, on_row_click=)` | leaf | AG Grid with the admin theme + shared defaults |
+| `c.data_grid(column_defs, row_data, *, compact=, auto_height=, row_click_to=, on_cell_click=, on_row_click=)` | leaf | AG Grid with the admin theme + shared defaults. Height: default = viewport-sized, `compact=True` = shorter, `auto_height=True` = derived from the row count (no empty space under the last row) — only for a **caller-bounded** row count. `auto_height` deliberately avoids AG Grid's `domLayout: "autoHeight"`, which breaks in the NiceGUI embed: the inner wrapper grows past the outer element and paints over the next section |
 | `c.bar_chart(categories, values)` | leaf | ECharts vertical bar; sized by `AdminClasses.CHART` / `--admin-chart-height`, bar fill = `AdminColors.PRIMARY`, top corners rounded |
 | `c.pagination(*, current, total_pages, on_prev, on_next)` | leaf | Prev / page / next row |
 | `c.empty_state(icon=)` | context mgr | Centered empty placeholder; add the message inside |

--- a/src/_apps/admin/pages/dashboard.py
+++ b/src/_apps/admin/pages/dashboard.py
@@ -105,7 +105,11 @@ def _render_recent_activity(metrics: DashboardMetrics) -> None:
                 {"headerName": "Domain", "field": "domain"},
             ],
             rows,
-            compact=True,
+            # Sized to its rows, not to the viewport: this window is capped at
+            # DEFAULT_RECENT_LIMIT (8), and a fixed-height container left a
+            # ~200px empty box under the last row on the landing page. The cap
+            # is what makes autoHeight safe here (it renders every row).
+            auto_height=True,
         )
 
 

--- a/src/_core/infrastructure/admin/components/data.py
+++ b/src/_core/infrastructure/admin/components/data.py
@@ -20,12 +20,21 @@ _SHARED_DEFAULT_COL_DEF: dict[str, Any] = {
     "sortable": True,
 }
 
+# Measured on AG Grid v33 quartz in the NiceGUI embed at our ``rowHeight``:
+# ``.ag-header`` is 49px and the root wrapper carries a 1px border top+bottom.
+# ``49 + 8 * 36 + 2 = 339`` matched the measured ``.ag-root-wrapper`` height
+# exactly, which is what makes the derived height below reliable rather than a
+# guess. Re-measure if the grid theme or ``GRID_ROW_HEIGHT`` changes.
+_GRID_HEADER_HEIGHT = 49
+_GRID_BORDER_HEIGHT = 2
+
 
 def data_grid(
     column_defs: list[dict],
     row_data: list[dict],
     *,
     compact: bool = False,
+    auto_height: bool = False,
     row_click_to: Callable[[dict], str] | None = None,
     on_cell_click: Callable[[Any], Any] | None = None,
     on_row_click: Callable[[Any], Awaitable[None]] | Callable[[Any], Any] | None = None,
@@ -34,6 +43,26 @@ def data_grid(
 ) -> ui.aggrid:
     """Render an AG Grid with the admin theme class + shared defaults.
 
+    Height:
+    - default → viewport-sized (``--admin-grid-height``); ``compact=True`` →
+      the shorter ``--admin-grid-height-compact``. Both are *fixed*, so a grid
+      holding fewer rows than the container leaves empty space below the last
+      row.
+    - ``auto_height=True`` → the height is *derived from the row count* and set
+      inline, so there is no empty space under the last row. Use only when the
+      caller bounds the row count; every row is laid out, so an unbounded grid
+      gets an arbitrarily tall page. ``compact`` is ignored when
+      ``auto_height`` is set.
+
+      This deliberately does **not** use AG Grid's ``domLayout: "autoHeight"``.
+      That was tried first and does not work in the NiceGUI embed: AG Grid grows
+      its inner ``.ag-root-wrapper`` (measured 339px for 8 rows) while the outer
+      NiceGUI element keeps the height Quasar computed for it (256px), so the
+      grid paints 83px over whatever follows it — on the dashboard the Quick
+      Actions section was overlapped and its heading hidden. Deriving a fixed
+      height keeps the mechanism that already works and only changes where the
+      number comes from.
+
     Click handling (all optional, async-safe):
     - ``row_click_to``: row dict → route; navigates on cellClicked (the common
       list→detail case).
@@ -41,17 +70,24 @@ def data_grid(
       cellClicked / rowClicked events (e.g. opening a detail dialog).
     """
     col_def = {**_SHARED_DEFAULT_COL_DEF, **(default_col_def or {})}
-    grid = ui.aggrid(
-        {
-            "columnDefs": column_defs,
-            "rowData": row_data,
-            "rowSelection": {"mode": "singleRow"}
-            if selection == "single"
-            else selection,
-            "rowHeight": AdminMetrics.GRID_ROW_HEIGHT,
-            "defaultColDef": col_def,
-        }
-    ).classes(f"w-full {AdminClasses.GRID_COMPACT if compact else AdminClasses.GRID}")
+    options: dict[str, Any] = {
+        "columnDefs": column_defs,
+        "rowData": row_data,
+        "rowSelection": {"mode": "singleRow"} if selection == "single" else selection,
+        "rowHeight": AdminMetrics.GRID_ROW_HEIGHT,
+        "defaultColDef": col_def,
+    }
+    if auto_height:
+        height_class = AdminClasses.GRID_AUTO
+    else:
+        height_class = AdminClasses.GRID_COMPACT if compact else AdminClasses.GRID
+    grid = ui.aggrid(options).classes(f"w-full {height_class}")
+    if auto_height:
+        # At least one row's worth so a zero-row grid is not 0px tall.
+        visible_rows = max(len(row_data), 1)
+        grid.style(
+            f"height: {_GRID_HEADER_HEIGHT + visible_rows * AdminMetrics.GRID_ROW_HEIGHT + _GRID_BORDER_HEIGHT}px"
+        )
 
     if row_click_to is not None:
         grid.on(

--- a/src/_core/infrastructure/admin/theme.py
+++ b/src/_core/infrastructure/admin/theme.py
@@ -148,6 +148,10 @@ class AdminClasses:
     SUCCESS_SURFACE: Final = "admin-success-surface"
     GRID: Final = "admin-grid"
     GRID_COMPACT: Final = "admin-grid-compact"
+    # Sets no height — AG Grid owns it via ``domLayout: "autoHeight"``, which
+    # requires the container div to have no height of its own. Paired with
+    # ``c.data_grid(auto_height=True)``; see _HELPER_CSS.
+    GRID_AUTO: Final = "admin-grid-auto"
     CHART: Final = "admin-chart"
     PAGINATION: Final = "admin-pagination"
     EMPTY_STATE: Final = "admin-empty-state"
@@ -373,6 +377,14 @@ body {
   width: 100%;
   height: var(--admin-grid-height-compact);
 }
+/* Deliberately sets no height: `c.data_grid(auto_height=True)` derives one from
+   the row count and sets it inline, so this class must not supply a competing
+   value. (AG Grid's own `domLayout: "autoHeight"` was tried and does not work
+   in the NiceGUI embed — the inner wrapper grows past the outer element and
+   paints over the next section. See components/data.py.) */
+.admin-grid-auto {
+  width: 100%;
+}
 /* AG Grid v33 Theming API: params map to --ag-<kebab-case>. `rowBorder`
    supersedes the legacy --ag-row-border-{color,style,width} trio.
 
@@ -386,7 +398,8 @@ body {
    Striping is pinned to the surface colour rather than deleted so the quartz
    default odd-row tint cannot leak back in; rows separate by border (#365). */
 .admin-grid,
-.admin-grid-compact {
+.admin-grid-compact,
+.admin-grid-auto {
   --ag-background-color: var(--admin-surface);
   --ag-header-background-color: var(--admin-bg);
   --ag-odd-row-background-color: var(--admin-row-alt);
@@ -406,7 +419,10 @@ body {
 .admin-grid .ag-header-cell,
 .admin-grid-compact .ag-cell,
 .admin-grid-compact .ag-row,
-.admin-grid-compact .ag-header-cell {
+.admin-grid-compact .ag-header-cell,
+.admin-grid-auto .ag-cell,
+.admin-grid-auto .ag-row,
+.admin-grid-auto .ag-header-cell {
   visibility: visible !important;
 }
 .admin-chart {

--- a/tests/unit/_core/infrastructure/admin/test_components.py
+++ b/tests/unit/_core/infrastructure/admin/test_components.py
@@ -76,6 +76,52 @@ def test_data_grid_carries_theme_and_defaults():
 def test_data_grid_compact_uses_compact_class():
     grid = c.data_grid([], [], compact=True)
     assert AdminClasses.GRID_COMPACT in grid._classes
+    assert "height" not in (grid._style or {})
+
+
+def test_data_grid_auto_height_derives_height_from_row_count():
+    """Height scales with rows so no empty space sits under the last row.
+
+    Asserts the derived value, not just that *some* height was set: the point of
+    the feature is the number. `49 + rows * 36 + 2` was measured against the
+    real `.ag-root-wrapper` in the NiceGUI embed.
+    """
+    rows = [{"id": i} for i in range(8)]
+    grid = c.data_grid([{"field": "id"}], rows, auto_height=True)
+    assert AdminClasses.GRID_AUTO in grid._classes
+    assert AdminClasses.GRID not in grid._classes
+    assert AdminClasses.GRID_COMPACT not in grid._classes
+    assert grid._style["height"] == f"{49 + 8 * AdminMetrics.GRID_ROW_HEIGHT + 2}px"
+
+    # Three rows must be shorter than eight — the whole point.
+    shorter = c.data_grid([{"field": "id"}], rows[:3], auto_height=True)
+    assert shorter._style["height"] == f"{49 + 3 * AdminMetrics.GRID_ROW_HEIGHT + 2}px"
+
+
+def test_data_grid_auto_height_never_collapses_to_zero():
+    """A zero-row grid still reserves one row, so it cannot render 0px tall."""
+    grid = c.data_grid([{"field": "id"}], [], auto_height=True)
+    assert grid._style["height"] == f"{49 + 1 * AdminMetrics.GRID_ROW_HEIGHT + 2}px"
+
+
+def test_data_grid_does_not_use_ag_grid_dom_layout_auto_height():
+    """`domLayout: autoHeight` is broken in the NiceGUI embed — never emit it.
+
+    AG Grid grows its inner `.ag-root-wrapper` (measured 339px for 8 rows) while
+    the outer NiceGUI element keeps Quasar's computed height (256px), so the grid
+    paints over the following section. Reaching for the option again is the
+    natural instinct; this test is the tripwire.
+    """
+    for kwargs in ({}, {"compact": True}, {"auto_height": True}):
+        grid = c.data_grid([], [], **kwargs)
+        assert "domLayout" not in grid._props["options"]
+
+
+def test_data_grid_auto_height_overrides_compact():
+    """`compact` imposes a height, so it cannot coexist with autoHeight."""
+    grid = c.data_grid([], [], compact=True, auto_height=True)
+    assert AdminClasses.GRID_AUTO in grid._classes
+    assert AdminClasses.GRID_COMPACT not in grid._classes
 
 
 def test_data_grid_merges_default_col_def():

--- a/tests/unit/_core/infrastructure/admin/test_theme.py
+++ b/tests/unit/_core/infrastructure/admin/test_theme.py
@@ -11,6 +11,8 @@ Toss-style look in #365.
 
 from __future__ import annotations
 
+import re
+
 from src._core.infrastructure.admin.theme import (
     EMPTY_DISPLAY,
     AdminClasses,
@@ -227,6 +229,39 @@ def test_zebra_striping_is_off_and_rows_separate_by_border():
     assert f"{AdminVars.ROW_ALT}: #18181b" in dark_block
     assert "--ag-odd-row-background-color: var(--admin-row-alt)" in css
     assert "--ag-row-border: 1px solid var(--admin-border)" in css
+
+
+def test_auto_height_grid_class_declares_no_height():
+    """`.admin-grid-auto` must not set `height` — AG Grid owns it.
+
+    `domLayout: "autoHeight"` requires the container div to carry no height of
+    its own. A `height` here would fight the option and restore the empty box
+    under the last row that the class exists to remove. Also asserts the class
+    still receives the `--ag-*` token mapping and the #234 `ag-delay-render`
+    visibility fix, which a new grid class silently misses otherwise.
+    """
+    css = build_admin_css()
+    start = css.index(f".{AdminClasses.GRID_AUTO} {{")
+    block = css[start : css.index("}", start)]
+    assert "width: 100%" in block
+    assert "height" not in block
+
+    # The --ag-* token mapping must list the new class. Strip comments before
+    # parsing rules: the explanatory comment above that rule contains a literal
+    # `--ag-row-border-{color,style,width}`, and a naive scan for the nearest
+    # preceding `{` lands inside it.
+    stripped = re.sub(r"/\*.*?\*/", "", css, flags=re.DOTALL)
+    token_selectors = next(
+        sel
+        for sel, body in re.findall(r"([^{}]+)\{([^{}]*)\}", stripped)
+        if "--ag-background-color" in body
+    )
+    assert AdminClasses.GRID_AUTO in token_selectors
+    assert AdminClasses.GRID in token_selectors
+    assert AdminClasses.GRID_COMPACT in token_selectors
+
+    # #234: without this the new class inherits the stuck-`ag-delay-render` bug.
+    assert f".{AdminClasses.GRID_AUTO} .ag-cell" in css
 
 
 def test_grid_surface_comes_from_the_same_token_as_every_other_panel():


### PR DESCRIPTION
Fixes the first defect from #368's corrected diagnosis.

## The defect

The dashboard's Recent Activity grid reserved `--admin-grid-height-compact` = `calc(100vh - 360px)` — 540px at a 900px viewport — while its content occupies 339px (49px header + 8 rows × 36px + 2px border). The remaining ~200px rendered as an empty white box in the middle of the landing page.

**#365 made this worse rather than causing it.** Dropping `GRID_ROW_HEIGHT` from 44 to 36 shortened the rows while the container height stayed fixed, so the void grew. While planning #365 I recorded "`GRID_HEIGHT` unchanged; fine" — that judgement was wrong and it shipped.

## The fix

`c.data_grid(auto_height=True)` derives the height from the row count, plus a heightless `.admin-grid-auto` class so nothing competes with the inline value. The dashboard opts in; its window is capped at `DEFAULT_RECENT_LIMIT` (8), and that cap is what makes a derived height safe. `ai_usage` keeps the fixed compact height because its grid is a per-org aggregate with no row bound — applying this to every `compact` grid would have been the "half-configured" mistake.

## What I got wrong first, and why it is documented in the code

The obvious implementation is AG Grid's own `domLayout: "autoHeight"`. I tried that first. **It is broken in the NiceGUI embed**, and the result was worse than the void:

| element | height |
|---|---|
| outer NiceGUI element `.admin-grid-auto` | **256px** (Quasar's computed value) |
| inner AG Grid `.ag-root-wrapper` | **339px** |

AG Grid grew its inner wrapper while the outer element kept the height Quasar gave it, so the grid painted 83px over the Quick Actions section and hid its heading. Both numbers are browser measurements, not inference — and the same measurement produced the `49px` header constant the derived height now uses (`49 + 8*36 + 2 = 339`, matching `.ag-root-wrapper` exactly).

`test_data_grid_does_not_use_ag_grid_dom_layout_auto_height` now fails if `domLayout` is ever emitted, because reaching for the documented-but-broken option is the natural instinct for the next person. This is the same class of embed defect as #234 (`ag-delay-render` sticking), so the new class was also added to that visibility fix — a new grid class silently misses it otherwise.

## Verification

- Browser: page height **1439px → 1238px**, Quick Actions heading visible, nothing overlapped; outer element and inner wrapper both measure 339px
- `make check-core` — 1829 passed, 29 skipped
- `make check-minimal` — 7 passed
- `pre-commit run --all-files` — exit 0
- Tests assert the derived **value** (not merely that some height was set), that 3 rows are shorter than 8, and that a zero-row grid reserves one row rather than collapsing to 0px

## Guard I — consumers of the changed contract

`compact=` remains supported, so `docs/ai/shared/skills/add-admin-page.md`'s template (`c.data_grid(column_defs, rows, compact=True)`) stays correct — that example is an unbounded summary list, where `compact` is the right choice anyway. `project-dna.md` and `harness-asset-matrix.md` do not describe builder parameters. Only the design-system catalog row needed updating.

## Governor Footer

- trigger: yes
- reviewer: self-structured
- rounds: 1
- r-points-fixed: 1
- r-points-deferred: 0
- r-points-rejected: 0
- touched-adr-consequences: none
- pr-scope-notes: Governor surface is one catalog row in docs/ai/shared/admin-design-system.md documenting the new data_grid kwarg. R1 = the domLayout autoHeight attempt overlapped the following section (measured 339px inner vs 256px outer); Fixed within this PR by deriving the height in Python and pinned by a test that forbids emitting domLayout. Cross-tool Codex review not attempted again: codex exec timed out with no final answer twice earlier in this session on codex-cli 0.144.4, so self-structured per AGENTS.md Independent Review Trigger. No ADR consequence added — the constraint (domLayout autoHeight is unusable in the NiceGUI embed) is an admin design-system fact recorded in the catalog and in code comments, not a repo-wide governance rule.
- final-verdict: merge-ready
- links: https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/369, n/a
