### PR TITLE
feat(types): widen pyright to the admin shell

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,8 @@ include = [
     # injection, and Starlette's `add_exception_handler` signature — framework
     # contracts, not code this repo can annotate its way out of.
     "src/_apps/admin/pages",
+    # The admin shell itself — inherited by every domain admin page.
+    "src/_core/infrastructure/admin",
 ]
 pythonVersion = "3.12"
 typeCheckingMode = "standard"

--- a/src/_core/infrastructure/admin/audit/repository.py
+++ b/src/_core/infrastructure/admin/audit/repository.py
@@ -8,8 +8,9 @@ detail dialog), and ``delete_older_than`` (retention cleanup).
 
 from collections.abc import Callable
 from datetime import UTC, datetime
+from typing import cast
 
-from sqlalchemy import delete, func, select
+from sqlalchemy import CursorResult, delete, func, select
 
 from src._core.infrastructure.admin.audit.dtos.audit_log_dto import (
     AdminAction,
@@ -177,7 +178,9 @@ class AdminAuditLogRepository:
                 delete(AdminAuditLog).where(AdminAuditLog.created_at < naive_cutoff)
             )
             await session.commit()
-            return result.rowcount or 0
+            # `AsyncSession.execute` is typed `Result[Any]`, but a DML statement
+            # returns a `CursorResult`, which is where `rowcount` lives.
+            return cast(CursorResult, result).rowcount or 0
 
     # ── Helpers ──────────────────────────────────────────────────────────────
 

--- a/src/_core/infrastructure/admin/base_admin_page.py
+++ b/src/_core/infrastructure/admin/base_admin_page.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from datetime import date, datetime
 from typing import TYPE_CHECKING, Any
 
 from nicegui import ui
@@ -268,8 +269,13 @@ class BaseAdminPage:
     def render_pagination(self, pagination: PaginationInfo, search: str) -> None:
         """Hook: render prev/next pagination (delegates to the pagination builder)."""
 
-        def _build_page_url(target_page: int) -> str:
-            params = f"page={target_page}"
+        def _build_page_url(target_page: int | None) -> str:
+            # `previous_page` / `next_page` are None at the ends of the range.
+            # `c.pagination` disables the corresponding button there, so this
+            # branch is unreachable in practice — falling back to the current
+            # page keeps it harmless rather than building `page=None` if that
+            # ever changes.
+            params = f"page={target_page or pagination.current_page}"
             if search:
                 params += f"&search={search}"
             return f"/admin/{self.domain_name}?{params}"
@@ -303,7 +309,10 @@ class BaseAdminPage:
                     display_value = "****" if value else EMPTY_DISPLAY
                 elif is_empty:
                     display_value = EMPTY_DISPLAY
-                elif hasattr(value, "isoformat"):
+                elif isinstance(value, (datetime, date)):
+                    # `isinstance`, not `hasattr("isoformat")`: a type checker
+                    # cannot narrow through hasattr, and these are the only two
+                    # types the branch was ever meant to catch.
                     display_value = value.isoformat()
                 else:
                     display_value = str(value)

--- a/src/_core/infrastructure/admin/error_handler.py
+++ b/src/_core/infrastructure/admin/error_handler.py
@@ -19,6 +19,11 @@ Design rules:
 
 from __future__ import annotations
 
+from typing import Literal
+
+# `ui.notify(type=...)` takes a Quasar notification kind, not any string.
+_NotifyType = Literal["positive", "negative", "warning", "info", "ongoing"]
+
 import functools
 from collections.abc import Awaitable, Callable
 from typing import TypeVar
@@ -58,7 +63,7 @@ class AdminErrorHandler:
     """Shared admin error surface: sanitized notify + structured log + escalate."""
 
     @staticmethod
-    def _safe_message(exc: Exception) -> tuple[str, str]:
+    def _safe_message(exc: Exception) -> tuple[str, _NotifyType]:
         """Return ``(message, notify_type)``; never leak ``str(exc)`` to the UI."""
         if _is_user_safe(exc):
             return exc.message, "warning"  # type: ignore[attr-defined]


### PR DESCRIPTION
#381 step 2b (partial). `src/_core/infrastructure/admin` reaches 0 errors and enters the allow-list — the shell every domain admin page inherits.

## This turned out to be code, not the policy decision I expected

I had scoped step 2b as "decide how to treat third-party stub friction". Measuring it properly, **6 of the remaining `_core` findings were repo code**, so they got fixed instead:

**`hasattr` cannot narrow a type.** `hasattr(value, "isoformat")` followed by `value.isoformat()` left the call unchecked. Now `isinstance(value, (datetime, date))`, which narrows *and* is more precise — those are the only two types the branch was ever meant to catch. Verified in a browser that detail-page timestamps still render, since `model_dump()` keeps `datetime` objects and the branch is live:

```
detail page url: 1
ISO timestamps rendered: 2  ['2026-08-12T09:21', '2026-08-12T09:21']
```

**`_build_page_url(target_page: int)` was handed `int | None`.** `pagination.previous_page` / `next_page` are None at the ends of the range. `c.pagination` disables the corresponding button there, so it is unreachable today — the signature now admits None and falls back to the current page rather than building `page=None` if that ever changes.

**`_safe_message` returned `tuple[str, str]`** and fed `ui.notify(type=...)`, which takes a Quasar notification kind. Now a `Literal` alias, so a typo in a future branch fails the check instead of silently rendering an untyped toast.

**`session.execute(delete(...))` is typed `Result[Any]`** but returns a `CursorResult` for DML, which is where `rowcount` lives. Cast, with the reason at the call site.

## Remaining debt, now genuinely external

`pyright src` **29 → 23**. What is left:

| cause | count | fixable here? |
|---|---|---|
| aioboto3 client context managers | 6 | no |
| dependency-injector `Provider[Any]` + module-attribute injection | 6 | no |
| Starlette `add_exception_handler` | 3 | no |
| aiobotocore `TypedDict` | 3 | no |
| `NoReturn is not awaitable` in the S3 vector store | 4 | **yes — next target** |
| misc `float | None` in taskiq middleware | 1 | yes |

So step 2b's policy question is smaller than I framed it: 5 of the 23 are still repo code, and the other 18 are the genuine "decide how to treat this" set.

## Verification

| gate | result |
|---|---|
| `pyright` (allow-list) | **0 errors** |
| `pyright src` | 29 → **23** |
| `make check-core` | 1924 passed, 4 skipped |
| `make check-minimal` | 7 passed |
| browser | admin list → detail navigation, ISO timestamps rendered |

The browser check matters here: `isinstance` replacing `hasattr` changes which values take the `isoformat()` branch, and no unit test covers detail-page value formatting.

## Governor Footer

- trigger: yes
- reviewer: self-structured
- rounds: 1
- r-points-fixed: 1
- r-points-deferred: 0
- r-points-rejected: 0
- touched-adr-consequences: none
- pr-scope-notes: Governor surface is the [tool.pyright] section of pyproject.toml (governor-paths.md Tier C); checked with tools/check_governor_footer.py locally before opening. R1 = I had planned step 2b as a policy decision about stub friction, and the measurement showed 6 of the findings were repo code; Fixed by treating it as a code change and re-scoping the remaining policy question to the 18 findings that really are external. Cross-tool review not obtained: codex exec 0.147.0 answers small prompts but echoes and exits without generating for a large prompt carrying an inline diff, reproduced four times in-repo and from /tmp. Self-structured per AGENTS.md Independent Review Trigger, supplemented by browser verification of the isoformat branch this change rewrote.
- final-verdict: merge-ready
- links: https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/385, n/a
