### PR TITLE
feat(types): widen pyright to every admin page

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,12 @@ include = [
     # client context managers and aiobotocore TypedDicts there are third-party
     # stub friction, not findings this repo can fix in code.
     "src/_core/infrastructure/persistence/rdb",
+    # Step 3. Every admin page. `_apps/admin/bootstrap.py` and
+    # `_apps/server/bootstrap.py` stay out: their findings are
+    # dependency-injector `Provider[Any]` dynamic attributes, module-attribute
+    # injection, and Starlette's `add_exception_handler` signature — framework
+    # contracts, not code this repo can annotate its way out of.
+    "src/_apps/admin/pages",
 ]
 pythonVersion = "3.12"
 typeCheckingMode = "standard"

--- a/src/_apps/admin/pages/accounts.py
+++ b/src/_apps/admin/pages/accounts.py
@@ -74,9 +74,12 @@ async def accounts_page():
         temp_pw_label.set_visibility(False)
 
         async def create_account():
-            username = new_username.value.strip()
-            full_name = new_full_name.value.strip()
-            email = new_email.value.strip()
+            # `ui.input().value` is `str | None`; the falsy guard below already
+            # treats a blank field as missing, so coercing None to "" keeps the
+            # same behaviour instead of relying on the widget never being None.
+            username = (new_username.value or "").strip()
+            full_name = (new_full_name.value or "").strip()
+            email = (new_email.value or "").strip()
             if not (username and full_name and email):
                 ui.notify("All fields are required", type="warning")
                 return

--- a/src/_apps/admin/pages/change_password.py
+++ b/src/_apps/admin/pages/change_password.py
@@ -54,10 +54,14 @@ async def change_password_page():
         )
 
         async def do_change():
-            if len(new_pw.value) < 8:
+            # Widget values are `str | None`; read them once, coerced.
+            current_value = current_pw.value or ""
+            new_value = new_pw.value or ""
+            confirm_value = confirm_pw.value or ""
+            if len(new_value) < 8:
                 ui.notify("New password must be at least 8 characters", type="warning")
                 return
-            if new_pw.value != confirm_pw.value:
+            if new_value != confirm_value:
                 ui.notify("Passwords do not match", type="warning")
                 return
 
@@ -65,8 +69,8 @@ async def change_password_page():
                 try:
                     await get_admin_account_use_case().change_password(
                         admin_id=session.user_id,
-                        current_password=current_pw.value,
-                        new_password=new_pw.value,
+                        current_password=current_value,
+                        new_password=new_value,
                     )
                 except AdminInvalidCredentialsException as exc:
                     await get_audit_logger().log(

--- a/src/_apps/admin/pages/dashboard.py
+++ b/src/_apps/admin/pages/dashboard.py
@@ -122,16 +122,25 @@ def _render_ai_usage(usage: AiUsageMetrics) -> None:
                 "admin-text-muted"
             )
             return
+        # The three counters are set together by the facade — all int, or all
+        # None when the read failed. Narrowing them here enforces that at the
+        # boundary rather than assuming it: `or 0` would collapse "no data" into
+        # "zero", which is exactly the distinction the facade keeps.
+        calls, failures, tokens = usage.calls, usage.failures, usage.total_tokens
+        if failures is None or tokens is None:
+            ui.label("Agent usage unavailable").classes("admin-text-muted")
+            return
+
         with ui.row().classes("q-gutter-md"):
-            c.stat_card("Calls", usage.calls, icon="smart_toy")
-            c.stat_card("Failures", usage.failures, icon="error")
+            c.stat_card("Calls", calls, icon="smart_toy")
+            c.stat_card("Failures", failures, icon="error")
             rate = usage.failure_rate
             c.stat_card(
                 "Failure rate",
                 f"{rate:.1%}" if rate is not None else "—",
                 icon="percent",
             )
-            c.stat_card("Tokens", usage.total_tokens, icon="toll")
+            c.stat_card("Tokens", tokens, icon="toll")
 
 
 def _render_growth(metrics: DashboardMetrics) -> None:

--- a/src/_apps/admin/pages/login.py
+++ b/src/_apps/admin/pages/login.py
@@ -66,8 +66,10 @@ def login_page(request: Request):
             async with button_loading(login_btn):
                 try:
                     session = await get_admin_auth_provider().authenticate(
-                        username.value,
-                        password.value,
+                        # `str | None` from the widgets; an empty string reaches
+                        # the same invalid-credentials path as a wrong one.
+                        username.value or "",
+                        password.value or "",
                         ip_address=client_ip,
                     )
                 except AdminSetupRequiredException:

--- a/src/_apps/admin/pages/setup.py
+++ b/src/_apps/admin/pages/setup.py
@@ -18,6 +18,7 @@ from src._core.infrastructure.admin.error_handler import (
 )
 from src._core.infrastructure.admin.layout import button_loading
 from src._core.infrastructure.admin.theme import AdminClasses
+from src.admin_identity.domain.dtos.admin_identity_dto import AdminIdentityDTO
 from src.admin_identity.domain.exceptions.admin_identity_exceptions import (
     AdminSetupForbiddenException,
 )
@@ -53,27 +54,33 @@ async def setup_page():
         result_card.set_visibility(False)
 
         async def create_first_admin():
-            username = username_input.value.strip()
-            full_name = full_name_input.value.strip()
-            email = email_input.value.strip()
+            # `ui.input().value` is `str | None`; the falsy guard below already
+            # treats a blank field as missing, so coercing None to "" keeps the
+            # same behaviour instead of relying on the widget never being None.
+            username = (username_input.value or "").strip()
+            full_name = (full_name_input.value or "").strip()
+            email = (email_input.value or "").strip()
             if not (username and full_name and email):
                 ui.notify("All fields are required", type="warning")
                 return
 
-            setup_already_complete = False
+            # Holds the result instead of a separate `setup_already_complete`
+            # flag. The flag worked, but the guarantee that `new_admin` is bound
+            # lived in a correlation between that flag and an early `return` —
+            # nothing enforced it, so an `except` added later that neither set the
+            # flag nor returned would raise UnboundLocalError here, in a flow that
+            # runs once per deployment. `None` carries the same information and a
+            # type checker can see it.
+            created: tuple[AdminIdentityDTO, str] | None = None
             async with button_loading(create_btn):
                 try:
-                    (
-                        new_admin,
-                        temp_password,
-                    ) = await get_admin_account_use_case().create_first_admin(
+                    created = await get_admin_account_use_case().create_first_admin(
                         username=username,
                         full_name=full_name,
                         email=email,
                         bootstrap_username=settings.admin_bootstrap_username,
                     )
                 except AdminSetupForbiddenException as exc:
-                    setup_already_complete = True
                     await get_audit_logger().log(
                         action=AdminAction.FIRST_ADMIN_CREATE,
                         domain="auth",
@@ -94,11 +101,13 @@ async def setup_page():
                     )
                     await AdminErrorHandler.handle(exc, context="admin_setup_create")
                     return
-            # Navigate only after loading state is cleared (button not yet torn down).
-            if setup_already_complete:
+            # Navigate only after loading state is cleared (button not yet torn
+            # down) — which is why this is not handled inside the except block.
+            if created is None:
                 ui.notify("Setup is already complete. Please log in.", type="warning")
                 ui.navigate.to("/admin/login")
                 return
+            new_admin, temp_password = created
 
             await get_audit_logger().log(
                 action=AdminAction.FIRST_ADMIN_CREATE,


### PR DESCRIPTION
#381 step 3. `src/_apps/admin/pages` reaches 0 errors and enters the allow-list — every admin page is now type-gated. 20 findings fixed, and the two clusters that mattered were not annotation noise.

## Seven `possibly unbound` in the setup wizard

`new_admin` / `temp_password` were assigned inside a `try`, and the guarantee they were bound by the time they were used lived in a correlation between a separate `setup_already_complete` flag and an early `return`. **Nothing enforced that correlation.**

Not a live bug today — I traced every path: the forbidden-exception handler sets the flag and falls through to a `return`, the generic handler returns directly. But an `except` added later that neither set the flag nor returned would raise `UnboundLocalError` in the flow that **runs once per deployment**, creating the first admin.

The result now lives in `created: tuple[AdminIdentityDTO, str] | None`, which carries the same information where a type checker can see it, and the flag is gone. The navigate-after-loading-state behaviour the flag existed for is preserved, and now commented so the next person does not re-introduce the flag.

## Eleven `str | None` uses

`ui.input().value` is `str | None`. Six `.strip()` calls and five arguments across accounts, setup, change_password and login. Each site coerces once; behaviour is unchanged because the existing falsy guards already treat blank as missing — an empty field still hits "All fields are required", an empty credential still hits the invalid-credentials path.

## Two in code I wrote earlier this session

`_render_ai_usage` passed `usage.failures` and `usage.total_tokens` (both `int | None`) to `stat_card`, having narrowed only `usage.calls`. The facade sets all three together — all int, or all None — so the page narrows at the boundary instead of assuming it.

Deliberately **not** `or 0`: that collapses "could not be read" into "zero", which is precisely the distinction the facade's docstring exists to preserve.

## What stays out, and why the path is a sub-package

`_apps/admin/bootstrap.py` and `_apps/server/bootstrap.py` keep nine findings and are excluded:

- 5 × `Cannot access attribute … for class "Provider[Any]"` — dependency-injector dynamic attributes on the `DynamicContainer` this repo deliberately uses for domain auto-discovery
- 1 × `Cannot assign to attribute "page_configs" for class "ModuleType"` — the documented module-attribute injection
- 3 × Starlette's `add_exception_handler` rejecting handlers typed to concrete exception subclasses, which is the ordinary FastAPI pattern

Framework contracts, not code this repo can annotate its way out of. Adding those paths would mean suppressions standing in for cleanliness.

## Verification

Beyond the type checker, because this changed page logic:

| gate | result |
|---|---|
| `pyright` (allow-list) | **0 errors** |
| `pyright src` (remaining debt) | 49 → **29** |
| `make check-core` | 1922 passed, 4 skipped |
| `make check-minimal` | 7 passed |

Flows driven in a real browser against `make quickstart`, on a fresh database:

```
login empty-submit stays on login:        True   (no AttributeError on None)
bootstrap login lands on:                 setup
setup empty-submit stays on setup:        True
first-admin created:                      True   (the restructured `created` path)
one-time credential block rendered:       True
```

The last two are the ones that matter — they exercise the rewritten branch that previously depended on the flag/return correlation.

## Remaining in #381

Step 2b — the rest of `_core` (stub-friction cluster; needs a decision on scoped exclusion rather than fixes). Step 4 — retire the mypy hook (#375). The 29 remaining findings are now, by construction, almost entirely third-party/framework friction rather than repo code.

## Governor Footer

- trigger: yes
- reviewer: self-structured
- rounds: 1
- r-points-fixed: 2
- r-points-deferred: 1
- r-points-rejected: 0
- touched-adr-consequences: none
- pr-scope-notes: Governor surface is the [tool.pyright] section of pyproject.toml (governor-paths.md Tier C). Checked with tools/check_governor_footer.py locally before opening this time - the two previous PRs in this series each tripped Validate on a different line of that same list. R1 = setup wizard possibly-unbound, restructured to a typed Optional result; Fixed. R2 = my own _render_ai_usage passed int | None counters to stat_card; Fixed by narrowing at the boundary rather than `or 0`. R3 = the two bootstrap modules are Deferred-with-rationale (dependency-injector Provider[Any], module-attribute injection, Starlette add_exception_handler) and stay outside the allow-list rather than entering behind suppressions. Cross-tool review not obtained: codex exec 0.147.0 answers small prompts but echoes and exits without generating for a large prompt carrying an inline diff, reproduced four times in-repo and from /tmp. Self-structured per AGENTS.md Independent Review Trigger, supplemented here by browser verification of the changed flows rather than tests alone.
- final-verdict: merge-ready
- links: https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/384, n/a
