### PR TITLE
feat(admin): replace what the dashboard answers, with onboarding as a real state

### DIFF
--- a/src/_apps/admin/dashboard_metrics.py
+++ b/src/_apps/admin/dashboard_metrics.py
@@ -1,45 +1,43 @@
-"""Dashboard read facade for the admin landing page.
+"""What the admin landing page reads (#193, reworked in #368).
 
-Isolates **all** data gathering for ``/admin/`` so the page file
-(``pages/dashboard.py``) stays a thin renderer — a core admin landing page must
-not embed cross-domain orchestration, dynamic service probing, or error
-isolation inline.
+A façade that **never raises**: every source is isolated so one failing backend
+degrades its own section instead of 500-ing the page. Sources that are absent
+report ``None``, which the page renders as "Unavailable" — distinguishable from a
+real zero, because "the count is 0" and "the count could not be read" are
+different facts and collapsing them hides outages.
 
-Design invariants:
-
-* **Never raises into the caller.** Each metric source is fetched in its own
-  best-effort block; one failing source degrades *that* section to an explicit
-  "unavailable" state (``count=None`` / ``audit_recent=None``) and is recorded
-  via structlog. The dashboard as a whole never breaks because one service is
-  down.
-* **No raw exception text leaves this module.** Failures are logged with
-  ``error_type`` only; the UI renders a neutral "Unavailable" marker. This keeps
-  the no-``str(exc)``-leak invariant (#195) intact end to end.
-* **CRUD contract stays minimal.** ``count_datas`` is implemented by every
-  ``BaseService`` but is intentionally *not* on ``AdminCrudServiceProtocol``.
-  The single dynamic ``getattr`` probe is quarantined here rather than widening
-  the shared CRUD protocol just to feed a dashboard.
+What the dashboard answers, and what it stopped answering
+---------------------------------------------------------
+#368 replaced the questions. The page now reports **what is wired up**, **AI
+usage and its failure rate**, and **per-domain growth**. The audit-derived
+sections it used to carry (an activity chart and a recent-activity table) are
+gone, and so is the collection behind them: ``/admin/audit-log`` is a strict
+superset with filtering and pagination, so the landing page was reading audit
+data to show a worse version of a page that already existed. Not rendering it is
+also one fewer audit read per dashboard load.
 """
 
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
 
 import structlog
 
-from src._core.infrastructure.admin.audit.dtos.audit_log_dto import (
-    AuditLogFilter,
-    AuditLogSummaryDTO,
-    AuditResult,
-)
-from src._core.infrastructure.admin.audit.logger import get_audit_repository
+from src._apps.admin.operational_status import InfraStatus, collect_operational_status
+from src._core.domain.value_objects.daily_count import DailyCount
 from src._core.infrastructure.admin.base_admin_page import BaseAdminPage
 
 _logger = structlog.stdlib.get_logger(__name__)
 
-DEFAULT_RECENT_LIMIT = 8
+# Fixed window. An operator-selectable range needs a control plus somewhere to
+# keep the selection, which is deferred rather than smuggled in here (#368).
+GROWTH_WINDOW_DAYS = 7
+
+# The one status that counts as success. Failures are derived by subtraction
+# rather than by summing the known failure states — see _collect_ai_usage.
+_OK_STATUS = "ok"
 
 
 @dataclass(frozen=True)
@@ -53,25 +51,106 @@ class DomainCount:
 
 
 @dataclass(frozen=True)
-class AuditMetrics:
-    """Audit-derived metrics for the recent window. ``recent is None`` => unavailable."""
+class DomainGrowth:
+    """Per-domain daily counts over the window. ``points is None`` => unavailable.
 
-    recent: list[AuditLogSummaryDTO] | None
-    total: int | None
-    failures: int | None
-    by_action: dict[str, int] = field(default_factory=dict)
+    Empty-but-not-None means the window genuinely holds no rows, which is the
+    normal state of a fresh install and must not read as a failure.
+    """
+
+    domain_name: str
+    display_name: str
+    points: list[DailyCount] | None
 
     @property
     def available(self) -> bool:
-        return self.recent is not None
+        return self.points is not None
+
+    @property
+    def total(self) -> int:
+        return sum(p.count for p in self.points or [])
+
+
+@dataclass(frozen=True)
+class AiUsageMetrics:
+    """Agent-call volume and failure rate over the window.
+
+    ``calls is None`` => no domain exposed a usage summary, or the read failed.
+    """
+
+    calls: int | None
+    failures: int | None
+    total_tokens: int | None
+
+    @property
+    def available(self) -> bool:
+        return self.calls is not None
+
+    @property
+    def failure_rate(self) -> float | None:
+        """Fraction of calls that did not succeed, or ``None`` when unknowable.
+
+        ``None`` for zero calls rather than ``0.0``: a rate needs a denominator,
+        and reporting a healthy 0% for a system that has served nothing is a
+        false reassurance.
+        """
+        if self.calls is None or self.failures is None or self.calls == 0:
+            return None
+        return self.failures / self.calls
 
 
 @dataclass(frozen=True)
 class DashboardMetrics:
     """Everything the landing page renders. Always fully populated (no raises)."""
 
+    infra: list[InfraStatus]
     domain_counts: list[DomainCount]
-    audit: AuditMetrics
+    growth: list[DomainGrowth]
+    ai_usage: AiUsageMetrics
+
+    @property
+    def growth_by_day(self) -> list[DailyCount]:
+        """New records per day summed across every visible domain, oldest first.
+
+        One aggregate series rather than one chart per domain. Charting each
+        domain separately reproduced the defect #369 had just removed: N fixed
+        height charts, each mostly empty, pushing the page past 1700px. The
+        per-domain totals are already on the stat cards above; what the chart
+        adds is the shape over time, and that reads better as a single line.
+
+        Domains whose read failed contribute nothing rather than zero — see
+        ``DomainGrowth.available``.
+        """
+        totals: dict[date, int] = {}
+        for domain in self.growth:
+            for point in domain.points or []:
+                totals[point.day] = totals.get(point.day, 0) + point.count
+        return [DailyCount(day=day, count=totals[day]) for day in sorted(totals)]
+
+    @property
+    def has_any_data(self) -> bool:
+        """Whether anything worth charting exists yet.
+
+        Drives the onboarding screen. Deliberately ignores ``infra``: a fresh
+        install always has infrastructure to report, so counting it would mean
+        the onboarding view never appears — which is the state every OSS adopter
+        opens first. Unavailable sources (``None``) do not count as data either;
+        a broken backend is not evidence of records.
+        """
+        if any(dc.count for dc in self.domain_counts):
+            return True
+        return bool(self.ai_usage.calls)
+
+
+def window_start(now: datetime | None = None) -> datetime:
+    """Lower bound for the growth/usage window.
+
+    Naive on purpose: every timestamp column in-tree is naive ``DateTime``, and
+    ``BaseRepository.count_datas_by_day`` deliberately does not coerce. ``now`` is
+    injectable so tests do not depend on the wall clock.
+    """
+    base = now or datetime.now()
+    return base - timedelta(days=GROWTH_WINDOW_DAYS)
 
 
 async def _count_for(config: BaseAdminPage) -> DomainCount:
@@ -102,53 +181,104 @@ async def _count_for(config: BaseAdminPage) -> DomainCount:
     )
 
 
-async def _collect_audit(recent_limit: int) -> AuditMetrics:
-    """Best-effort recent-audit metrics; all-``None`` when the repo is unavailable."""
-    try:
-        repo = get_audit_repository()
-        recent, total = await repo.list_filtered(
-            AuditLogFilter(), page=1, page_size=recent_limit
-        )
-    except Exception as exc:  # noqa: BLE001 - isolated, swallowed by design
-        _logger.warning("dashboard_audit_failed", error_type=type(exc).__name__)
-        return AuditMetrics(recent=None, total=None, failures=None)
+async def _growth_for(config: BaseAdminPage, since: datetime) -> DomainGrowth:
+    """Best-effort daily counts for one domain; ``points=None`` on any failure.
 
-    failures = sum(1 for row in recent if row.result == AuditResult.FAILURE)
-    by_action: dict[str, int] = {}
-    for row in recent:
-        key = row.action.value
-        by_action[key] = by_action.get(key, 0) + 1
-    return AuditMetrics(
-        recent=list(recent),
-        total=total,
-        failures=failures,
-        by_action=by_action,
+    Probed dynamically for the same reason as ``count_datas``: a domain whose
+    model has no temporal column raises a curated 400 from the repository, and a
+    domain that predates this method simply does not have it. Neither should cost
+    the operator their whole dashboard.
+    """
+    points: list[DailyCount] | None
+    try:
+        service = config._get_service()
+        by_day = getattr(service, "count_datas_by_day", None)
+        if by_day is None:
+            raise AttributeError("service does not implement count_datas_by_day")
+        points = await by_day(since=since)
+    except Exception as exc:  # noqa: BLE001 - per-section isolation, by design
+        _logger.warning(
+            "dashboard_growth_failed",
+            domain=config.domain_name,
+            error_type=type(exc).__name__,
+        )
+        points = None
+    return DomainGrowth(
+        domain_name=config.domain_name,
+        display_name=config.display_name,
+        points=points,
     )
 
 
+async def _collect_ai_usage(
+    configs: list[BaseAdminPage], since: datetime
+) -> AiUsageMetrics:
+    """Agent-call volume and failures from whichever domain exposes a summary.
+
+    Capability-probed rather than importing ``AiUsageService``: a fork that drops
+    the domain should lose the panel, not the page. The domain must be in
+    ``configs``, so an operator without its permission never causes the read.
+
+    Failures are ``total - ok`` rather than a sum over the known failure states.
+    ``UsageStatus`` is ``Literal["ok", "error", "timeout", "rate_limited"]``, and
+    summing three of them means a fourth state added later is silently counted as
+    success. Subtracting from the total cannot drift that way.
+    """
+    for config in configs:
+        try:
+            service = config._get_service()
+        except Exception as exc:  # noqa: BLE001 - isolated probe
+            _logger.warning(
+                "dashboard_ai_usage_service_failed",
+                domain=config.domain_name,
+                error_type=type(exc).__name__,
+            )
+            continue
+        get_summary = getattr(service, "get_usage_summary", None)
+        if get_summary is None:
+            continue
+        try:
+            overall, _ = await get_summary(start_at=since)
+            ok, _ = await get_summary(start_at=since, status=_OK_STATUS)
+        except Exception as exc:  # noqa: BLE001 - degrade this panel only
+            _logger.warning(
+                "dashboard_ai_usage_failed",
+                domain=config.domain_name,
+                error_type=type(exc).__name__,
+            )
+            return AiUsageMetrics(calls=None, failures=None, total_tokens=None)
+        return AiUsageMetrics(
+            calls=overall.call_count,
+            failures=max(overall.call_count - ok.call_count, 0),
+            total_tokens=overall.total_tokens,
+        )
+    return AiUsageMetrics(calls=None, failures=None, total_tokens=None)
+
+
 async def collect_dashboard_metrics(
-    visible_configs: Sequence[BaseAdminPage],
+    visible_configs: list[BaseAdminPage],
     *,
-    include_audit: bool = True,
-    recent_limit: int = DEFAULT_RECENT_LIMIT,
+    now: datetime | None = None,
 ) -> DashboardMetrics:
     """Gather all landing-page metrics concurrently, isolating per-source failures.
 
     ``visible_configs`` must already be permission-filtered by the caller — this
-    facade does not enforce authorization, it only reads what it is handed.
+    facade does not enforce authorization, it only reads what it is handed. That
+    filtering is also what keeps the AI panel and the growth section scoped: a
+    domain the operator may not see is not in the list, so it is never read.
 
-    ``include_audit`` gates the audit read entirely: callers without the
-    ``audit_log`` permission pass ``False`` so the audit repository is **never
-    touched** (least-privilege / data-minimization — a caller who may not see
-    audit data must not cause it to be read server-side, and must not trigger
-    audit-backend warnings on their dashboard).
+    Infrastructure status is not gathered concurrently because it touches no I/O;
+    it is a read over ``settings``.
     """
-    counts = asyncio.gather(*(_count_for(cfg) for cfg in visible_configs))
-    if include_audit:
-        domain_counts, audit = await asyncio.gather(
-            counts, _collect_audit(recent_limit)
-        )
-    else:
-        domain_counts = await counts
-        audit = AuditMetrics(recent=None, total=None, failures=None)
-    return DashboardMetrics(domain_counts=list(domain_counts), audit=audit)
+    since = window_start(now)
+    counts, growth, ai_usage = await asyncio.gather(
+        asyncio.gather(*(_count_for(cfg) for cfg in visible_configs)),
+        asyncio.gather(*(_growth_for(cfg, since) for cfg in visible_configs)),
+        _collect_ai_usage(list(visible_configs), since),
+    )
+    return DashboardMetrics(
+        infra=collect_operational_status(),
+        domain_counts=list(counts),
+        growth=list(growth),
+        ai_usage=ai_usage,
+    )

--- a/src/_apps/admin/operational_status.py
+++ b/src/_apps/admin/operational_status.py
@@ -1,0 +1,152 @@
+"""What is actually wired up in this deployment (#368).
+
+The one thing that is **not** zero on a fresh install. Every count on the admin
+dashboard starts at 0, but which optional infrastructure is live — and which is
+silently running a stub — has a real answer on day one, and it is the answer a
+new adopter needs first. Read-only over ``settings``; no database access, so it
+cannot fail a page render.
+
+Security contract
+-----------------
+Several of the enable/disable predicates in ``core_container`` key off
+**credentials** (``dynamodb_access_key``, ``s3vectors_access_key``,
+``notification_webhook_url``). This module reports only the *boolean result* of
+those checks plus a non-secret type/provider label. That is enforced
+mechanically rather than by review judgement: every value rendered must come
+from a settings field on :data:`_SAFE_DETAIL_FIELDS`, and no field whose name
+matches :data:`_SECRET_NAME_PARTS` may ever be read for display. See
+``test_operational_status.py``, which asserts that credential-shaped settings
+values never appear in the output.
+
+Selector predicates are duplicated here on purpose — deliberately, not by
+accident. Importing ``core_container`` would pull the DI graph (and its lazy
+infra imports) into a page render, and the container resolves providers rather
+than answering "is this on?". The predicates are one-liners; the cost of the
+duplication is a comment pointing at the canonical source, and the tests below
+pin the pairing so a change there fails here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from src._core.config import settings
+
+# Settings fields whose values may be rendered. Anything not listed is reported
+# as a state only. Keep this list conservative: a field is safe when its value
+# is a *type or provider name*, never a credential, endpoint or connection
+# string.
+_SAFE_DETAIL_FIELDS: frozenset[str] = frozenset(
+    {
+        "database_engine",
+        "broker_type",
+        "vector_store_type",
+        "storage_type",
+        "embedding_provider",
+        "embedding_model_name",
+        "llm_provider",
+        "llm_model_name",
+        "notification_provider",
+    }
+)
+
+# Substrings that mark a settings field as credential-shaped. Used by the tests
+# to prove no such value reaches the output.
+_SECRET_NAME_PARTS: frozenset[str] = frozenset(
+    {"key", "secret", "password", "token", "url", "dsn"}
+)
+
+
+class InfraState(StrEnum):
+    """Why the three states are distinct rather than a bool.
+
+    ADR 042 gives optional infrastructure two different disabled behaviours, and
+    conflating them hides the one that bites: ``STUB`` means requests are served
+    by a stand-in (``StubEmbedder``, PydanticAI ``TestModel``,
+    ``NoopNotificationClient``) and therefore *appear to work* while doing
+    nothing real. ``DISABLED`` means the capability is simply absent. An
+    operator debugging "why are my embeddings meaningless" needs to see STUB.
+    """
+
+    ACTIVE = "active"
+    STUB = "stub"
+    DISABLED = "disabled"
+
+
+@dataclass(frozen=True)
+class InfraStatus:
+    label: str
+    state: InfraState
+    detail: str | None = None
+
+
+def _detail(field: str) -> str | None:
+    """Read a display value, refusing anything not explicitly allowlisted."""
+    if field not in _SAFE_DETAIL_FIELDS:
+        raise ValueError(
+            f"{field!r} is not an allowlisted display field; "
+            "add it to _SAFE_DETAIL_FIELDS only if its value is not a credential"
+        )
+    value = getattr(settings, field, None)
+    return str(value) if value else None
+
+
+def collect_operational_status() -> list[InfraStatus]:
+    """Current infra wiring, in the order an operator cares about.
+
+    Predicate sources (canonical: ``_core/infrastructure/di/core_container.py``):
+    storage → ``storage_type``, dynamodb → ``dynamodb_access_key``,
+    s3vectors → ``s3vectors_access_key``, embedding → ``embedding_model_name``,
+    llm → ``llm_model_name``, notification → ``notification_webhook_url``.
+    """
+    return [
+        InfraStatus("Database", InfraState.ACTIVE, _detail("database_engine")),
+        # Unset means the in-process broker, which runs tasks inline in the
+        # producer — not "no broker" (#324).
+        InfraStatus(
+            "Broker",
+            InfraState.ACTIVE,
+            _detail("broker_type") or "inmemory",
+        ),
+        InfraStatus(
+            "Vector store",
+            InfraState.ACTIVE,
+            _detail("vector_store_type") or "inmemory",
+        ),
+        InfraStatus(
+            "Embedding",
+            InfraState.ACTIVE if settings.embedding_model_name else InfraState.STUB,
+            _detail("embedding_provider"),
+        ),
+        InfraStatus(
+            "LLM",
+            InfraState.ACTIVE if settings.llm_model_name else InfraState.STUB,
+            _detail("llm_provider"),
+        ),
+        InfraStatus(
+            "Error notification",
+            InfraState.ACTIVE if settings.notification_webhook_url else InfraState.STUB,
+            _detail("notification_provider"),
+        ),
+        InfraStatus(
+            "Object storage",
+            InfraState.ACTIVE if settings.storage_type else InfraState.DISABLED,
+            _detail("storage_type"),
+        ),
+        InfraStatus(
+            "DynamoDB",
+            InfraState.ACTIVE if settings.dynamodb_access_key else InfraState.DISABLED,
+            None,  # nothing safe to show: the predicate is the access key itself
+        ),
+        InfraStatus(
+            "S3 Vectors",
+            InfraState.ACTIVE if settings.s3vectors_access_key else InfraState.DISABLED,
+            None,  # same
+        ),
+        InfraStatus(
+            "OpenTelemetry",
+            InfraState.ACTIVE if settings.otel_enabled else InfraState.DISABLED,
+            None,
+        ),
+    ]

--- a/src/_apps/admin/pages/dashboard.py
+++ b/src/_apps/admin/pages/dashboard.py
@@ -18,6 +18,30 @@ page_configs: list[BaseAdminPage] = []
 
 _UNAVAILABLE = "Unavailable"
 
+# Gate for the infrastructure panel. `require_auth_allowlisted()` authenticates
+# without checking page permissions, so without this every admin — including one
+# holding zero grants — would read the deployment's configuration posture. That
+# matters beyond tidiness: "Error notification: stub" tells the holder of a
+# low-privilege account that failures raise no alert, and "OpenTelemetry:
+# disabled" that there are no traces. Both are directly useful to someone who has
+# compromised such an account.
+#
+# `accounts` is the closest thing to a super-admin marker here — the registry
+# calls it "the account-management gate", i.e. the permission to create admins and
+# grant their permissions. Onboarding is unaffected because the setup wizard
+# grants the first admin every key (see AdminPermissionRegistry).
+#
+# This is a policy choice, not a security law. A deployment that treats every
+# authenticated admin as fully trusted can widen it here; the point is that the
+# decision is now written down and pinned by a test rather than implicit.
+_INFRA_PERMISSION = "accounts"
+
+
+def may_see_infrastructure(permissions: set[str]) -> bool:
+    """Whether this operator may see the infrastructure posture panel."""
+    return _INFRA_PERMISSION in permissions
+
+
 # What an operator can do about each stub, by infra label. Shown only on the
 # onboarding view: once there is data, a stub is a deliberate choice rather than
 # an unfinished setup, and repeating the hint forever would be nagging.
@@ -50,17 +74,20 @@ async def dashboard_page():
     # section below scoped to what this operator may see.
     metrics = await collect_dashboard_metrics(visible_configs)
 
+    show_infra = may_see_infrastructure(permissions)
+
     if metrics.has_any_data:
         c.page_header("Dashboard", subtitle=f"Last {GROWTH_WINDOW_DAYS} days")
         _render_stat_cards(metrics)
         _render_ai_usage(metrics.ai_usage)
         _render_growth(metrics)
-        _render_infrastructure(metrics.infra)
+        if show_infra:
+            _render_infrastructure(metrics.infra)
     else:
         # Every count is 0 on a fresh install, which is what every OSS adopter
         # opens first. Charting zeros there looks broken; naming the next action
         # does not (#368).
-        _render_onboarding(metrics)
+        _render_onboarding(metrics, show_infra=show_infra)
 
 
 # ── Populated view ──
@@ -158,7 +185,7 @@ def _render_infrastructure(infra: list[InfraStatus]) -> None:
 # ── Onboarding view (no data yet) ──
 
 
-def _render_onboarding(metrics: DashboardMetrics) -> None:
+def _render_onboarding(metrics: DashboardMetrics, *, show_infra: bool) -> None:
     c.page_header(
         "Welcome",
         subtitle="No records yet — here is what is wired up and what to do next",
@@ -176,17 +203,21 @@ def _render_onboarding(metrics: DashboardMetrics) -> None:
                 "Create some records",
                 "Run make demo for CRUD, or make demo-rag for the RAG walkthrough.",
             )
-            for row in stubs:
-                hint = _NEXT_STEPS.get(row.label)
-                if hint:
-                    _step("build", f"{row.label} is running a stub", hint)
+            # The stub hints disclose the same posture as the panel below — "LLM
+            # is running a stub" is the panel's LLM row in prose — so they sit
+            # behind the same gate rather than leaking around it.
+            if show_infra:
+                for row in stubs:
+                    hint = _NEXT_STEPS.get(row.label)
+                    if hint:
+                        _step("build", f"{row.label} is running a stub", hint)
 
-    _render_infrastructure(metrics.infra)
-
-    if active and not stubs:
-        ui.label("Every optional component is configured.").classes(
-            "admin-text-muted q-mt-md"
-        )
+    if show_infra:
+        _render_infrastructure(metrics.infra)
+        if active and not stubs:
+            ui.label("Every optional component is configured.").classes(
+                "admin-text-muted q-mt-md"
+            )
 
 
 def _step(icon: str, title: str, detail: str) -> None:

--- a/src/_apps/admin/pages/dashboard.py
+++ b/src/_apps/admin/pages/dashboard.py
@@ -1,9 +1,12 @@
 from nicegui import ui
 
 from src._apps.admin.dashboard_metrics import (
+    GROWTH_WINDOW_DAYS,
+    AiUsageMetrics,
     DashboardMetrics,
     collect_dashboard_metrics,
 )
+from src._apps.admin.operational_status import InfraState, InfraStatus
 from src._core.infrastructure.admin import components as c
 from src._core.infrastructure.admin.auth import require_auth_allowlisted
 from src._core.infrastructure.admin.base_admin_page import BaseAdminPage
@@ -13,12 +16,22 @@ from src._core.infrastructure.admin.layout import admin_layout
 # page_configs is injected by bootstrap_admin() after discovery
 page_configs: list[BaseAdminPage] = []
 
-# Audit-derived sections (event totals, activity chart, recent table) are only
-# rendered for operators holding the audit_log permission — the landing page
-# must not surface audit data more broadly than the dedicated audit-log page.
-_AUDIT_PERMISSION = "audit_log"
-
 _UNAVAILABLE = "Unavailable"
+
+# What an operator can do about each stub, by infra label. Shown only on the
+# onboarding view: once there is data, a stub is a deliberate choice rather than
+# an unfinished setup, and repeating the hint forever would be nagging.
+_NEXT_STEPS: dict[str, str] = {
+    "LLM": "Set LLM_PROVIDER + LLM_MODEL to replace the TestModel stub",
+    "Embedding": "Set EMBEDDING_PROVIDER + EMBEDDING_MODEL to replace StubEmbedder",
+    "Error notification": (
+        "Set NOTIFICATION_PROVIDER + the matching webhook URL to receive alerts"
+    ),
+}
+
+# Cards would otherwise size to their own text, so a column of steps came out
+# with ragged right edges that read as a layout bug rather than a choice.
+_STEP_WIDTH = "max-width: 720px"
 
 
 @ui.page("/admin/")
@@ -28,91 +41,158 @@ async def dashboard_page():
     if session is None:
         return
     admin_layout(page_configs, current_domain="", session=session)
-    c.page_header("Dashboard", subtitle="Welcome to the Admin Dashboard")
 
     permissions = set(session.permissions)
     visible_configs = [pc for pc in page_configs if pc.domain_name in permissions]
-    show_audit = _AUDIT_PERMISSION in permissions
 
     # The facade never raises; failures degrade individual sections in place.
-    # Audit reads are gated on the permission so unauthorized operators never
-    # cause audit data to be read server-side.
-    metrics = await collect_dashboard_metrics(visible_configs, include_audit=show_audit)
+    # `visible_configs` is already permission-filtered, which is what keeps every
+    # section below scoped to what this operator may see.
+    metrics = await collect_dashboard_metrics(visible_configs)
 
-    # No "Quick Actions" section: it rendered one nav card per visible domain,
-    # i.e. exactly the destinations the left drawer already lists, ~1300px down
-    # the page where nobody scrolled to it (#368). Offering the same target
-    # twice only made the landing page longer. If a genuine action surface is
-    # wanted here later it should carry *actions* (create, export, run), not
-    # navigation.
-    _render_stat_cards(metrics, show_audit=show_audit)
-    if show_audit:
-        _render_activity_chart(metrics)
-        _render_recent_activity(metrics)
+    if metrics.has_any_data:
+        c.page_header("Dashboard", subtitle=f"Last {GROWTH_WINDOW_DAYS} days")
+        _render_stat_cards(metrics)
+        _render_ai_usage(metrics.ai_usage)
+        _render_growth(metrics)
+        _render_infrastructure(metrics.infra)
+    else:
+        # Every count is 0 on a fresh install, which is what every OSS adopter
+        # opens first. Charting zeros there looks broken; naming the next action
+        # does not (#368).
+        _render_onboarding(metrics)
 
 
-def _render_stat_cards(metrics: DashboardMetrics, *, show_audit: bool) -> None:
+# ── Populated view ──
+
+
+def _render_stat_cards(metrics: DashboardMetrics) -> None:
     with ui.row().classes("q-gutter-md q-mb-md"):
         for dc in metrics.domain_counts:
             value = dc.count if dc.count is not None else _UNAVAILABLE
             c.stat_card(dc.display_name, value, icon=dc.icon)
-        if show_audit:
-            # Always render the card when permitted; a backend failure shows
-            # "Unavailable" rather than silently dropping the card, so the
-            # operator can tell "no permission" apart from "audit down".
-            total = metrics.audit.total
-            c.stat_card(
-                "Audit Events",
-                total if total is not None else _UNAVAILABLE,
-                icon="fact_check",
+
+
+def _render_ai_usage(usage: AiUsageMetrics) -> None:
+    """Agent-call volume and failure rate — the distinctive signal for this stack.
+
+    Omitted entirely when no domain exposes a usage summary: an empty panel would
+    imply the capability exists and is broken.
+    """
+    if not usage.available:
+        return
+    with c.section(f"Agent Calls ({GROWTH_WINDOW_DAYS}d)"):
+        if not usage.calls:
+            # A row of four zeros is the "looks broken" shape this rework set out
+            # to remove. One line still answers the question — and it is a real
+            # answer, unlike a hidden panel, which would be indistinguishable
+            # from the domain being absent.
+            #
+            # A muted label, not `c.empty_state`: that builder is a whole-page
+            # placeholder (48px vertical padding, centred) and using it for an
+            # inline note spent ~250px on one sentence.
+            ui.label(f"No agent calls in the last {GROWTH_WINDOW_DAYS} days").classes(
+                "admin-text-muted"
             )
-            if metrics.audit.failures:
-                c.stat_card("Recent Failures", metrics.audit.failures, icon="error")
-
-
-def _render_activity_chart(metrics: DashboardMetrics) -> None:
-    by_action = metrics.audit.by_action
-    if not metrics.audit.available or not by_action:
-        return  # unavailable or empty window: omit the chart rather than show a blank axis
-    actions = list(by_action.keys())
-    counts = [by_action[a] for a in actions]
-    with c.section("Recent Activity by Action"):
-        c.bar_chart(actions, counts)
-
-
-def _render_recent_activity(metrics: DashboardMetrics) -> None:
-    with c.section("Recent Activity"):
-        if not metrics.audit.available:
-            with c.empty_state("cloud_off"):
-                ui.label("Audit data unavailable")
             return
-        recent = metrics.audit.recent or []
-        if not recent:
-            with c.empty_state("inbox"):
-                ui.label("No recent activity")
-            return
-        rows = [
-            {
-                "time": row.created_at.strftime("%Y-%m-%d %H:%M"),
-                "action": row.action.value,
-                "result": row.result.value,
-                "user": row.admin_username,
-                "domain": row.domain,
-            }
-            for row in recent
-        ]
+        with ui.row().classes("q-gutter-md"):
+            c.stat_card("Calls", usage.calls, icon="smart_toy")
+            c.stat_card("Failures", usage.failures, icon="error")
+            rate = usage.failure_rate
+            c.stat_card(
+                "Failure rate",
+                f"{rate:.1%}" if rate is not None else "—",
+                icon="percent",
+            )
+            c.stat_card("Tokens", usage.total_tokens, icon="toll")
+
+
+def _render_growth(metrics: DashboardMetrics) -> None:
+    """One aggregate chart of new records per day across all visible domains.
+
+    Deliberately *not* one chart per domain. That was the first shape and it
+    reproduced the defect #369 had just fixed: each chart is a fixed 260px, so
+    two domains pushed the page past 1700px with two nearly-empty plots. The
+    per-domain totals are already on the stat cards; the chart's job is the shape
+    over time.
+    """
+    points = metrics.growth_by_day
+    if points:
+        with c.section(f"New Records ({GROWTH_WINDOW_DAYS}d)"):
+            c.bar_chart(
+                [p.day.strftime("%m-%d") for p in points],
+                [p.count for p in points],
+            )
+
+    unavailable = [g.display_name for g in metrics.growth if not g.available]
+    if unavailable:
+        # Named rather than silently dropped: a missing domain in an aggregate is
+        # invisible, and "the trend excludes X" is the actionable part.
+        ui.label(f"Trend unavailable: {', '.join(unavailable)}").classes(
+            "admin-text-muted"
+        )
+
+
+def _render_infrastructure(infra: list[InfraStatus]) -> None:
+    with c.section("Infrastructure"):
         c.data_grid(
             [
-                {"headerName": "Time", "field": "time"},
-                {"headerName": "Action", "field": "action"},
-                {"headerName": "Result", "field": "result"},
-                {"headerName": "User", "field": "user"},
-                {"headerName": "Domain", "field": "domain"},
+                {"headerName": "Component", "field": "component"},
+                {"headerName": "State", "field": "state"},
+                {"headerName": "Detail", "field": "detail"},
             ],
-            rows,
-            # Sized to its rows, not to the viewport: a fixed-height container
-            # left a ~200px empty box under the last row on the landing page.
-            # Safe because this window is capped at DEFAULT_RECENT_LIMIT (8) —
-            # every row is laid out, so an unbounded grid must not opt in.
+            [
+                {
+                    "component": row.label,
+                    "state": row.state.value,
+                    "detail": row.detail or "—",
+                }
+                for row in infra
+            ],
+            # Bounded by the number of infra components, so deriving the height
+            # from the row count is safe (see c.data_grid).
             auto_height=True,
         )
+
+
+# ── Onboarding view (no data yet) ──
+
+
+def _render_onboarding(metrics: DashboardMetrics) -> None:
+    c.page_header(
+        "Welcome",
+        subtitle="No records yet — here is what is wired up and what to do next",
+    )
+
+    stubs = [row for row in metrics.infra if row.state is InfraState.STUB]
+    active = [row for row in metrics.infra if row.state is InfraState.ACTIVE]
+
+    with c.section("Next steps"):
+        with ui.column().classes("q-gutter-md").style(_STEP_WIDTH):
+            # Seeding data first: it is the step that turns this view into the
+            # real dashboard, and it needs no credentials.
+            _step(
+                "play_circle",
+                "Create some records",
+                "Run make demo for CRUD, or make demo-rag for the RAG walkthrough.",
+            )
+            for row in stubs:
+                hint = _NEXT_STEPS.get(row.label)
+                if hint:
+                    _step("build", f"{row.label} is running a stub", hint)
+
+    _render_infrastructure(metrics.infra)
+
+    if active and not stubs:
+        ui.label("Every optional component is configured.").classes(
+            "admin-text-muted q-mt-md"
+        )
+
+
+def _step(icon: str, title: str, detail: str) -> None:
+    with c.card(classes="full-width"):
+        with ui.row().classes("items-center no-wrap q-gutter-md"):
+            ui.icon(icon).classes("text-h5 admin-accent-icon")
+            with ui.column().classes("q-gutter-none"):
+                ui.label(title).classes("text-subtitle2")
+                ui.label(detail).classes("text-caption admin-text-muted")

--- a/tests/unit/_apps/admin/test_dashboard_metrics.py
+++ b/tests/unit/_apps/admin/test_dashboard_metrics.py
@@ -1,36 +1,81 @@
-"""Unit tests for the admin dashboard read facade.
+"""Unit tests for the admin dashboard read facade (#193, reworked in #368).
 
 Focus: the never-raise / per-source isolation invariants. One failing metric
 source must degrade only its own section (``count=None`` / ``available=False``)
 without raising or affecting the others, and no raw exception text escapes.
+
+The audit-derived sections and their collection were removed in #368 —
+``/admin/audit-log`` is a strict superset — so the tests that covered them are
+gone with them rather than kept green against dead code.
 """
 
 from __future__ import annotations
 
-from datetime import datetime
-
-import pytest
+from datetime import date, datetime
 
 from src._apps.admin import dashboard_metrics as dm
-from src._core.infrastructure.admin.audit.dtos.audit_log_dto import (
-    AdminAction,
-    AuditLogSummaryDTO,
-    AuditResult,
-)
+from src._core.domain.value_objects.daily_count import DailyCount
 
 
 class _FakeService:
-    def __init__(self, count: int | Exception) -> None:
+    """A CRUD service with the two capabilities the dashboard probes for."""
+
+    def __init__(
+        self,
+        count: int | Exception = 0,
+        points: list[DailyCount] | Exception | None = None,
+    ) -> None:
         self._count = count
+        self._points = points if points is not None else []
+        self.since_seen: datetime | None = None
 
     async def count_datas(self) -> int:
         if isinstance(self._count, Exception):
             raise self._count
         return self._count
 
+    async def count_datas_by_day(
+        self, *, since: datetime, column_name: str = "created_at"
+    ) -> list[DailyCount]:
+        self.since_seen = since
+        if isinstance(self._points, Exception):
+            raise self._points
+        return self._points
+
 
 class _ServiceWithoutCount:
-    """Mimics a CRUD service that does not implement count_datas."""
+    """Mimics a CRUD service that implements neither probed capability."""
+
+
+class _UsageSummary:
+    def __init__(self, call_count: int, total_tokens: int = 0) -> None:
+        self.call_count = call_count
+        self.total_tokens = total_tokens
+
+
+class _FakeUsageService:
+    """Mimics AiUsageService: `get_usage_summary` returns (summary, by_org)."""
+
+    def __init__(
+        self,
+        total: int,
+        ok: int,
+        *,
+        tokens: int = 0,
+        raise_exc: Exception | None = None,
+    ) -> None:
+        self._total = total
+        self._ok = ok
+        self._tokens = tokens
+        self._raise = raise_exc
+        self.calls: list[str | None] = []
+
+    async def get_usage_summary(self, *, start_at=None, status=None, **_):
+        if self._raise is not None:
+            raise self._raise
+        self.calls.append(status)
+        count = self._ok if status == "ok" else self._total
+        return _UsageSummary(count, self._tokens), []
 
 
 class _FakeConfig:
@@ -44,128 +89,179 @@ class _FakeConfig:
         return self._service
 
 
-class _FakeRepo:
-    def __init__(
-        self,
-        rows: list[AuditLogSummaryDTO],
-        total: int,
-        *,
-        raise_exc: Exception | None = None,
-    ) -> None:
-        self._rows = rows
-        self._total = total
-        self._raise = raise_exc
-
-    async def list_filtered(self, filter_vo, *, page: int, page_size: int):
-        if self._raise is not None:
-            raise self._raise
-        return self._rows[:page_size], self._total
+def _points(*pairs: tuple[int, int]) -> list[DailyCount]:
+    return [DailyCount(day=date(2026, 8, d), count=n) for d, n in pairs]
 
 
-def _row(action: AdminAction, result: AuditResult) -> AuditLogSummaryDTO:
-    return AuditLogSummaryDTO(
-        id=1,
-        admin_username="alice",
-        action=action,
-        domain="user",
-        result=result,
-        created_at=datetime(2026, 6, 2, 10, 0),
-    )
+class TestPerSourceIsolation:
+    async def test_one_failing_count_does_not_affect_the_others(self):
+        configs = [
+            _FakeConfig("user", _FakeService(count=10)),
+            _FakeConfig("docs", _FakeService(count=RuntimeError("db down"))),
+        ]
+
+        metrics = await dm.collect_dashboard_metrics(configs)  # type: ignore[arg-type]
+
+        by_name = {dc.domain_name: dc.count for dc in metrics.domain_counts}
+        assert by_name == {"user": 10, "docs": None}
+
+    async def test_a_service_missing_the_capability_degrades_to_none(self):
+        configs = [_FakeConfig("legacy", _ServiceWithoutCount())]
+
+        metrics = await dm.collect_dashboard_metrics(configs)  # type: ignore[arg-type]
+
+        assert metrics.domain_counts[0].count is None
+        assert metrics.growth[0].points is None
+
+    async def test_a_failing_growth_read_leaves_the_count_intact(self):
+        configs = [
+            _FakeConfig("user", _FakeService(count=3, points=RuntimeError("no column")))
+        ]
+
+        metrics = await dm.collect_dashboard_metrics(configs)  # type: ignore[arg-type]
+
+        assert metrics.domain_counts[0].count == 3
+        assert metrics.growth[0].available is False
+
+    async def test_no_sources_at_all_still_returns_a_full_object(self):
+        metrics = await dm.collect_dashboard_metrics([])
+
+        assert metrics.domain_counts == []
+        assert metrics.growth == []
+        assert metrics.ai_usage.available is False
+        assert metrics.infra, "infra is settings-derived and always present"
 
 
-def _patch_audit(monkeypatch: pytest.MonkeyPatch, repo: _FakeRepo) -> None:
-    monkeypatch.setattr(dm, "get_audit_repository", lambda: repo)
+class TestGrowthWindow:
+    async def test_window_start_is_naive_and_days_back(self):
+        now = datetime(2026, 8, 11, 12, 0)
+
+        since = dm.window_start(now)
+
+        assert since == datetime(2026, 8, 4, 12, 0)
+        assert since.tzinfo is None, (
+            "columns in-tree are naive DateTime; an aware bound would not compare"
+        )
+
+    async def test_the_same_window_reaches_every_domain(self):
+        svc_a, svc_b = _FakeService(count=1), _FakeService(count=1)
+        configs = [_FakeConfig("a", svc_a), _FakeConfig("b", svc_b)]
+
+        await dm.collect_dashboard_metrics(
+            configs,  # type: ignore[arg-type]
+            now=datetime(2026, 8, 11, 12, 0),
+        )
+
+        assert svc_a.since_seen == svc_b.since_seen == datetime(2026, 8, 4, 12, 0)
+
+    async def test_growth_total_sums_the_points(self):
+        configs = [
+            _FakeConfig("user", _FakeService(count=9, points=_points((9, 2), (10, 3))))
+        ]
+
+        metrics = await dm.collect_dashboard_metrics(configs)  # type: ignore[arg-type]
+
+        assert metrics.growth[0].total == 5
 
 
-async def test_happy_path_aggregates_counts_and_audit(monkeypatch):
-    rows = [
-        _row(AdminAction.LOGIN, AuditResult.SUCCESS),
-        _row(AdminAction.LOGIN, AuditResult.FAILURE),
-        _row(AdminAction.ACCOUNT_CREATE, AuditResult.SUCCESS),
-    ]
-    _patch_audit(monkeypatch, _FakeRepo(rows, total=42))
-    configs = [
-        _FakeConfig("user", _FakeService(10)),
-        _FakeConfig("docs", _FakeService(5)),
-    ]
+class TestAiUsage:
+    async def test_failures_are_derived_by_subtraction(self):
+        """`UsageStatus` has three failure states, so summing them would let a
+        fourth added later count as success. total - ok cannot drift that way."""
+        svc = _FakeUsageService(total=10, ok=7, tokens=1234)
+        configs = [_FakeConfig("ai_usage", svc)]
 
-    metrics = await dm.collect_dashboard_metrics(configs)  # type: ignore[arg-type]
+        metrics = await dm.collect_dashboard_metrics(configs)  # type: ignore[arg-type]
 
-    assert [(c.domain_name, c.count) for c in metrics.domain_counts] == [
-        ("user", 10),
-        ("docs", 5),
-    ]
-    assert metrics.audit.available is True
-    assert metrics.audit.total == 42
-    assert metrics.audit.failures == 1
-    assert metrics.audit.by_action == {"LOGIN": 2, "ACCOUNT_CREATE": 1}
+        assert metrics.ai_usage.calls == 10
+        assert metrics.ai_usage.failures == 3
+        assert metrics.ai_usage.total_tokens == 1234
+        assert svc.calls == [None, "ok"], "one unfiltered read plus one ok-only read"
 
+    async def test_failure_rate_is_none_without_calls(self):
+        """A healthy 0% for a system that served nothing is a false reassurance."""
+        configs = [_FakeConfig("ai_usage", _FakeUsageService(total=0, ok=0))]
 
-async def test_one_failing_count_is_isolated(monkeypatch):
-    _patch_audit(monkeypatch, _FakeRepo([], total=0))
-    configs = [
-        _FakeConfig("user", _FakeService(10)),
-        _FakeConfig("docs", _FakeService(RuntimeError("db down"))),
-    ]
+        metrics = await dm.collect_dashboard_metrics(configs)  # type: ignore[arg-type]
 
-    metrics = await dm.collect_dashboard_metrics(configs)  # type: ignore[arg-type]
+        assert metrics.ai_usage.calls == 0
+        assert metrics.ai_usage.failure_rate is None
 
-    counts = {c.domain_name: c.count for c in metrics.domain_counts}
-    assert counts == {"user": 10, "docs": None}
-    # Audit still works despite the count failure.
-    assert metrics.audit.available is True
+    async def test_failure_rate_when_calls_exist(self):
+        configs = [_FakeConfig("ai_usage", _FakeUsageService(total=4, ok=3))]
 
+        metrics = await dm.collect_dashboard_metrics(configs)  # type: ignore[arg-type]
 
-async def test_service_without_count_datas_degrades(monkeypatch):
-    _patch_audit(monkeypatch, _FakeRepo([], total=0))
-    configs = [_FakeConfig("legacy", _ServiceWithoutCount())]
+        assert metrics.ai_usage.failure_rate == 0.25
 
-    metrics = await dm.collect_dashboard_metrics(configs)  # type: ignore[arg-type]
+    async def test_absent_domain_means_unavailable_not_zero(self):
+        """A fork that drops ai_usage loses the panel, not the page."""
+        configs = [_FakeConfig("user", _FakeService(count=1))]
 
-    assert metrics.domain_counts[0].count is None
+        metrics = await dm.collect_dashboard_metrics(configs)  # type: ignore[arg-type]
 
+        assert metrics.ai_usage.available is False
+        assert metrics.ai_usage.calls is None
 
-async def test_audit_unavailable_does_not_break_counts(monkeypatch):
-    _patch_audit(
-        monkeypatch, _FakeRepo([], total=0, raise_exc=RuntimeError("not configured"))
-    )
-    configs = [_FakeConfig("user", _FakeService(7))]
+    async def test_a_failing_summary_degrades_only_that_panel(self):
+        configs = [
+            _FakeConfig("user", _FakeService(count=2)),
+            _FakeConfig(
+                "ai_usage", _FakeUsageService(0, 0, raise_exc=RuntimeError("x"))
+            ),
+        ]
 
-    metrics = await dm.collect_dashboard_metrics(configs)  # type: ignore[arg-type]
+        metrics = await dm.collect_dashboard_metrics(configs)  # type: ignore[arg-type]
 
-    assert metrics.domain_counts[0].count == 7
-    assert metrics.audit.available is False
-    assert metrics.audit.total is None
-    assert metrics.audit.failures is None
-    assert metrics.audit.by_action == {}
+        assert metrics.ai_usage.available is False
+        assert metrics.domain_counts[0].count == 2
 
 
-async def test_audit_not_read_when_not_included(monkeypatch):
-    """Least privilege: include_audit=False must not touch the audit repository."""
-    calls = {"count": 0}
+class TestOnboardingDecision:
+    async def test_all_zero_counts_means_no_data(self):
+        configs = [
+            _FakeConfig("user", _FakeService(count=0)),
+            _FakeConfig("docs", _FakeService(count=0)),
+        ]
 
-    def _boom():
-        calls["count"] += 1
-        raise AssertionError("audit repository must not be accessed")
+        metrics = await dm.collect_dashboard_metrics(configs)  # type: ignore[arg-type]
 
-    monkeypatch.setattr(dm, "get_audit_repository", _boom)
-    configs = [_FakeConfig("user", _FakeService(3))]
+        assert metrics.has_any_data is False
 
-    metrics = await dm.collect_dashboard_metrics(configs, include_audit=False)  # type: ignore[arg-type]
+    async def test_any_nonzero_count_means_data(self):
+        configs = [
+            _FakeConfig("user", _FakeService(count=0)),
+            _FakeConfig("docs", _FakeService(count=1)),
+        ]
 
-    assert calls["count"] == 0
-    assert metrics.domain_counts[0].count == 3
-    assert metrics.audit.available is False
-    assert metrics.audit.by_action == {}
+        metrics = await dm.collect_dashboard_metrics(configs)  # type: ignore[arg-type]
 
+        assert metrics.has_any_data is True
 
-async def test_empty_inputs(monkeypatch):
-    _patch_audit(monkeypatch, _FakeRepo([], total=0))
+    async def test_agent_calls_alone_count_as_data(self):
+        configs = [
+            _FakeConfig("user", _FakeService(count=0)),
+            _FakeConfig("ai_usage", _FakeUsageService(total=3, ok=3)),
+        ]
 
-    metrics = await dm.collect_dashboard_metrics([])
+        metrics = await dm.collect_dashboard_metrics(configs)  # type: ignore[arg-type]
 
-    assert metrics.domain_counts == []
-    assert metrics.audit.available is True
-    assert metrics.audit.total == 0
-    assert metrics.audit.failures == 0
-    assert metrics.audit.by_action == {}
+        assert metrics.has_any_data is True
+
+    async def test_unavailable_sources_are_not_evidence_of_data(self):
+        """A broken backend must not skip the onboarding view — `None` is not a
+        record count."""
+        configs = [_FakeConfig("user", _FakeService(count=RuntimeError("db down")))]
+
+        metrics = await dm.collect_dashboard_metrics(configs)  # type: ignore[arg-type]
+
+        assert metrics.domain_counts[0].count is None
+        assert metrics.has_any_data is False
+
+    async def test_infrastructure_alone_never_counts_as_data(self):
+        """Every install has infra to report, so counting it would mean the
+        onboarding view never appears — the state every adopter opens first."""
+        metrics = await dm.collect_dashboard_metrics([])
+
+        assert metrics.infra, "settings-derived, always populated"
+        assert metrics.has_any_data is False

--- a/tests/unit/_apps/admin/test_dashboard_metrics.py
+++ b/tests/unit/_apps/admin/test_dashboard_metrics.py
@@ -265,3 +265,49 @@ class TestOnboardingDecision:
 
         assert metrics.infra, "settings-derived, always populated"
         assert metrics.has_any_data is False
+
+
+class TestInfrastructurePanelGate:
+    """Who may see the deployment's configuration posture (#368 security review).
+
+    `require_auth_allowlisted()` authenticates the dashboard without checking page
+    permissions, so without an explicit gate every admin — including one holding
+    zero grants — would read which components are stubbed. That is not a tidiness
+    concern: "Error notification: stub" tells the holder of a low-privilege
+    account that failures raise no alert.
+
+    The pre-#368 dashboard enforced the equivalent principle for its audit
+    sections, but only in a code comment — which is why removing it broke no rule
+    and failed no test. This test is that missing enforcement.
+    """
+
+    def test_accounts_permission_grants_the_panel(self):
+        from src._apps.admin.pages.dashboard import may_see_infrastructure
+
+        assert may_see_infrastructure({"accounts"}) is True
+
+    def test_zero_permission_admin_is_refused(self):
+        from src._apps.admin.pages.dashboard import may_see_infrastructure
+
+        assert may_see_infrastructure(set()) is False
+
+    def test_domain_permissions_alone_do_not_grant_it(self):
+        """A page grant is not a trust signal about infrastructure."""
+        from src._apps.admin.pages.dashboard import may_see_infrastructure
+
+        assert may_see_infrastructure({"user", "docs", "ai_usage"}) is False
+
+    def test_audit_permission_alone_does_not_grant_it(self):
+        from src._apps.admin.pages.dashboard import may_see_infrastructure
+
+        assert may_see_infrastructure({"audit_log"}) is False
+
+    def test_the_gate_is_a_registry_key(self):
+        """A typo'd key would silently refuse everyone; the registry is the
+        canonical source of valid permission keys."""
+        from src._apps.admin.pages.dashboard import _INFRA_PERMISSION
+        from src._core.infrastructure.admin.permission_registry import (
+            AdminPermissionRegistry,
+        )
+
+        assert AdminPermissionRegistry().is_valid_key(_INFRA_PERMISSION)

--- a/tests/unit/_apps/admin/test_operational_status.py
+++ b/tests/unit/_apps/admin/test_operational_status.py
@@ -1,0 +1,188 @@
+"""The operational-status panel must never render a credential (#368).
+
+The panel exists because "what is wired up" is the only non-zero information on a
+fresh install. The hazard is that several of the enable/disable predicates in
+``core_container`` key off **credentials** — ``dynamodb_access_key``,
+``s3vectors_access_key``, ``notification_webhook_url`` — so the code that decides
+what to display is reading secrets by construction. Showing a state derived from
+a secret is fine; showing the secret is not.
+
+These tests pin that mechanically rather than by review judgement: settings are
+populated with sentinel values for every credential-shaped field, and the
+rendered output is searched for them.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src._apps.admin.operational_status import (
+    _SAFE_DETAIL_FIELDS,
+    _SECRET_NAME_PARTS,
+    InfraState,
+    _detail,
+    collect_operational_status,
+)
+from src._core.config import settings
+
+# Distinctive so a substring search cannot produce a false negative.
+_SENTINEL = "SHOULD-NEVER-RENDER-b3f9a1"
+
+# Real settings *fields*. `notification_webhook_url`, `embedding_model_name` and
+# `llm_model_name` are computed properties with no setter, so the sentinel goes
+# into the fields they derive from — which is also where a real secret lives.
+_CREDENTIAL_FIELDS = (
+    "dynamodb_access_key",
+    "s3vectors_access_key",
+    "slack_webhook_url",
+    "discord_webhook_url",
+    "embedding_openai_api_key",
+    "llm_api_key",
+)
+
+
+@pytest.fixture
+def everything_enabled(monkeypatch):
+    """Turn every optional infra on, with credentials set to the sentinel.
+
+    Enabling everything is the point: a disabled panel has nothing to leak.
+    """
+    for field in _CREDENTIAL_FIELDS:
+        if hasattr(settings, field):
+            monkeypatch.setattr(settings, field, _SENTINEL, raising=False)
+    monkeypatch.setattr(settings, "storage_type", "s3", raising=False)
+    monkeypatch.setattr(settings, "broker_type", "sqs", raising=False)
+    monkeypatch.setattr(settings, "vector_store_type", "s3vectors", raising=False)
+    # `embedding_model_name` / `llm_model_name` are derived from provider+model.
+    monkeypatch.setattr(settings, "embedding_provider", "openai", raising=False)
+    monkeypatch.setattr(
+        settings, "embedding_model", "text-embedding-3-small", raising=False
+    )
+    monkeypatch.setattr(settings, "llm_provider", "openai", raising=False)
+    monkeypatch.setattr(settings, "llm_model", "gpt-4o", raising=False)
+    monkeypatch.setattr(settings, "notification_provider", "slack", raising=False)
+    monkeypatch.setattr(settings, "otel_enabled", True, raising=False)
+    return settings
+
+
+class TestNoCredentialReachesTheOutput:
+    def test_sentinel_credentials_are_absent_from_every_field(
+        self, everything_enabled
+    ) -> None:
+        rendered = " | ".join(
+            f"{row.label} {row.state} {row.detail or ''}"
+            for row in collect_operational_status()
+        )
+
+        assert _SENTINEL not in rendered, (
+            "a credential-shaped settings value reached the operational-status "
+            f"panel: {rendered}"
+        )
+
+    def test_every_allowlisted_field_is_credential_free_by_name(self) -> None:
+        """The allowlist is the enforcement point, so guard the allowlist itself.
+
+        A future field added to `_SAFE_DETAIL_FIELDS` whose name looks like a
+        credential fails here rather than silently rendering.
+        """
+        offenders = {
+            field
+            for field in _SAFE_DETAIL_FIELDS
+            for part in _SECRET_NAME_PARTS
+            if part in field
+        }
+        assert not offenders, f"credential-shaped names on the allowlist: {offenders}"
+
+    def test_detail_refuses_a_field_outside_the_allowlist(self) -> None:
+        with pytest.raises(ValueError, match="not an allowlisted display field"):
+            _detail("notification_webhook_url")
+
+    def test_dynamodb_and_s3vectors_show_no_detail_at_all(
+        self, everything_enabled
+    ) -> None:
+        """Their predicate *is* the access key, so there is nothing safe to show."""
+        rows = {row.label: row for row in collect_operational_status()}
+
+        assert rows["DynamoDB"].detail is None
+        assert rows["S3 Vectors"].detail is None
+        assert rows["DynamoDB"].state is InfraState.ACTIVE  # enabled, still no detail
+
+
+class TestStateSemantics:
+    def test_stub_and_disabled_are_not_conflated(self, monkeypatch) -> None:
+        """ADR 042 gives two different disabled behaviours and the distinction is
+        the useful part: STUB serves requests with a stand-in and therefore looks
+        like it works."""
+        # Clear the *fields*; the model-name and webhook-url properties follow.
+        for field in (
+            "embedding_provider",
+            "embedding_model",
+            "llm_provider",
+            "llm_model",
+            "notification_provider",
+            "slack_webhook_url",
+            "discord_webhook_url",
+            "storage_type",
+            "dynamodb_access_key",
+            "s3vectors_access_key",
+        ):
+            monkeypatch.setattr(settings, field, None, raising=False)
+        monkeypatch.setattr(settings, "otel_enabled", False, raising=False)
+
+        rows = {row.label: row.state for row in collect_operational_status()}
+
+        assert rows["Embedding"] is InfraState.STUB
+        assert rows["LLM"] is InfraState.STUB
+        assert rows["Error notification"] is InfraState.STUB
+        assert rows["Object storage"] is InfraState.DISABLED
+        assert rows["DynamoDB"] is InfraState.DISABLED
+        assert rows["OpenTelemetry"] is InfraState.DISABLED
+
+    def test_unset_broker_and_vector_store_report_inmemory_not_absent(
+        self, monkeypatch
+    ) -> None:
+        """`BROKER_TYPE` unset means the in-process broker that runs tasks inline
+        in the producer (#324) — reporting it as "off" would be wrong."""
+        monkeypatch.setattr(settings, "broker_type", None, raising=False)
+        monkeypatch.setattr(settings, "vector_store_type", None, raising=False)
+
+        rows = {row.label: row for row in collect_operational_status()}
+
+        assert rows["Broker"].detail == "inmemory"
+        assert rows["Broker"].state is InfraState.ACTIVE
+        assert rows["Vector store"].detail == "inmemory"
+
+
+class TestPredicateParityWithTheContainer:
+    """The panel duplicates the container's selector predicates, so pin the pair.
+
+    Duplication is deliberate — importing the DI graph into a page render to ask
+    "is this on?" is the wrong dependency — but a silent divergence would make
+    the panel lie. These compare the panel's verdict against the container's own
+    selector functions under the same settings.
+    """
+
+    @pytest.mark.parametrize(
+        ("label", "selector_name"),
+        [
+            ("Embedding", "_embedding_selector"),
+            ("LLM", "_llm_selector"),
+            ("Error notification", "_notification_selector"),
+            ("Object storage", "_storage_selector"),
+            ("DynamoDB", "_dynamodb_selector"),
+            ("S3 Vectors", "_s3vector_selector"),
+        ],
+    )
+    def test_panel_agrees_with_selector(
+        self, everything_enabled, label, selector_name
+    ) -> None:
+        from src._core.infrastructure.di import core_container
+
+        selector = getattr(core_container, selector_name)
+        rows = {row.label: row.state for row in collect_operational_status()}
+
+        panel_says_on = rows[label] is InfraState.ACTIVE
+        container_says_on = selector() == "enabled"
+        assert panel_says_on == container_says_on, (
+            f"{label}: panel={rows[label]} but {selector_name}()={selector()}"
+        )


### PR DESCRIPTION
Second of two PRs for #368. **Supersedes #372**, which GitHub closed permanently when I merged #371 with `--delete-branch`: deleting a PR's base branch closes it and it cannot be reopened. Same branch, same commits, rebased onto `main` — the earlier number is left closed as the record.

Base is now `main` (#371 is merged), so the diff is only the dashboard work: 2 commits, 5 files.

## What the dashboard answers now

| | before | after |
|---|---|---|
| sections | stat cards · audit activity chart · recent-audit table | what is wired up · agent calls + failure rate · new records (7d) |
| zero-data state | the same page with every number at 0 | a distinct onboarding screen |
| audit reads per load | 1 | 0 |

The audit sections are gone **and so is the collection behind them**. `/admin/audit-log` is a strict superset with filtering and pagination, so the landing page was reading audit data to render a worse copy of a page that already existed.

## Zero data is the default, so it gets a real screen

Every count is 0 on a fresh install — that is what every OSS adopter opens first and what a demo recording captures. Charting zeros there looks broken. That path now shows what is configured plus the next action: *"Run make demo"*, *"LLM is running a stub — set LLM_PROVIDER + LLM_MODEL"*.

`has_any_data` deliberately ignores infrastructure: every install has infra to report, so counting it would mean the onboarding view never appears. Unavailable sources (`None`) are not evidence of data either, so a broken backend does not skip past onboarding into an empty dashboard.

## Two decisions worth arguing with

**Failures are `total - ok`, not a sum of failure states.** `UsageStatus` is `Literal["ok", "error", "timeout", "rate_limited"]`. Summing the three known failures means a fourth state added later is silently counted as *success*. Subtracting from the total cannot drift that way.

**`failure_rate` is `None`, not `0.0`, when there are no calls.** A rate needs a denominator, and a healthy 0% for a system that has served nothing is a false reassurance. It renders as an em dash.

## Reachability, not new coupling

Both new sources are capability-probed off the service, matching how `count_datas` is already reached rather than importing `AiUsageService`:

- a fork that drops `ai_usage` loses the panel, not the page
- a domain whose model has no temporal column degrades its own section (the repository raises a curated 400; the facade catches it per-section)
- `visible_configs` is already permission-filtered, which is what keeps the AI read scoped — an operator without the permission never causes it

## Three layout defects were mine, and only the screenshot pass found them

None was reachable by a unit test:

1. **One chart per domain reproduced the defect #369 had just removed.** Each chart is a fixed 260px, so two domains pushed the page to **1740px** with two nearly-empty plots. Replaced with one aggregate series — the per-domain totals are already on the stat cards, and what the chart adds is shape over time.
2. **`c.empty_state` is a whole-page placeholder** (48px vertical padding, centred). Using it for an inline "no agent calls" note spent ~250px on one sentence. Muted labels instead.
3. **Step cards sized to their own text**, so the onboarding column had ragged right edges that read as a layout bug.

Page height across the three fixes: **1740 → 1255px**.

## Verification

| gate | result |
|---|---|
| `make check-core` (SQLite) | 1862 passed, 29 skipped |
| `make test-pg` (real PostgreSQL) | 1989 passed, 43 skipped |
| `make check-minimal` | 7 passed |
| `pyright` | 0 errors |

Visual: both light and dark, on the **onboarding path** (fresh database) and the **populated path** (after `make demo` + `make demo-rag`). The two paths are separate branches in the page, so exercising only one would have proven half of it.

## Security note — please read with the operational-status facade

The enable/disable predicates in `core_container` key off credentials (`dynamodb_access_key`, `s3vectors_access_key`, `notification_webhook_url`), so the code deciding what the panel shows reads secrets by construction. Reporting a state derived from a secret is fine; reporting the secret is not.

Enforced mechanically rather than by review judgement: a value renders only if its settings field is on an allowlist, `_detail` raises on anything else, and a test populates every credential-shaped field with a sentinel and searches the rendered output for it. A second test guards the allowlist itself against credential-shaped names, and a third compares the panel's verdict against each container selector so the duplicated predicates cannot silently diverge.

`STUB` and `DISABLED` are kept distinct because ADR 042 gives optional infra two different disabled behaviours, and conflating them hides the one that bites: a stub *appears* to work.

## Not done here

`/security-review` and `/review-architecture` from the execution packet have **not** been run — the packet marks the security review L3 (sensitive-data item applies), so it is the next step rather than something to self-certify in a PR description.
