### PR TITLE
fix(admin): drop the dashboard's Quick Actions section

### DIFF
--- a/src/_apps/admin/pages/dashboard.py
+++ b/src/_apps/admin/pages/dashboard.py
@@ -39,11 +39,16 @@ async def dashboard_page():
     # cause audit data to be read server-side.
     metrics = await collect_dashboard_metrics(visible_configs, include_audit=show_audit)
 
+    # No "Quick Actions" section: it rendered one nav card per visible domain,
+    # i.e. exactly the destinations the left drawer already lists, ~1300px down
+    # the page where nobody scrolled to it (#368). Offering the same target
+    # twice only made the landing page longer. If a genuine action surface is
+    # wanted here later it should carry *actions* (create, export, run), not
+    # navigation.
     _render_stat_cards(metrics, show_audit=show_audit)
     if show_audit:
         _render_activity_chart(metrics)
         _render_recent_activity(metrics)
-    _render_quick_actions(visible_configs, permissions)
 
 
 def _render_stat_cards(metrics: DashboardMetrics, *, show_audit: bool) -> None:
@@ -105,28 +110,9 @@ def _render_recent_activity(metrics: DashboardMetrics) -> None:
                 {"headerName": "Domain", "field": "domain"},
             ],
             rows,
-            # Sized to its rows, not to the viewport: this window is capped at
-            # DEFAULT_RECENT_LIMIT (8), and a fixed-height container left a
-            # ~200px empty box under the last row on the landing page. The cap
-            # is what makes autoHeight safe here (it renders every row).
+            # Sized to its rows, not to the viewport: a fixed-height container
+            # left a ~200px empty box under the last row on the landing page.
+            # Safe because this window is capped at DEFAULT_RECENT_LIMIT (8) —
+            # every row is laid out, so an unbounded grid must not opt in.
             auto_height=True,
         )
-
-
-def _render_quick_actions(
-    visible_configs: list[BaseAdminPage], permissions: set[str]
-) -> None:
-    def _nav_card(icon: str, label: str, target: str) -> None:
-        with c.card(clickable_to=target):
-            with ui.row().classes("items-center q-pa-sm"):
-                ui.icon(icon).classes("text-h4 text-primary")
-                ui.label(label).classes("text-h6")
-
-    with c.section("Quick Actions"):
-        with ui.row().classes("q-gutter-md"):
-            for pc in visible_configs:
-                _nav_card(pc.icon, pc.display_name, f"/admin/{pc.domain_name}")
-            if "accounts" in permissions:
-                _nav_card("manage_accounts", "Accounts", "/admin/accounts")
-            if _AUDIT_PERMISSION in permissions:
-                _nav_card("fact_check", "Audit Log", "/admin/audit-log")


### PR DESCRIPTION
Closes defect 2 from #368's corrected diagnosis.

## What was there

`_render_quick_actions` rendered one clickable nav card per visible domain, plus Accounts and Audit Log — **exactly the destinations the left drawer already lists**. It sat roughly 1300px down the landing page, below the fold on a 900px viewport, which is why I did not even see it when I first filed #368.

So it was redundant navigation that nobody reached. Removing it is not a taste call: a second copy of the same five targets cannot earn the vertical space it costs.

Combined with #369, the dashboard goes **1439px → 1094px** and now ends where its content ends:

| | before #369 | now |
|---|---|---|
| page height | 1439px | 1094px |
| sections | stat cards · chart · table · Quick Actions | stat cards · chart · table |
| below the fold | 539px | 194px |

The reasoning is recorded at the call site so the section is not reflexively re-added. If an action surface belongs on the landing page later, it should carry actual *actions* — create, export, run — not navigation.

## `c.card(clickable_to=)` is kept on purpose

This removal leaves `clickable_to` with zero call sites, and I did not delete it. #331's dead-code test is that something is dead only when nothing references it **and** no document advertises it as an extension point — and `admin-design-system.md` lists it in the builder catalog (`c.card(*, clickable_to=, classes=)`). That is the same test under which `BUSINESS_CONFLICT`, `build_stub_llm_model` and `BaseDynamoService` were kept in the #331 audit. The `.q-card.cursor-pointer:hover` border treatment in `theme.py` also remains valid for any future clickable card.

## Also fixed

A stale comment from #369's first attempt: the `auto_height=True` call site still explained the height in terms of AG Grid's `domLayout: "autoHeight"`, which #369 abandoned as unusable in the NiceGUI embed. It now describes what the code actually does.

## Verification

- Browser: Quick Actions absent, page height 1094px, nothing else moved or clipped
- `make check-core` — 1829 passed, 29 skipped
- `make check-minimal` — 7 passed
- `ruff check` clean
- Touches one file (`src/_apps/admin/pages/dashboard.py`); no governor path, so no Governor Footer required

## Remaining in #368

- defect 3: stat cards hug the left edge with ~700px unused to their right, and the single-category chart is one bar in a very wide plot area
- defect 4: login composition
- still gated on the issue's Open Questions: any *new* dashboard metric or section
