### PR TITLE
feat(types): widen pyright to persistence/rdb

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,10 @@ include = [
     "src/admin_identity",
     "src/auth",
     "src/ai_usage",
+    # Step 2a. The rest of _core/infrastructure stays out for now: the aioboto3
+    # client context managers and aiobotocore TypedDicts there are third-party
+    # stub friction, not findings this repo can fix in code.
+    "src/_core/infrastructure/persistence/rdb",
 ]
 pythonVersion = "3.12"
 typeCheckingMode = "standard"

--- a/src/_core/infrastructure/persistence/rdb/base_repository.py
+++ b/src/_core/infrastructure/persistence/rdb/base_repository.py
@@ -9,6 +9,7 @@ import structlog
 from pydantic import BaseModel
 from sqlalchemy import Date, DateTime, String, func, or_, select
 from sqlalchemy.orm import InstrumentedAttribute
+from sqlalchemy.sql.elements import UnaryExpression
 
 from src._core.domain.value_objects.daily_count import DailyCount
 from src._core.exceptions.base_exception import BaseCustomException
@@ -332,13 +333,17 @@ class BaseRepository(Generic[ReturnDTO], ABC):
         day = func.date(column)
         async with self.database.session() as session:
             result = await session.execute(
-                select(day.label("day"), func.count().label("count"))
+                # Labelled `total`, not `count`: `Row` is a sequence, so `row.count`
+                # collides with `tuple.count`. SQLAlchemy does resolve the label
+                # first (verified), but depending on it shadowing a builtin
+                # method is fragile and unclear to read.
+                select(day.label("day"), func.count().label("total"))
                 .where(column >= since)
                 .group_by(day)
                 .order_by(day)
             )
             return [
-                DailyCount(day=self._as_date(row.day), count=row.count)
+                DailyCount(day=self._as_date(row.day), count=row.total)
                 for row in result
             ]
 
@@ -376,7 +381,7 @@ class BaseRepository(Generic[ReturnDTO], ABC):
                 .execution_options(populate_existing=True)
             )
 
-    def _stable_order(self) -> tuple[InstrumentedAttribute, ...]:
+    def _stable_order(self) -> tuple[UnaryExpression[Any], ...]:
         """A deterministic tiebreaker for offset pagination (ADR 058 D2).
 
         Offset paging over an unordered result set can repeat or skip rows,

--- a/src/_core/infrastructure/persistence/rdb/database.py
+++ b/src/_core/infrastructure/persistence/rdb/database.py
@@ -190,7 +190,10 @@ class Database:
 
     @asynccontextmanager
     async def session(self) -> AsyncGenerator[AsyncSession, None]:
-        session = None
+        # Annotated, not bare `= None`: without it the declared type is `None`,
+        # so the `if session:` guards below narrow to `Never` and every
+        # `await session.rollback()` reads as un-awaitable to a type checker.
+        session: AsyncSession | None = None
 
         try:
             session = self.async_session_factory()


### PR DESCRIPTION
#381 step 2a. The RDB persistence package reaches 0 errors and enters the allow-list.

Highest-leverage target in `_core`: `BaseRepository` and `Database` are inherited or used by **6 domains and 9 examples**, so a type defect there ships N times.

## Four fixes, three of them real

**`Database.session()` narrowed to `Never`.** It declared `session = None`, so the inferred type was `None`, the `if session:` guards narrowed to `Never`, and every `await session.rollback()` in the three exception paths read as un-awaitable. Now `session: AsyncSession | None = None`.

**`_stable_order()` had the wrong return type.** Declared `-> tuple[InstrumentedAttribute, ...]`, but it returns `(self._id_column().desc(),)` — a `UnaryExpression`. Wrong since ADR 058 introduced it, and it also mis-typed the `ordering.extend(...)` call site (2 of the 6 errors were one cause).

**A column labelled `count` collided with `tuple.count`.** `count_datas_by_day` did `func.count().label("count")` then read `row.count`, and `Row` is a sequence. Verified at runtime that SQLAlchemy resolves the label first — `row.count` really is the value, not the bound method:

```
row.count -> 1     callable? -> False     row._mapping -> {'day': 'x', 'count': 1}
```

So **not a live bug**. But depending on a label shadowing a builtin method is fragile and unclear to read, so the label is now `total`. This is code I added two PRs ago; the type checker found it as soon as the package was in scope, which is the argument for widening in the first place.

## What deliberately stays out

The rest of `_core/infrastructure` is not added. Its remaining findings are aioboto3 client context managers (`Object of type "_" cannot be used with "async with"`) and aiobotocore `TypedDict` mismatches — third-party stub friction that no code change here fixes. Adding those paths would mean `# type: ignore` standing in for cleanliness, which is the opposite of the point.

That is also why the allow-list gains a **sub-package** path rather than `src/_core/infrastructure`: the granularity is what lets clean code be gated without dragging unfixable stub noise along.

## Verification

| gate | result |
|---|---|
| `pyright` (allow-list, what CI runs) | **0 errors** |
| `pyright src` (remaining debt) | 55 → **49** |
| `make check-core` (SQLite) | 1920 passed, 4 skipped |
| `make test-pg` (real PostgreSQL) | 2085 passed, 16 skipped |
| `make check-minimal` | 7 passed |

The suites matter more than usual here: both changed files are on the path of every database call in the repo.

## Remaining in #381

Step 2b — the rest of `_core` (the stub-friction cluster; likely needs a decision about scoped suppression rather than fixes). Step 3 — `_apps`. Step 4 — retire the mypy hook (#375).


## Governor Footer

- trigger: yes
- reviewer: self-structured
- rounds: 1
- r-points-fixed: 1
- r-points-deferred: 1
- r-points-rejected: 0
- touched-adr-consequences: none
- pr-scope-notes: Governor surface is the [tool.pyright] section of pyproject.toml (governor-paths.md Tier C, "linting/typing/policy sections"). I missed this again - one PR earlier the trigger was .github/workflows and I checked only that line this time; the Validate job caught it, and from here I run tools/check_governor_footer.py locally before opening. R1 = _stable_order has been annotated tuple[InstrumentedAttribute, ...] since ADR 058 while returning a UnaryExpression; Fixed, and it accounted for 2 of the 6 findings. R2 = the rest of _core/infrastructure is Deferred-with-rationale: its findings are aioboto3 context managers and aiobotocore TypedDicts, third-party stub friction no code change here fixes, so it stays out of the allow-list rather than entering behind suppressions. Cross-tool review not obtained: codex exec 0.147.0 answers small prompts (it reviewed #375 substantively earlier today and corrected two of my claims) but echoes and exits without generating for a large prompt carrying an inline diff - reproduced four times, in-repo and from /tmp. Self-structured per AGENTS.md Independent Review Trigger; that self-review is what found the row.count / tuple.count collision in my own recent code.
- final-verdict: merge-ready
- links: https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/383, n/a
