### PR TITLE
feat(core): add count_datas_by_day to BaseRepository, BaseService and the protocol

### DIFF
--- a/src/_core/domain/protocols/repository_protocol.py
+++ b/src/_core/domain/protocols/repository_protocol.py
@@ -6,6 +6,9 @@ from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar
 from pydantic import BaseModel
 
 if TYPE_CHECKING:
+    from datetime import datetime
+
+    from src._core.domain.value_objects.daily_count import DailyCount
     from src._core.domain.value_objects.query_filter import QueryFilter
 
 ReturnDTO = TypeVar("ReturnDTO", bound=BaseModel)
@@ -53,3 +56,7 @@ class BaseRepositoryProtocol(Protocol, Generic[ReturnDTO]):
     async def delete_data_by_data_id(self, data_id: int) -> bool: ...
 
     async def count_datas(self) -> int: ...
+
+    async def count_datas_by_day(
+        self, *, since: datetime, column_name: str = "created_at"
+    ) -> list[DailyCount]: ...

--- a/src/_core/domain/services/base_service.py
+++ b/src/_core/domain/services/base_service.py
@@ -9,6 +9,9 @@ from src._core.common.pagination import make_pagination
 from src._core.domain.protocols.repository_protocol import BaseRepositoryProtocol
 
 if TYPE_CHECKING:
+    from datetime import datetime
+
+    from src._core.domain.value_objects.daily_count import DailyCount
     from src._core.domain.value_objects.query_filter import QueryFilter
 
 CreateDTO = TypeVar("CreateDTO", bound=BaseModel)
@@ -66,6 +69,27 @@ class BaseService(Generic[CreateDTO, UpdateDTO, ReturnDTO]):
 
     async def count_datas(self) -> int:
         return await self.repository.count_datas()
+
+    async def count_datas_by_day(
+        self, *, since: datetime, column_name: str = "created_at"
+    ) -> list[DailyCount]:
+        """Rows per calendar day at or after ``since`` (#368).
+
+        A pass-through, like :meth:`count_datas`, and it exists for the same
+        reason: callers reach a domain through its **service**, so a repository
+        method with no service counterpart is unreachable from the places that
+        need it — the admin dashboard resolves ``config._get_service()``, never a
+        repository.
+
+        Read-only, so there is no ``_validate_*`` hook: the write-validation
+        hooks guard mutations, and adding one here would imply a decision point
+        that does not exist. Engine normalisation and the fail-closed behaviour
+        on a missing or non-temporal column live in ``BaseRepository`` (ADR 058);
+        this layer adds nothing and must not paper over them.
+        """
+        return await self.repository.count_datas_by_day(
+            since=since, column_name=column_name
+        )
 
     async def _validate_create(self, entity: CreateDTO) -> None:
         return None

--- a/src/_core/domain/value_objects/daily_count.py
+++ b/src/_core/domain/value_objects/daily_count.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+
+
+@dataclass(frozen=True)
+class DailyCount:
+    """One day's record count from a date-grouped aggregate.
+
+    A read result that is intrinsically a value and never mutated downstream, so
+    it is a frozen VO rather than a DTO — the same reasoning as ``CursorPage``
+    and ``VectorSearchResult``. ``@dataclass(frozen=True)`` (not the Pydantic
+    ``ValueObject`` base) because there is nothing to validate at runtime.
+
+    Produced by ``BaseRepository.count_datas_by_day``. Days with no rows are
+    **absent** rather than zero-filled: the repository reports what the table
+    contains, and deciding whether a gap means "zero" or "no data yet" is the
+    caller's business (the admin dashboard fills gaps for its chart, an alerting
+    consumer might not).
+    """
+
+    day: date
+    count: int

--- a/src/_core/infrastructure/persistence/rdb/base_repository.py
+++ b/src/_core/infrastructure/persistence/rdb/base_repository.py
@@ -309,10 +309,12 @@ class BaseRepository(Generic[ReturnDTO], ABC):
         precedent (ADR 058 D3) rather than returning an empty list that reads
         like "no data".
 
-        ``since`` must match the column's tz-awareness — the models differ
-        (``user.created_at`` is naive ``DateTime``, ``ai_usage.occurred_at`` is
-        ``DateTime(timezone=True)``), and coercing here would be guessing at the
-        caller's intent.
+        ``since`` must match the column's tz-awareness. Every timestamp column
+        in-tree today is naive ``DateTime`` (``user.created_at``,
+        ``ai_usage.occurred_at``), so a naive ``since`` is what callers pass; a
+        fork that switches a column to ``DateTime(timezone=True)`` has to pass an
+        aware one. No coercion happens here because guessing which the caller
+        meant is worse than the comparison failing.
         """
         column = getattr(self.model, column_name, None)
         if not isinstance(column, InstrumentedAttribute) or not isinstance(

--- a/src/_core/infrastructure/persistence/rdb/base_repository.py
+++ b/src/_core/infrastructure/persistence/rdb/base_repository.py
@@ -2,13 +2,15 @@ from __future__ import annotations
 
 from abc import ABC
 from collections.abc import Mapping
+from datetime import date, datetime
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 import structlog
 from pydantic import BaseModel
-from sqlalchemy import String, func, or_, select
+from sqlalchemy import Date, DateTime, String, func, or_, select
 from sqlalchemy.orm import InstrumentedAttribute
 
+from src._core.domain.value_objects.daily_count import DailyCount
 from src._core.exceptions.base_exception import BaseCustomException
 from src._core.infrastructure.persistence.rdb.database import Base, Database
 from src._core.infrastructure.persistence.rdb.exceptions import DatabaseException
@@ -267,6 +269,91 @@ class BaseRepository(Generic[ReturnDTO], ABC):
         async with self.database.session() as session:
             result = await session.execute(select(func.count()).select_from(self.model))
             return result.scalar_one()
+
+    async def count_datas_by_day(
+        self, *, since: datetime, column_name: str = "created_at"
+    ) -> list[DailyCount]:
+        """Rows per calendar day at or after ``since``, oldest day first.
+
+        Two dialect differences are absorbed here rather than left to callers,
+        per the ADR 058 guarantee that ``BaseRepository`` behaves the same on
+        PostgreSQL, MySQL and SQLite.
+
+        **1. How the day is truncated.** ``func.date(column)`` is used, and the
+        alternatives were measured rather than assumed:
+
+        =============================== ========= ============
+        expression                      SQLite    PostgreSQL
+        =============================== ========= ============
+        ``cast(column, Date)``          **fails** works
+        ``func.date(column)``           works     works
+        ``substr(cast(col, String), …)`` works     works
+        =============================== ========= ============
+
+        ``cast(column, Date)`` raises ``TypeError: fromisoformat: argument must
+        be str`` on SQLite, which is the quickstart default — so the obvious
+        cast is the one that breaks the most common configuration. Do not
+        "simplify" this to a cast. MySQL's ``DATE()`` is long-standing, but note
+        ADR 058's stated limit: no real MySQL runs in CI, so that leg rests on
+        documentation rather than a test.
+
+        **2. What Python type comes back.** ``func.date`` returns ``str`` on
+        SQLite and ``datetime.date`` on PostgreSQL (both measured). Callers get
+        ``datetime.date`` on every engine because :meth:`_as_date` normalises it;
+        without that, a caller formatting the value would work on one engine and
+        raise on another.
+
+        Days with no rows are **absent**, not zero-filled — see
+        :class:`DailyCount`. Fails closed with a curated 400 when the column
+        cannot carry the aggregate, following the ``DB_SEARCH_FIELD_UNUSABLE``
+        precedent (ADR 058 D3) rather than returning an empty list that reads
+        like "no data".
+
+        ``since`` must match the column's tz-awareness — the models differ
+        (``user.created_at`` is naive ``DateTime``, ``ai_usage.occurred_at`` is
+        ``DateTime(timezone=True)``), and coercing here would be guessing at the
+        caller's intent.
+        """
+        column = getattr(self.model, column_name, None)
+        if not isinstance(column, InstrumentedAttribute) or not isinstance(
+            column.type, (Date, DateTime)
+        ):
+            raise DatabaseException(
+                status_code=400,
+                message=(
+                    f"Field [ {column_name} ] cannot carry a date-grouped count; "
+                    "a Date or DateTime column is required"
+                ),
+                error_code="DB_TIME_FIELD_UNUSABLE",
+            )
+
+        day = func.date(column)
+        async with self.database.session() as session:
+            result = await session.execute(
+                select(day.label("day"), func.count().label("count"))
+                .where(column >= since)
+                .group_by(day)
+                .order_by(day)
+            )
+            return [
+                DailyCount(day=self._as_date(row.day), count=row.count)
+                for row in result
+            ]
+
+    @staticmethod
+    def _as_date(value: object) -> date:
+        """Normalise a grouped day value to ``datetime.date`` across engines."""
+        if isinstance(value, datetime):
+            return value.date()
+        if isinstance(value, date):
+            return value
+        if isinstance(value, str):
+            return date.fromisoformat(value[:10])
+        raise DatabaseException(
+            status_code=500,
+            message=f"Unsupported grouped-day type {type(value).__name__}",
+            error_code="DB_INTERNAL_ERROR",
+        )
 
     async def _populate_defaults(self, session, datas: list) -> None:
         """Load server-side defaults for freshly flushed instances.

--- a/tests/unit/_core/domain/services/test_base_service.py
+++ b/tests/unit/_core/domain/services/test_base_service.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from datetime import date, datetime
 from typing import Any
 
 from pydantic import BaseModel
 
 from src._core.application.dtos.base_response import PaginationInfo
 from src._core.domain.services.base_service import BaseService
+from src._core.domain.value_objects.daily_count import DailyCount
 
 
 class CreateItem(BaseModel):
@@ -27,6 +29,7 @@ class FakeRepository:
         self.items: dict[int, ItemDTO] = {}
         self.next_id = 1
         self.deleted: list[int] = []
+        self.by_day_calls: list[tuple[datetime, str]] = []
 
     async def insert_data(self, entity: BaseModel) -> ItemDTO:
         item = ItemDTO(id=self.next_id, name=entity.model_dump()["name"])
@@ -94,6 +97,12 @@ class FakeRepository:
     async def count_datas(self) -> int:
         return len(self.items)
 
+    async def count_datas_by_day(
+        self, *, since: datetime, column_name: str = "created_at"
+    ) -> list[DailyCount]:
+        self.by_day_calls.append((since, column_name))
+        return [DailyCount(day=date(2026, 8, 11), count=2)]
+
 
 class HookedService(BaseService[CreateItem, UpdateItem, ItemDTO]):
     def __init__(self, repository: FakeRepository) -> None:
@@ -152,3 +161,39 @@ async def test_base_service_read_paths_still_return_pagination():
     assert len(items) == 1
     assert isinstance(pagination, PaginationInfo)
     assert pagination.total_items == 1
+
+
+class TestCountDatasByDayDelegation:
+    """`BaseService.count_datas_by_day` is a pass-through, and the reason it
+    exists is reachability: callers hold a **service**, so a repository method
+    with no service counterpart cannot be used by the admin dashboard, which
+    resolves `config._get_service()` and never a repository (#368).
+    """
+
+    async def test_arguments_reach_the_repository_verbatim(self) -> None:
+        repo = FakeRepository()
+        service = BaseService[CreateItem, UpdateItem, ItemDTO](repository=repo)
+
+        await service.count_datas_by_day(
+            since=datetime(2026, 8, 1), column_name="occurred_at"
+        )
+
+        assert repo.by_day_calls == [(datetime(2026, 8, 1), "occurred_at")]
+
+    async def test_default_column_is_created_at(self) -> None:
+        repo = FakeRepository()
+        service = BaseService[CreateItem, UpdateItem, ItemDTO](repository=repo)
+
+        await service.count_datas_by_day(since=datetime(2026, 8, 1))
+
+        assert repo.by_day_calls == [(datetime(2026, 8, 1), "created_at")]
+
+    async def test_repository_result_is_returned_unchanged(self) -> None:
+        """No reshaping at this layer: engine normalisation and the fail-closed
+        column check belong to BaseRepository (ADR 058) and must not be masked."""
+        repo = FakeRepository()
+        service = BaseService[CreateItem, UpdateItem, ItemDTO](repository=repo)
+
+        rows = await service.count_datas_by_day(since=datetime(2026, 8, 1))
+
+        assert rows == [DailyCount(day=date(2026, 8, 11), count=2)]

--- a/tests/unit/_core/infrastructure/persistence/rdb/test_base_repository_contract.py
+++ b/tests/unit/_core/infrastructure/persistence/rdb/test_base_repository_contract.py
@@ -47,11 +47,15 @@ back, producing an opaque 500.
 
 from __future__ import annotations
 
+from datetime import date, datetime
+
 import pytest
+from sqlalchemy import update
 
 from src._core.domain.value_objects.query_filter import QueryFilter
 from src._core.infrastructure.persistence.rdb.exceptions import DatabaseException
 from src.user.domain.dtos.user_dto import UserDTO
+from src.user.infrastructure.database.models.user_model import UserModel
 from src.user.infrastructure.repositories.user_repository import UserRepository
 from tests.factories.user_factory import make_create_user_request
 
@@ -322,3 +326,142 @@ class TestNoDeadRelationshipHook:
         ).read_text(encoding="utf-8")
 
         assert "related_entities" not in source
+
+
+class TestDateGroupedCountAcrossEngines:
+    """`count_datas_by_day` must behave identically on every engine (#368).
+
+    Two dialect differences were measured before writing this, and both would
+    otherwise have shipped as engine-specific behaviour:
+
+    - `cast(column, Date)` — the obvious expression, and the one the plan for
+      this work originally specified — raises `TypeError: fromisoformat:
+      argument must be str` on **SQLite**, the quickstart default. `func.date`
+      works on both engines tested.
+    - `func.date` returns `str` on SQLite and `datetime.date` on PostgreSQL, so
+      a caller that formatted the value would work on one engine and raise on
+      the other.
+
+    These run on SQLite in CI and on PostgreSQL under `make test-pg`, so the
+    parity assertions are exercised on both. Per ADR 058's stated limit, MySQL
+    still rests on documentation rather than a test.
+
+    **Each test owns a distinct year and asserts only on that year.** `test_db`
+    is session-scoped, so the whole suite shares one database and rows
+    accumulate — the same reason the tests above use unique usernames. `since`
+    is only a *lower* bound, so every row another test inserts with
+    `created_at = now()` also falls inside these windows; anchoring the era
+    without filtering the result was the first thing that broke here, and it
+    broke only in the full run. Running these with `-k DateGrouped` hides it,
+    because then no other rows exist. Use :meth:`_era` and run the full suite on
+    both engines.
+    """
+
+    @staticmethod
+    def _era(rows, year: int):
+        """Only this test's own year, so rows from the shared session-scoped
+        database cannot leak into the assertion."""
+        return [(r.day.isoformat(), r.count) for r in rows if r.day.year == year]
+
+    @staticmethod
+    async def _backdate(test_db, username: str, when: datetime) -> None:
+        """Force `created_at`, which carries `server_default=func.now()`.
+
+        Naive datetimes on purpose: `user.created_at` is `DateTime` without
+        `timezone=True`, and `count_datas_by_day` deliberately does not coerce.
+        """
+        async with test_db.session() as session:
+            await session.execute(
+                update(UserModel)
+                .where(UserModel.username == username)
+                .values(created_at=when)
+            )
+            await session.commit()
+
+    async def _seed(self, repository, test_db, name: str, when: datetime) -> None:
+        await repository.insert_data(_request(name))
+        await self._backdate(test_db, name, when)
+
+    @pytest.mark.asyncio
+    async def test_day_is_a_date_object_on_every_engine(
+        self, repository, test_db
+    ) -> None:
+        await self._seed(repository, test_db, "dgc_type", datetime(2001, 3, 10, 7, 0))
+
+        rows = await repository.count_datas_by_day(since=datetime(2001, 1, 1))
+
+        mine = [r for r in rows if r.day.year == 2001]
+        assert mine, "expected the backdated row to be counted"
+        assert isinstance(mine[0].day, date), (
+            f"engine leaked {type(mine[0].day).__name__} instead of datetime.date"
+        )
+        assert not isinstance(mine[0].day, datetime), "a day must not carry a time"
+
+    @pytest.mark.asyncio
+    async def test_rows_on_the_same_day_collapse_into_one_entry(
+        self, repository, test_db
+    ) -> None:
+        await self._seed(repository, test_db, "dgc_a", datetime(2002, 3, 11, 7, 0))
+        # Same day, late in the day — must not spill into the next one.
+        await self._seed(repository, test_db, "dgc_b", datetime(2002, 3, 11, 23, 30))
+        await self._seed(repository, test_db, "dgc_c", datetime(2002, 3, 10, 1, 0))
+
+        rows = await repository.count_datas_by_day(since=datetime(2002, 1, 1))
+
+        assert self._era(rows, 2002) == [
+            ("2002-03-10", 1),
+            ("2002-03-11", 2),
+        ], "grouping or ordering differs from oldest-day-first"
+
+    @pytest.mark.asyncio
+    async def test_since_excludes_older_rows(self, repository, test_db) -> None:
+        await self._seed(repository, test_db, "dgc_old", datetime(2003, 1, 5, 12, 0))
+        await self._seed(repository, test_db, "dgc_new", datetime(2003, 6, 20, 12, 0))
+
+        rows = await repository.count_datas_by_day(since=datetime(2003, 6, 1))
+
+        assert self._era(rows, 2003) == [("2003-06-20", 1)]
+
+    @pytest.mark.asyncio
+    async def test_days_with_no_rows_are_absent_not_zero_filled(
+        self, repository, test_db
+    ) -> None:
+        """The repository reports what the table holds; gap-filling is the
+        caller's policy decision (see DailyCount)."""
+        await self._seed(repository, test_db, "dgc_gap1", datetime(2004, 5, 5, 9, 0))
+        await self._seed(repository, test_db, "dgc_gap2", datetime(2004, 5, 9, 9, 0))
+
+        rows = await repository.count_datas_by_day(since=datetime(2004, 1, 1))
+
+        assert self._era(rows, 2004) == [("2004-05-05", 1), ("2004-05-09", 1)]
+
+    @pytest.mark.asyncio
+    async def test_window_with_no_rows_returns_an_empty_list(self, repository) -> None:
+        rows = await repository.count_datas_by_day(
+            since=datetime(1990, 1, 1), column_name="created_at"
+        )
+        # 1990 predates every seeded era, and `since` is a lower bound, so this
+        # asserts on a window nothing falls into rather than on an empty table.
+        assert [r for r in rows if r.day.year < 2000] == []
+
+    @pytest.mark.asyncio
+    async def test_unknown_column_raises_a_curated_400(self, repository) -> None:
+        with pytest.raises(DatabaseException) as exc:
+            await repository.count_datas_by_day(
+                since=datetime(2005, 1, 1), column_name="nope"
+            )
+
+        assert exc.value.status_code == 400
+        assert exc.value.error_code == "DB_TIME_FIELD_UNUSABLE"
+
+    @pytest.mark.asyncio
+    async def test_non_temporal_column_raises_a_curated_400(self, repository) -> None:
+        """Fails closed rather than grouping by a string column and returning
+        nonsense days — the DB_SEARCH_FIELD_UNUSABLE precedent (ADR 058 D3)."""
+        with pytest.raises(DatabaseException) as exc:
+            await repository.count_datas_by_day(
+                since=datetime(2005, 1, 1), column_name="username"
+            )
+
+        assert exc.value.status_code == 400
+        assert exc.value.error_code == "DB_TIME_FIELD_UNUSABLE"


### PR DESCRIPTION
First of two PRs for #368. This one is the shared-contract half: a date-grouped record count on `BaseRepository`, surfaced through `BaseService` and the protocol. The dashboard that consumes it follows in PR 2 — the review lenses are different (engine portability here, UI and secret-exposure there) and mixing them means neither gets read properly.

## Why it is on the base class

#368 needs a growth trend. Putting the query in `user` alone would have set a pattern the next domain copies, so it goes where `count_datas` already lives and every domain inherits it.

## Two dialect differences, both measured

The plan for this work specified `cast(column, Date)`. **That was wrong**, and it was wrong in the worst direction:

| expression | SQLite | PostgreSQL |
|---|---|---|
| `cast(column, Date)` | **fails** — `TypeError: fromisoformat: argument must be str` | works |
| `func.date(column)` | works | works |
| `substr(cast(col, String), 1, 10)` | works | works |

SQLite is the quickstart default, so the obvious cast breaks the most common configuration rather than an exotic one. `func.date` is used, and the table above is in the docstring so nobody "simplifies" it back.

The second difference would have shipped silently: `func.date` returns **`str` on SQLite** and **`datetime.date` on PostgreSQL**. A caller formatting the value works on one engine and raises on the other. `_as_date` normalises it, so callers get `datetime.date` everywhere. This is the ADR 058 guarantee — dialect differences are absorbed by the base class — applied to a new method.

Per ADR 058's own stated limit, MySQL still rests on documentation (`DATE()`) rather than a test; no real MySQL runs in CI.

## Fail-closed, not empty

A missing or non-temporal column raises a curated `400 DB_TIME_FIELD_UNUSABLE` rather than returning `[]`, following the `DB_SEARCH_FIELD_UNUSABLE` precedent (ADR 058 D3). An empty list would read as "no data yet", which is a different and actionable state.

Days with no rows are **absent** rather than zero-filled. Gap-filling is a caller policy — a chart wants zeros, an alerting consumer does not — and that reasoning is recorded on the new `DailyCount` VO.

## Service and protocol

The repository method alone was unreachable: callers hold a **service** (the dashboard resolves `config._get_service()`, never a repository). `count_datas` already exists on both `BaseService` and `BaseRepositoryProtocol`; this follows that shape instead of becoming a special case. The protocol declaration is required rather than stylistic — `BaseService.__init__` takes `BaseRepositoryProtocol[ReturnDTO]`, so an undeclared member fails the type check.

No `_validate_*` hook on the service method: those guard writes, and adding one to a read path implies a decision point that does not exist.

## Blast radius, measured

`BaseRepository` and `BaseService` are inherited by 6 domains and 9 examples, so widening the protocol needed checking rather than assuming:

- All **13** repositories under `src/` and `examples/` inherit `BaseRepository`, so every one satisfies the widened protocol with no edit.
- Structural implementers in tests are unaffected: the mypy hook excludes `tests/` and runs only at the manual stage, and CI's `typecheck` job is pyright scoped by the `[tool.pyright]` allow-list — which **does** include `src/_core/domain`, so the protocol and service changes here are genuinely checked.

## Verification

| gate | result |
|---|---|
| `make check-core` (SQLite) | 1839 passed, 29 skipped |
| `make test-pg` (**real PostgreSQL**) | 1966 passed, 43 skipped |
| `make check-minimal` | 7 passed |
| `pyright` (CI gate) | 0 errors |

Running the new tests alone was itself misleading and is worth recording: `since` is only a *lower* bound, so rows other tests insert with `created_at = now()` fell inside the windows. `-k DateGrouped` hid it because then no other rows exist; the full run on PostgreSQL failed 3 tests. Each test now owns a distinct year and asserts only on that year, and the class docstring says not to switch back to "the table is empty" assertions.

## Two pre-existing problems found on the way (not fixed here)

1. **`test_db` cannot recover on PostgreSQL if tables already exist.** `Base.metadata.drop_all` raises `DependentObjectsStillExistError` (`refresh_token`'s FK depends on `user`), so `make test-pg` only works against a clean database. Reproduced with an **existing** test, unrelated to this change.
2. **The manual mypy stage cannot run at all.** `.claude/hooks/completion_gate.py` and `.antigravity/hooks/completion_gate.py` are a duplicate module name, and mypy stops with `errors prevented further checking` before checking anything.

Both deserve their own issues.
