### PR TITLE
fix(tests): load every model before the schema fixture runs

### DIFF
--- a/.claude/rules/commands.md
+++ b/.claude/rules/commands.md
@@ -1,6 +1,6 @@
 # Suggested Commands
 
-> Last synced: 2026-08-12 via #368 (added the `make test-pg` clean-database caveat — see #374; no new commands). Prior: 2026-08-11 via #365/PR #366 (Admin Dashboard — the UI theming block now names the neutral-mono theme instead of the Toss-style one, and records that the `--q-*` brand group must be emitted under `body` with `!important`, because NiceGUI writes that palette as an inline body style and a `:root` declaration is inert — the pre-#365 state, in which the whole brand half of the palette never applied). Prior: 2026-08-01 via #286/PR #313 + #315/PR #319 (Error Notification — severity channel routing section and example added; `:159` corrected, it had contradicted the Coverage bullet in the same block since #310). Prior: 2026-07-28 via #310 (Error Notification — dispatch extended to Taskiq worker task failures; the server-only scope note from PR #311 is superseded). Prior: 2026-07-27 via #307/PR #311 (Error Notification section — runbook pointer, server-only dispatch scope, first-dispatch disabled warning). Prior: 2026-07-23 via #17/PR #304 (added the Error Notification section — `NOTIFICATION_*` env vars for Slack/Discord webhook alerts fired from the exception handlers). Prior: 2026-07-20 via ADR 056 (added `tools/check_migration_safety.py` — advisory unsafe-DDL scan for zero-downtime migrations — to Architecture Verification + DB Migrations). Prior: 2026-07-20 via #293 (added `make perf-test` — Locust performance-test harness — to the Test section).
+> Last synced: 2026-08-12 via #374 (the `make test-pg` clean-database caveat is gone — the fixture now loads every model, so a pre-existing schema no longer breaks it) and #368 (no new commands). Prior: 2026-08-11 via #365/PR #366 (Admin Dashboard — the UI theming block now names the neutral-mono theme instead of the Toss-style one, and records that the `--q-*` brand group must be emitted under `body` with `!important`, because NiceGUI writes that palette as an inline body style and a `:root` declaration is inert — the pre-#365 state, in which the whole brand half of the palette never applied). Prior: 2026-08-01 via #286/PR #313 + #315/PR #319 (Error Notification — severity channel routing section and example added; `:159` corrected, it had contradicted the Coverage bullet in the same block since #310). Prior: 2026-07-28 via #310 (Error Notification — dispatch extended to Taskiq worker task failures; the server-only scope note from PR #311 is superseded). Prior: 2026-07-27 via #307/PR #311 (Error Notification section — runbook pointer, server-only dispatch scope, first-dispatch disabled warning). Prior: 2026-07-23 via #17/PR #304 (added the Error Notification section — `NOTIFICATION_*` env vars for Slack/Discord webhook alerts fired from the exception handlers). Prior: 2026-07-20 via ADR 056 (added `tools/check_migration_safety.py` — advisory unsafe-DDL scan for zero-downtime migrations — to Architecture Verification + DB Migrations). Prior: 2026-07-20 via #293 (added `make perf-test` — Locust performance-test harness — to the Test section).
 > Purpose: Quick reference for Claude Code when executing shell commands.
 > Also referenced when running Skills.
 > Default Flow context: see [`AGENTS.md` § Default Coding Flow](../../AGENTS.md#default-coding-flow). The commands below are consulted by the `implement` and `verify` steps; this file is **not** a primary entry point in the Default Flow.
@@ -71,11 +71,11 @@ make smoke-examples # copy-flow smoke: every example boots after cp-to-src (#260
 make perf-test
 
 # Run against real PostgreSQL (docker-compose.local.yml postgres service).
-# CAVEAT (#374): only works against a database with no tables yet. If the schema
-# is already there, the session fixture's drop_all dies on the refresh_token ->
-# user FK and EVERY test errors at setup, which looks like a broken change.
-# Reset first:  docker exec fastapi-agent-blueprint-postgres \
-#                 psql -U postgres -c 'DROP SCHEMA public CASCADE; CREATE SCHEMA public;'
+# Works against a database that already holds the schema since #374 — before that
+# fix, a partial `Base.metadata` (whatever the selected tests happened to import)
+# made the fixture's drop_all die on the refresh_token -> user FK, and every test
+# errored at setup. `tests/conftest.py` now calls `load_models()` so metadata is
+# complete regardless of test selection; do not remove that call.
 make test-pg
 # or manually:
 TEST_DB_ENGINE=postgresql \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,32 @@ import pytest
 import pytest_asyncio
 import structlog
 
+from migrations.env_utils import load_models
 from src._core.infrastructure.persistence.rdb.config import DatabaseConfig
 from src._core.infrastructure.persistence.rdb.database import Base, Database
+
+# Populate ``Base.metadata`` with *every* model before any fixture touches the
+# schema (#374).
+#
+# Without this, metadata holds only the models that the collected test modules
+# happen to import, so it varies with the test selection. On PostgreSQL that
+# turns `drop_all` into a coin flip: run a single file whose imports omit
+# `refresh_token` and the fixture tries to drop `user` while the real table's
+# `refresh_token_user_id_fkey` still references it —
+# `DependentObjectsStillExistError`, at *setup*, for every test in the file. It
+# looks like a broken change rather than a partial-metadata problem.
+#
+# The full-suite run masked it (enough modules imported enough models) and SQLite
+# masked it entirely (no FK enforcement, fresh in-memory database), so the bug
+# only appeared when someone ran a subset against a PostgreSQL that already had
+# the schema — from `make dev`, an `alembic upgrade`, or a previous run.
+#
+# Reusing the Alembic helper rather than re-listing model paths here keeps one
+# source of truth for where models live; it only imports
+# `src/*/infrastructure/database/models/**` plus the explicit `_core` packages,
+# so it pulls in no optional-extra dependency and `make check-minimal` is
+# unaffected. `importlib` caches, so calling it at import time is idempotent.
+load_models()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/_core/infrastructure/persistence/rdb/test_metadata_completeness.py
+++ b/tests/unit/_core/infrastructure/persistence/rdb/test_metadata_completeness.py
@@ -1,0 +1,97 @@
+"""`Base.metadata` must be complete regardless of which tests are selected (#374).
+
+The `test_db` fixture calls `drop_all` / `create_all` against whatever
+`Base.metadata` happens to hold. That used to depend on which test modules the
+run collected, because nothing imported the models deliberately — so metadata
+varied with `-k`, with a single-file run, and with collection order.
+
+On PostgreSQL that made `drop_all` a coin flip. A selection whose imports omitted
+`refresh_token` left metadata unaware that `refresh_token.user_id` references
+`user`, so the fixture tried to drop `user` first and PostgreSQL refused:
+
+    DependentObjectsStillExistError: cannot drop table "user" because other
+    objects depend on it
+    DETAIL: constraint refresh_token_user_id_fkey on table refresh_token ...
+
+Every test in the file then errored at *setup*, which reads as a broken change
+rather than a partial-metadata problem. Two things hid it: the full suite
+imported enough models by accident, and SQLite enforces no FKs and starts from a
+fresh in-memory database. It only surfaced against a PostgreSQL that already had
+the schema — from `make dev`, an `alembic upgrade`, or an earlier run.
+
+**Running this file on its own is the reproduction.** In isolation nothing else
+imports the models, so if `conftest.py` stops calling `load_models()` these
+assertions fail here. In a full-suite run they would pass either way, which is
+precisely why the defect survived: a green full run proves nothing about this.
+"""
+
+from __future__ import annotations
+
+from src._core.infrastructure.persistence.rdb.database import Base
+
+# Cross-domain FK pairs are the ones that break `drop_all` when metadata is
+# partial — a table can only be dropped after its dependants, and metadata is
+# the only thing that knows the order.
+_FK_DEPENDENT_PAIRS = (
+    ("refresh_token", "user"),
+    ("admin_refresh_token", "admin_identity"),
+)
+
+# One representative table per model-bearing domain, plus the cross-cutting
+# `_core` tables that live outside the per-domain layout `load_models` scans by
+# convention. A new domain with models belongs here.
+_EXPECTED_TABLES = frozenset(
+    {
+        "user",
+        "refresh_token",
+        "admin_identity",
+        "admin_refresh_token",
+        "document",
+        "ai_usage_log",
+        "admin_audit_log",
+    }
+)
+
+
+def test_every_expected_table_is_registered() -> None:
+    missing = sorted(_EXPECTED_TABLES - set(Base.metadata.tables))
+    assert not missing, (
+        f"missing from Base.metadata: {missing}. "
+        "conftest.py must call load_models() before any fixture touches the "
+        "schema; without it metadata depends on the test selection (#374)."
+    )
+
+
+def test_cross_domain_foreign_keys_are_visible_to_metadata() -> None:
+    """Both ends of each FK must be registered, or `drop_all` cannot order them.
+
+    Asserting the tables exist is not enough — the dependency itself has to be in
+    metadata, which is what `sorted_tables` uses.
+    """
+    for dependent, target in _FK_DEPENDENT_PAIRS:
+        assert dependent in Base.metadata.tables, f"{dependent} not registered"
+        assert target in Base.metadata.tables, f"{target} not registered"
+
+        table = Base.metadata.tables[dependent]
+        referenced = {fk.column.table.name for fk in table.foreign_keys}
+        assert target in referenced, (
+            f"{dependent} does not declare its FK to {target} in metadata; "
+            "drop_all would order them arbitrarily and PostgreSQL would refuse"
+        )
+
+
+def test_drop_order_places_dependants_before_their_targets() -> None:
+    """The actual invariant `drop_all` relies on.
+
+    `sorted_tables` is create order; drop order is its reverse. This asserts the
+    property directly rather than trusting that registering the tables was
+    enough.
+    """
+    order = [table.name for table in Base.metadata.sorted_tables]
+    drop_order = list(reversed(order))
+
+    for dependent, target in _FK_DEPENDENT_PAIRS:
+        assert drop_order.index(dependent) < drop_order.index(target), (
+            f"{dependent} would be dropped after {target}, which PostgreSQL "
+            "rejects while the FK constraint exists"
+        )


### PR DESCRIPTION
Closes #374.

## The bug

`tests/conftest.py` never imported the models. So `Base.metadata` held only whatever the collected test modules happened to import — measured as `['user']` for the entire `persistence/rdb` directory.

On PostgreSQL that made `drop_all` order-dependent. Metadata unaware that `refresh_token.user_id` references `user` tried to drop `user` first, and PostgreSQL refused while `refresh_token_user_id_fkey` existed. Every test in the file errored at **setup**, which reads as a broken change rather than a partial-metadata problem.

Two things hid it:

- the full-suite run imported enough models **by accident**
- SQLite enforces no FKs and starts from a fresh in-memory database

So it only surfaced when someone ran a subset against a PostgreSQL that already held the schema — from `make dev`, an `alembic upgrade`, or an earlier run.

## The fix

Call the existing Alembic `load_models()` helper at conftest import time. Reusing it rather than re-listing model paths keeps one source of truth for where models live. It imports only `src/*/infrastructure/database/models/**` plus the explicit `_core` packages, so it pulls in no optional-extra dependency — `make check-minimal` still passes.

## Causality was established, not assumed — and it took three attempts

My first two measurements contradicted each other: the same command appeared to pass with and without the fix. The cause was my own method — a previous `drop_all` had already destroyed the schema I was measuring against, and `alembic upgrade head` silently did nothing because `alembic_version` still said *head*. So I was testing against an empty database and proving nothing.

Verified from one clean state per measurement: reset the schema, `alembic upgrade head`, confirm `refresh_token_user_id_fkey` exists, then run the same single test.

| condition | result |
|---|---|
| without `load_models()` | **ERROR at setup** (`DBAPIError`) |
| with `load_models()` | 1 passed |

The mechanism was also confirmed in isolation: with metadata built from only the user model, a standalone `drop_all` against an FK-bearing schema raises; with `load_models()` it succeeds.

`make test-pg` against a pre-existing schema — the scenario the issue reports — now passes in full: **1997 passed**.

## Tests

`test_metadata_completeness.py` pins three things: every expected table is registered, both ends of each cross-domain FK are visible to metadata, and the derived **drop order** places dependants before their targets (the property `drop_all` actually relies on).

Its docstring records why running that file alone is the meaningful check: in isolation nothing else imports the models, so removing the `load_models()` call fails there, while a full-suite run would pass either way — which is precisely why the defect survived.

## Also

`commands.md` loses the manual-reset caveat added earlier today. It is now false, and a stale workaround is worse than none.

## Verification

| gate | result |
|---|---|
| `make test-pg` **against a non-empty schema** | 1997 passed, 43 skipped |
| `make check-core` (SQLite) | 1870 passed, 29 skipped |
| `make check-minimal` | 7 passed |
| `pyright` | 0 errors |
| `pre-commit run --all-files` | exit 0 |

## Governor Footer

- trigger: yes
- reviewer: self-structured
- rounds: 1
- r-points-fixed: 1
- r-points-deferred: 0
- r-points-rejected: 0
- touched-adr-consequences: none
- pr-scope-notes: Governor surface is one line in .claude/rules/commands.md removing a now-false caveat. R1 = my first two before/after measurements contradicted each other because I measured against a schema a previous drop_all had already destroyed; Fixed by re-measuring from one clean state per run and confirming the FK exists first. Cross-tool Codex review not attempted: codex exec timed out with no final answer twice earlier in this session on codex-cli 0.144.4, so self-structured per AGENTS.md Independent Review Trigger. No ADR consequence added — this is a test-fixture correctness fix, not a durable architecture constraint.
- final-verdict: merge-ready
- links: https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/377, n/a
