### PR TITLE
refactor(types): retire the mypy hook, make pyright the only type checker

### DIFF
--- a/.claude/rules/commands.md
+++ b/.claude/rules/commands.md
@@ -94,8 +94,14 @@ make test-dynamo
 
 ## Lint / Format
 ```bash
-# pre-commit (ruff + mypy)
+# pre-commit (ruff check --fix + ruff format + the local policy hooks)
 pre-commit run --all-files
+
+# Type check — pyright is the single authority, blocking in CI. This is exactly
+# what the `typecheck` job runs; scope is [tool.pyright] include in pyproject.toml.
+# There is no mypy hook: the manual-stage one was retired in #375 because it
+# aborted on a duplicate module name and inspected no source at all.
+uv run pyright
 ```
 
 ## DB Migrations

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 # Execution order: auto-fix → check-only
-# Separated by stages: commit (auto-fix), manual (manual check)
+# Separated by stages: commit (auto-fix), commit-msg (message policy)
 repos:
   # ==================== STAGE: COMMIT (auto-run) ====================
   # 1. Basic file validation and auto-fix
@@ -44,22 +44,13 @@ repos:
       - id: ruff-format
         exclude: ^migrations/
 
-  # ==================== STAGE: MANUAL (manual run) ====================
-  # Type checking: pre-commit run --hook-stage manual mypy
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.14.1
-    hooks:
-      - id: mypy
-        stages: [manual]
-        exclude: ^(migrations/|tests/|.*test\.py$|run_.*\.py$|force_.*\.py$)
-        args:
-          - --ignore-missing-imports
-          - --check-untyped-defs  # relaxed from disallow
-          - --warn-redundant-casts
-          - --no-implicit-optional
-        additional_dependencies:
-          - types-requests
-          - pydantic
+  # No type-checking hook here on purpose. pyright is the single type-check
+  # authority and runs blocking in the CI `typecheck` job over `[tool.pyright]
+  # include` — `uv run pyright` reproduces it exactly. A manual-stage mypy hook
+  # lived here from #34 until #375 and could not type-check anything: two harness
+  # copies of `completion_gate.py` collapse to one module name, so mypy aborted
+  # during resolution, reported that one error, and inspected no source at all.
+  # Nothing ran it (`stages: [manual]`), so it read as coverage for two releases.
 
   # ==================== STAGE: COMMIT (architecture violation checks) ====================
   - repo: local

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,8 +218,14 @@ Run the guards manually at any time:
 
 ```bash
 make pre-commit   # runs all pre-commit hooks against staged files
-make lint         # ruff check + mypy
+make lint         # ruff check
+uv run pyright    # type check — the same command the CI typecheck job runs
 ```
+
+`pyright` is the only type checker. It is blocking in CI and its scope is
+`[tool.pyright] include` in `pyproject.toml`. Add a suppression only for a
+framework contract you cannot annotate around, write the reason at the call site,
+and account for it in `tests/unit/tools/test_pyright_scope.py`.
 
 If you change files in `AGENTS.md`, `.claude/`, `.codex/`, or `docs/ai/shared/`, run `/sync-guidelines` (Claude Code) or `$sync-guidelines` (Codex CLI) before the final commit. The completion gate will remind you if you forget.
 

--- a/docs/ai/shared/governor-paths.md
+++ b/docs/ai/shared/governor-paths.md
@@ -38,7 +38,7 @@ Tier B includes Tier A's `.claude/rules/**`, `.codex/rules/**`, and `.antigravit
 ### Tier C — Other Repo-Level Governance Artefacts (trigger if introduced)
 
 - `.github/workflows/**` (CI as governance)
-- `pyproject.toml`'s `[tool.ruff]`, `[tool.mypy]`, or other linting/typing/policy sections
+- `pyproject.toml`'s `[tool.ruff]`, `[tool.pyright]`, or other linting/typing/policy sections (`[tool.mypy]` until #375 retired it)
 - `.pre-commit-config.yaml`
 - Any new file at the repo root that defines policy (future ADR will add)
 

--- a/docs/ai/shared/project-dna.md
+++ b/docs/ai/shared/project-dna.md
@@ -577,15 +577,20 @@ class {Name}Container(containers.DeclarativeContainer):
 
 ### Pre-commit (Manual Stage)
 
-- mypy (--ignore-missing-imports, --check-untyped-defs). `stages: [manual]`, so
-  `pre-commit run --all-files` — including the CI `architecture` job — does **not** run it.
-  Until #333 that meant nothing in CI type-checked anything; the blocking check now lives in
-  the `typecheck` job below rather than here.
+- Empty since #375. It held one hook, mypy, which was retired rather than repaired: two
+  harness copies of `completion_gate.py` map to one top-level module name, so mypy aborted
+  during resolution — `errors prevented further checking` — and inspected no source under
+  `src/` at all. Because `stages: [manual]` meant nothing ever ran it, one error and zero
+  findings read as coverage for two releases. Even repaired it would have been shallow: its
+  `additional_dependencies` were `types-requests` and `pydantic` only, so under
+  `--ignore-missing-imports` every fastapi / sqlalchemy / nicegui type resolved to `Any`.
+  pyright is now the single type-check authority (below).
 
 ### CI Type Check and Dependency Audit (#333)
 
-- **pyright — blocking, whole-tree.** `[tool.pyright] include` is `["src"]`: a new file is
-  checked from the moment it is written. It began (#333) as an allow-list of the packages
+- **pyright — blocking, and the only type checker.** `[tool.pyright] include` covers `src`,
+  `tools`, `scripts`, `examples`, `.agents` and the three root runners: a new file under any
+  of them is checked from the moment it is written. It began (#333) as an allow-list of the packages
   that passed, widened package by package through #381, and reached 0 errors across `src`
   from a starting 91. Two lessons from that run are worth keeping. First, an allow-list is
   itself a drift generator — this bullet still named five packages after four PRs had
@@ -598,7 +603,16 @@ class {Name}Container(containers.DeclarativeContainer):
   `tests/unit/tools/test_pyright_scope.py` fails if the include list stops covering a
   package under `src/` — pyright checks less rather than erroring — and pins where
   suppression comments are allowed to live, so `# pyright: ignore` cannot become the way
-  the tree stays green.
+  the tree stays green. `reportUnnecessaryTypeIgnoreComment` is on, so a suppression that
+  stops being needed is itself an error; enabling it is what retiring mypy bought, since
+  two of the three it flagged were mypy-only comments pyright never needed.
+- **The scope trap worth knowing (#375).** pyright's default `exclude` contains `**/.*`, so
+  a dot-directory named in `include` is skipped in silence. Measured: `.claude/hooks`
+  reported `0 errors` while analysing **0 of its 7 files**. `exclude` is therefore set
+  explicitly, and the scope test pins that pairing — "0 errors" and "nothing checked" print
+  identically, which is the same illusion the mypy hook sustained. Still out of scope by
+  decision: `tests/` (152 errors) and the three harness hook directories (91, mostly
+  unresolved imports needing `extraPaths`).
 - **pip-audit — advisory** (`continue-on-error`), writing to the job summary. A newly
   published CVE would otherwise redden a PR that changed nothing, which the §0
   advisory-first direction rules out. It installs the shipped extras before scanning so

--- a/examples/blog/post/domain/services/post_service.py
+++ b/examples/blog/post/domain/services/post_service.py
@@ -3,7 +3,7 @@
 # absolute-import pattern the real `src/auth -> src/user` dependency uses. It
 # does not resolve while the file still lives under examples/; the blog unit
 # tests provide a src-layout shadow via tests/unit/blog/conftest.py.
-from src.author.domain.protocols.author_repository_protocol import (
+from src.author.domain.protocols.author_repository_protocol import (  # pyright: ignore[reportMissingImports]
     AuthorRepositoryProtocol,
 )
 

--- a/examples/blog/post/infrastructure/di/post_container.py
+++ b/examples/blog/post/infrastructure/di/post_container.py
@@ -5,7 +5,7 @@ from dependency_injector import containers, providers
 # the class auto-discovery already registered under `src.author` — importing it
 # from anywhere else would map a second AuthorModel onto the same `author`
 # table and crash the boot. Unresolvable while this file lives under examples/.
-from src.author.infrastructure.repositories.author_repository import (
+from src.author.infrastructure.repositories.author_repository import (  # pyright: ignore[reportMissingImports]
     AuthorRepository,
 )
 

--- a/examples/url_shortener/infrastructure/repositories/link_repository.py
+++ b/examples/url_shortener/infrastructure/repositories/link_repository.py
@@ -1,6 +1,7 @@
 from datetime import UTC, datetime
+from typing import cast
 
-from sqlalchemy import delete, select
+from sqlalchemy import CursorResult, delete, select
 
 from src._core.exceptions.base_exception import BaseCustomException
 from src._core.infrastructure.persistence.rdb.base_repository import BaseRepository
@@ -56,7 +57,10 @@ class LinkRepository(BaseRepository[LinkDTO]):
                 )
             )
             await session.commit()
-            return result.rowcount or 0
+            # `session.execute` is typed `Result[Any]`, but a DML statement returns
+            # a `CursorResult` — which is where `rowcount` lives. Same shape as the
+            # fix in `_core/infrastructure/admin/audit/repository.py`.
+            return cast(CursorResult, result).rowcount or 0
 
     @staticmethod
     def _to_naive_utc(value: datetime) -> datetime:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,35 +94,56 @@ otel = [
 # `stages: [manual]`, so `pre-commit run --all-files` skipped it and the CI
 # `architecture` job type-checked nothing at all.
 #
-# `include` was an allow-list of clean packages while the tree was being cleaned
-# up (#381 steps 1-3). It now covers all of `src`, which is the stronger contract:
-# a new file is checked from the moment it is written instead of waiting for
-# someone to add its package here. Getting there took the measurements below.
+# Coverage. `include` reached all of `src` in #381 (91 errors -> 0) and now covers
+# everything the retired mypy hook nominally covered, plus the shared governor
+# package and the root runners, which it never did (#375).
 #
-# The count went 91 -> 0. Roughly half was repo code with real defects behind it
-# (possibly-unbound locals, a wrong return type, `hasattr` used where it cannot
-# narrow, an unguarded optional key in an S3 listing). The other half was AWS
-# typing that nobody had wired up: `types-aioboto3` gives `Session.client()` its
-# per-service overloads, without which every `async with ... .client()` resolved
-# to an untypeable placeholder, and `types-aiobotocore-s3vectors` types the four
-# s3vectors calls that had never been checked at all -- `S3VectorClient.client()`
-# used to yield the generic `AioBaseClient`, whose `__getattr__` always raises, so
-# `await client.put_vectors(...)` read as "NoReturn is not awaitable".
+# mypy is gone rather than repaired. It aborted during module resolution — two
+# harness copies of `completion_gate.py` map to one top-level module name — so it
+# reported one error and inspected nothing under `src/`. Two checkers with
+# different scopes, one unable to run, is worse than one. And even repaired it
+# would have been shallow: its `additional_dependencies` were `types-requests` and
+# `pydantic` only, so with `--ignore-missing-imports` every fastapi, sqlalchemy and
+# nicegui type resolved to Any.
 #
-# Nine suppressions remain, all in the two bootstrap modules and each with its
-# cause written at the call site: dependency-injector's dynamic provider
-# attributes, module-attribute injection, and Starlette's `add_exception_handler`
-# handler signature. They are line- and rule-scoped, so everything else in those
-# files is still checked.
+# `exclude` is set explicitly, which is load-bearing: pyright's default excludes
+# `**/.*`, so a dot-directory named in `include` is silently skipped. Measured
+# before overriding it — `.claude/hooks` reported "0 errors" while analysing 0 of
+# its 7 files. `test_pyright_scope.py` pins that pairing, because "0 errors"
+# and "nothing checked" print the same way, which is the exact failure that let
+# the mypy hook look like coverage for two releases.
 #
-# `reportUnnecessaryTypeIgnoreComment` would keep those suppressions from rotting
-# and is the natural next ratchet, but it is not enabled here: it reports 3
-# errors today, and 2 are mypy-only `# type: ignore` comments that pyright does
-# not need. Removing those belongs with retiring the mypy hook (#375), not here.
+# Deliberately still out of scope:
+#   tests/                152 errors. mypy excluded it too; widening it is its own
+#                         piece of work, not a side effect of retiring mypy.
+#   .claude/hooks/ and    91 errors, 70 of them unresolved imports because the
+#   the other two         hooks reach `.agents/shared/` through sys.path edits that
+#   harness copies        need `extraPaths`. Tracked separately.
 #
 # Never widen coverage by relaxing the rules below.
 [tool.pyright]
-include = ["src"]
+include = [
+    "src",
+    "tools",
+    "scripts",
+    "examples",
+    # The shared governor package every harness hook imports. Clean already; it
+    # had no type checker looking at it because it lives in a dot-directory.
+    ".agents",
+    # mypy excluded `run_.*\.py$`. Including them found that `make scheduler` had
+    # never run the scheduler: `run_scheduler` is a coroutine function and the call
+    # dropped it. Pinned by tests/unit/test_local_runners.py.
+    "run_server_local.py",
+    "run_worker_local.py",
+    "run_scheduler_local.py",
+]
+exclude = ["**/node_modules", "**/__pycache__", "**/.venv"]
+# Suppressions cannot rot: an ignore comment that stops being needed is an error.
+# Enabling this is what retiring mypy bought — it reported 3 errors while the hook
+# existed, and 2 were mypy-only `# type: ignore` comments pyright does not need.
+# Those are gone, and the remaining suppressions are `# pyright: ignore[rule]` so
+# each names the one rule it silences.
+reportUnnecessaryTypeIgnoreComment = "error"
 pythonVersion = "3.12"
 typeCheckingMode = "standard"
 

--- a/run_scheduler_local.py
+++ b/run_scheduler_local.py
@@ -13,9 +13,16 @@ Usage::
 """
 
 import argparse
+import asyncio
 
 from dotenv import load_dotenv
-from taskiq.cli.scheduler.cmd import SchedulerArgs, run_scheduler
+
+# Imported from the modules that *define* them, which is also what taskiq's own
+# `SchedulerCMD` does. `taskiq.cli.scheduler.cmd` re-exports neither symbol via
+# `__all__`, so importing from there reaches through a py.typed package's private
+# surface — the kind of import that breaks silently on an upstream refactor.
+from taskiq.cli.scheduler.args import SchedulerArgs
+from taskiq.cli.scheduler.run import run_scheduler
 
 
 def main() -> None:
@@ -23,7 +30,13 @@ def main() -> None:
         scheduler="src._apps.worker.scheduler:scheduler",
         modules=["src._apps.worker.scheduler"],
     )
-    run_scheduler(scheduler_args)
+    # `asyncio.run`, because `run_scheduler` is a coroutine function — unlike
+    # `run_worker`, which is sync. This file says it mirrors `run_worker_local.py`
+    # and did so literally, calling the coroutine and dropping it: `make scheduler`
+    # emitted "coroutine 'run_scheduler' was never awaited" and exited 0 without
+    # ever scheduling anything, so `audit_cleanup_task` never fired from the path
+    # the docs point at. taskiq's own `SchedulerCMD.exec` wraps it the same way.
+    asyncio.run(run_scheduler(scheduler_args))
 
 
 if __name__ == "__main__":

--- a/run_worker_local.py
+++ b/run_worker_local.py
@@ -2,7 +2,9 @@ import argparse
 
 from dotenv import load_dotenv
 from taskiq.cli.worker.args import WorkerArgs
-from taskiq.cli.worker.cmd import run_worker
+
+# The defining module, not the `cmd` shim — see run_scheduler_local.py.
+from taskiq.cli.worker.run import run_worker
 
 from src._apps.worker.guards import InMemoryWorkerError, ensure_worker_capable_broker
 
@@ -20,7 +22,10 @@ def main():
         reload=True,
     )
 
-    run_worker(worker_args)
+    # Propagated, not discarded: `run_worker` returns a status code and taskiq's
+    # own `WorkerCMD.exec` returns it, so swallowing it made this runner exit 0
+    # on a failed worker start. `SystemExit(None)` is still a 0 exit.
+    raise SystemExit(run_worker(worker_args))
 
 
 if __name__ == "__main__":

--- a/scripts/seed_demo_admin.py
+++ b/scripts/seed_demo_admin.py
@@ -84,7 +84,11 @@ def _admin_page_permission_keys() -> list[str]:
     """
     from src._core.infrastructure.discovery import discover_domains
 
-    keys = set(_FIXED_PERMISSION_KEYS)
+    # Annotated: `_FIXED_PERMISSION_KEYS` is an ALL_CAPS module constant, so its
+    # inferred type is a tuple of *literals* and the set would be
+    # `set[Literal["accounts", "audit_log"]]` — narrow enough to reject every
+    # discovered domain key added below.
+    keys: set[str] = set(_FIXED_PERMISSION_KEYS)
     for domain in discover_domains():
         config = (
             _REPO_ROOT
@@ -104,9 +108,13 @@ async def _seed(username: str, secret: str, email: str, full_name: str) -> int:
     from src._apps.server.di.container import create_server_container
     from src.admin_identity.domain.dtos.admin_identity_dto import CreateAdminAccountDTO
 
+    # The three suppressions below have the same cause as the ones in
+    # `_apps/admin/bootstrap.py`: dependency-injector resolves sub-container and
+    # provider attributes dynamically, and its stubs can only type that access as
+    # Provider[Any].
     container = create_server_container()
-    service = container.admin_identity_container.admin_identity_service()
-    repository = container.admin_identity_container.admin_repository()
+    service = container.admin_identity_container.admin_identity_service()  # pyright: ignore[reportAttributeAccessIssue]
+    repository = container.admin_identity_container.admin_repository()  # pyright: ignore[reportAttributeAccessIssue]
 
     try:
         existing = await repository.select_data_by_username(username)
@@ -141,7 +149,7 @@ async def _seed(username: str, secret: str, email: str, full_name: str) -> int:
         # alive after the coroutine returns. A long-lived server exits by
         # process teardown; a one-shot script would just hang. Observed:
         # seeding printed its success line and never returned.
-        await container.core_container.database().dispose()
+        await container.core_container.database().dispose()  # pyright: ignore[reportAttributeAccessIssue]
 
 
 def main() -> int:

--- a/src/_core/domain/services/rag_pipeline.py
+++ b/src/_core/domain/services/rag_pipeline.py
@@ -50,7 +50,7 @@ class RagPipeline(Generic[TChunk]):
         # citations without a second search round-trip. Underscore-
         # prefixed so it does not leak into serialisation.
         for chunk, distance in zip(chunks, distances, strict=False):
-            chunk._distance = distance  # type: ignore[attr-defined]
+            chunk._distance = distance  # pyright: ignore[reportAttributeAccessIssue]
 
         answer = await self._answer_agent.answer(
             question=question, context_chunks=chunks

--- a/src/_core/infrastructure/admin/audit/logger.py
+++ b/src/_core/infrastructure/admin/audit/logger.py
@@ -97,8 +97,8 @@ class AuditLogger:
         after_state: dict | None = None,
         failure_reason: str | None = None,
         ip_address: str | None = None,
-        admin_user_id: int | None = _UNSET,  # type: ignore[assignment]
-        admin_username: str | None = _UNSET,  # type: ignore[assignment]
+        admin_user_id: int | None = _UNSET,  # pyright: ignore[reportArgumentType]
+        admin_username: str | None = _UNSET,  # pyright: ignore[reportArgumentType]
     ) -> None:
         """Best-effort write of one audit-log entry. Never raises.
 
@@ -331,7 +331,7 @@ async def _safe_capture(
         result = hook(*args, **kwargs, **extra)
         if inspect.isawaitable(result):
             result = await result
-        return result  # type: ignore[return-value]
+        return result
     except Exception as exc:  # noqa: BLE001 - capture is best-effort
         _logger.warning(
             "audit_capture_hook_failed",

--- a/src/_core/infrastructure/admin/auth.py
+++ b/src/_core/infrastructure/admin/auth.py
@@ -110,7 +110,7 @@ class AdminAuthProvider:
         """Re-derive session from DB. Returns None if user is gone or not admin."""
         user_id = app.storage.user.get("user_id")
         try:
-            parsed_user_id = int(user_id)  # type: ignore[arg-type]
+            parsed_user_id = int(user_id)  # pyright: ignore[reportArgumentType]
         except (TypeError, ValueError):
             return None
 

--- a/src/_core/infrastructure/admin/error_handler.py
+++ b/src/_core/infrastructure/admin/error_handler.py
@@ -66,7 +66,7 @@ class AdminErrorHandler:
     def _safe_message(exc: Exception) -> tuple[str, _NotifyType]:
         """Return ``(message, notify_type)``; never leak ``str(exc)`` to the UI."""
         if _is_user_safe(exc):
-            return exc.message, "warning"  # type: ignore[attr-defined]
+            return exc.message, "warning"  # pyright: ignore[reportAttributeAccessIssue]
         return _GENERIC_MESSAGE, "negative"
 
     @staticmethod
@@ -133,7 +133,7 @@ def admin_error_boundary(context: str = "", critical: bool = False) -> Callable[
                 await AdminErrorHandler.handle(exc, context=context, critical=critical)
                 return None
 
-        return wrapper  # type: ignore[return-value]
+        return wrapper  # pyright: ignore[reportReturnType]
 
     return decorator
 

--- a/src/_core/infrastructure/admin/layout.py
+++ b/src/_core/infrastructure/admin/layout.py
@@ -269,7 +269,7 @@ def _stored_dark_preference() -> bool | None:
 
 
 def _app_username() -> str | None:
-    return app.storage.user.get("username")  # type: ignore[return-value]
+    return app.storage.user.get("username")
 
 
 async def _handle_logout() -> None:

--- a/tests/unit/test_local_runners.py
+++ b/tests/unit/test_local_runners.py
@@ -1,0 +1,121 @@
+"""The root `run_*_local.py` entrypoints must actually run what they announce.
+
+`run_scheduler_local.py` called `run_scheduler(args)` without awaiting it, so
+`make scheduler` printed `coroutine 'run_scheduler' was never awaited` and exited
+0 having scheduled nothing — `audit_cleanup_task` (`0 3 * * *`, the audit-log
+retention DELETE) never fired from the path the docs point at. The file's own
+docstring explains how: it "mirrors `run_worker_local.py`", and it did so
+literally, but taskiq's `run_worker` is sync while `run_scheduler` is a coroutine
+function.
+
+Found by extending pyright over the repo root (#375) — `reportUnusedCoroutine`.
+Nothing else could see it: the runners are excluded from the test suite, and a
+never-awaited coroutine is a warning, not an error, so the process exits 0.
+
+These tests pin the two halves that made it silent: that the wrapper awaits, and
+that the upstream function is still the shape the wrapper assumes.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import sys
+import warnings
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load(name: str) -> ModuleType:
+    """Import a root-level runner, which is a script rather than a package."""
+    spec = importlib.util.spec_from_file_location(name, _REPO_ROOT / f"{name}.py")
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestSchedulerRunner:
+    def test_taskiq_run_scheduler_is_still_a_coroutine_function(self) -> None:
+        """The assumption the wrapper is built on.
+
+        If taskiq ever makes this sync, `asyncio.run` starts raising instead of
+        silently no-opping — this test says which side changed.
+        """
+        from taskiq.cli.scheduler.run import run_scheduler
+
+        assert inspect.iscoroutinefunction(run_scheduler)
+
+    def test_main_awaits_the_scheduler(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        module = _load("run_scheduler_local")
+        awaited: list[Any] = []
+
+        async def _fake_run_scheduler(args: Any) -> None:
+            awaited.append(args)
+
+        monkeypatch.setattr(module, "run_scheduler", _fake_run_scheduler)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            module.main()
+
+        assert awaited, (
+            "main() returned without awaiting run_scheduler — the scheduler "
+            "process would exit 0 having scheduled nothing"
+        )
+        never_awaited = [w for w in caught if "never awaited" in str(w.message)]
+        assert not never_awaited, [str(w.message) for w in never_awaited]
+
+    def test_scheduler_args_point_at_the_scheduler_module(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A correctly-awaited call to the wrong target is the same outage."""
+        module = _load("run_scheduler_local")
+        seen: list[Any] = []
+
+        async def _capture(args: Any) -> None:
+            seen.append(args)
+
+        monkeypatch.setattr(module, "run_scheduler", _capture)
+        module.main()
+
+        (args,) = seen
+        assert args.scheduler == "src._apps.worker.scheduler:scheduler"
+        assert "src._apps.worker.scheduler" in args.modules
+
+
+class TestWorkerRunner:
+    def test_a_failed_worker_start_becomes_a_non_zero_exit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`run_worker` returns a status code; discarding it always exited 0."""
+        module = _load("run_worker_local")
+        monkeypatch.setattr(
+            module, "ensure_worker_capable_broker", lambda _broker: None
+        )
+        monkeypatch.setattr(module, "run_worker", lambda _args: 3)
+
+        with pytest.raises(SystemExit) as info:
+            module.main()
+
+        assert info.value.code == 3
+
+    def test_a_clean_worker_exit_stays_zero(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        module = _load("run_worker_local")
+        monkeypatch.setattr(
+            module, "ensure_worker_capable_broker", lambda _broker: None
+        )
+        monkeypatch.setattr(module, "run_worker", lambda _args: None)
+
+        with pytest.raises(SystemExit) as info:
+            module.main()
+
+        assert info.value.code is None, "SystemExit(None) is a 0 exit"

--- a/tests/unit/tools/test_pyright_scope.py
+++ b/tests/unit/tools/test_pyright_scope.py
@@ -1,23 +1,24 @@
 """Guard the pyright gate against silently shrinking.
 
-`[tool.pyright] include` is now `["src"]` — the whole tree, 0 errors. It got there
-as an allow-list of clean packages (#333, widened through #381), and that list
-turned out to be a drift generator in its own right: `project-dna.md` still named
-five packages after four PRs had added six more, and nothing failed, because a
-stale allow-list fails nothing.
+pyright is the only type checker (#375) and the scope it checks is
+`[tool.pyright] include`. Every failure mode of that arrangement is silent, which
+is the whole reason this file exists:
 
-Whole-tree coverage removes that particular trap but adds two of its own, both
-silent:
+- **Narrowing.** Replace an include path with a subset and pyright checks less,
+  exits 0, and the gate shrinks with CI still green. It does not warn.
+- **A dot-directory that is never analysed.** pyright's default `exclude` contains
+  `**/.*`, so naming `.agents` in `include` without overriding `exclude` skips it
+  entirely. Measured before this was fixed: `.claude/hooks` reported `0 errors`
+  while analysing **0 of its 7 files**. "0 errors" and "nothing checked" print
+  identically.
+- **Suppression creep.** `# pyright: ignore` is the other way to hold a tree at 0
+  errors without fixing anything. 21 exist, in 10 files, each with its cause
+  written at the call site. That is defensible *because* it is pinned; unpinned,
+  it is a trend.
 
-- **Narrowing.** Someone hits a wall of errors in one package and replaces `src`
-  with a subset. pyright does not error on a smaller scope — it just checks less,
-  exits 0, and the gate shrinks with CI still green.
-- **Suppression creep.** `# pyright: ignore` is the other way to keep the tree at
-  0 errors without fixing anything. Nine exist today, all in two bootstrap
-  modules, all for framework contracts this repo cannot annotate its way out of.
-  That is a defensible number *because* it is pinned; unpinned, it is a trend.
-
-These tests fail loudly in both cases.
+The third one is the same illusion the retired mypy hook sustained for two
+releases: it aborted on a duplicate module name, inspected nothing, and reported
+one error — which nobody read as "no coverage".
 """
 
 from __future__ import annotations
@@ -32,19 +33,28 @@ _REPO_ROOT = Path(__file__).resolve().parents[3]
 _PYPROJECT = _REPO_ROOT / "pyproject.toml"
 _SRC = _REPO_ROOT / "src"
 
-# Where suppressions are allowed, and how many. Each is a framework contract with
-# its cause written at the call site: dependency-injector's dynamic provider
-# attributes and module-attribute injection (admin), Starlette's
-# `add_exception_handler` handler signature (server), and a deliberately widened
-# `on_send` parameter that taskiq's own base middleware does not declare.
+# Every suppression in the checked scope, by file and count. Each is a framework
+# contract with its reason at the call site: dependency-injector's dynamic
+# provider attributes (admin bootstrap, the demo-admin seeder), module-attribute
+# injection, Starlette's `add_exception_handler` handler signature, a deliberately
+# widened `on_send` parameter taskiq's base middleware does not declare, and the
+# two `examples/blog` cross-domain imports that only resolve after the example is
+# copied into `src/`.
 #
-# Adding an entry here is allowed — silently adding one to a file that is not
-# listed is what this pins. If a genuine third-party limitation needs a new
-# suppression, add the file and say why in the same commit.
+# Adding an entry is allowed. Adding a suppression to a file that is *not* listed
+# is what this pins — if it is a genuine third-party limitation, add the file and
+# say why in the same commit; if it is not, fix the finding.
 _ALLOWED_SUPPRESSIONS = {
-    "_apps/admin/bootstrap.py": 6,
-    "_apps/server/bootstrap.py": 3,
-    "_core/infrastructure/logging/taskiq_middleware.py": 1,
+    "examples/blog/post/domain/services/post_service.py": 1,
+    "examples/blog/post/infrastructure/di/post_container.py": 1,
+    "scripts/seed_demo_admin.py": 3,
+    "src/_apps/admin/bootstrap.py": 6,
+    "src/_apps/server/bootstrap.py": 3,
+    "src/_core/domain/services/rag_pipeline.py": 1,
+    "src/_core/infrastructure/admin/audit/logger.py": 2,
+    "src/_core/infrastructure/admin/auth.py": 1,
+    "src/_core/infrastructure/admin/error_handler.py": 2,
+    "src/_core/infrastructure/logging/taskiq_middleware.py": 1,
 }
 
 # Matches a real directive, not a mention of one in prose. Pyright itself is this
@@ -72,6 +82,17 @@ def _src_packages() -> list[str]:
     )
 
 
+def _checked_files() -> list[Path]:
+    files: list[Path] = []
+    for path in _include_paths():
+        resolved = _REPO_ROOT / path
+        if resolved.is_file():
+            files.append(resolved)
+        else:
+            files.extend(sorted(resolved.rglob("*.py")))
+    return files
+
+
 def test_pyright_is_configured() -> None:
     config = _pyright_config()
 
@@ -79,24 +100,53 @@ def test_pyright_is_configured() -> None:
     assert config["pythonVersion"] == "3.12"
 
 
+def test_unnecessary_suppressions_are_an_error() -> None:
+    """Otherwise a suppression outlives the limitation it was added for."""
+    assert _pyright_config().get("reportUnnecessaryTypeIgnoreComment") == "error"
+
+
 @pytest.mark.parametrize("path", _include_paths())
 def test_every_include_path_exists(path: str) -> None:
     resolved = _REPO_ROOT / path
 
-    assert resolved.is_dir(), (
+    assert resolved.exists(), (
         f"[tool.pyright] include lists {path!r}, which no longer exists. "
         "pyright does not error on a missing include — it just checks less, "
         "so the CI type gate would shrink without anything going red."
+    )
+    if resolved.is_dir():
+        assert any(resolved.rglob("*.py")), f"{path!r} contains no Python to check"
+
+
+def test_dot_directory_includes_require_an_explicit_exclude() -> None:
+    """The trap: a dot-path in `include` is skipped unless `exclude` is overridden.
+
+    pyright's default `exclude` is `["**/node_modules", "**/__pycache__", "**/.*"]`
+    and specifying any `exclude` replaces it. So `.agents` is only really checked
+    because `exclude` is set and omits `**/.*`. Without this test the config could
+    lose its `exclude` line and the dot-path coverage would vanish in silence —
+    same error count, fewer files.
+    """
+    config = _pyright_config()
+    dotted = [p for p in _include_paths() if p.startswith(".")]
+    if not dotted:
+        pytest.skip("no dot-directory include paths to protect")
+
+    assert "exclude" in config, (
+        f"include names {dotted}, but `exclude` is unset — pyright's default "
+        "`**/.*` then skips those paths while still reporting 0 errors"
+    )
+    assert "**/.*" not in config["exclude"], (
+        f"`exclude` contains `**/.*`, which cancels the {dotted} include paths"
     )
 
 
 @pytest.mark.parametrize("package", _src_packages())
 def test_every_src_package_is_covered(package: str) -> None:
-    """Narrowing `["src"]` to a subset has to fail here.
+    """Narrowing `src` to a subset has to fail here.
 
-    Asserted per package rather than as `include == ["src"]` so that splitting the
-    list for an unrelated reason (a second root, an explicit exclude) stays legal
-    as long as nothing under `src/` falls out of scope.
+    Asserted per package rather than as `include == [...]` so that adding roots
+    stays legal — only losing coverage fails.
     """
     covered = [
         path
@@ -106,23 +156,40 @@ def test_every_src_package_is_covered(package: str) -> None:
 
     assert covered, (
         f"src/{package} is not covered by [tool.pyright] include "
-        f"{_include_paths()!r}. The type gate reached 0 errors across all of "
-        "src/; excluding a package to get past its errors gives that up "
+        f"{_include_paths()!r}. The type gate reached 0 errors across the whole "
+        "scope; excluding a package to get past its errors gives that up "
         "silently, because pyright exits 0 on a narrower scope."
+    )
+
+
+@pytest.mark.parametrize(
+    "path", ["tools", "scripts", "examples", ".agents", "run_scheduler_local.py"]
+)
+def test_the_scope_mypy_nominally_covered_stays_covered(path: str) -> None:
+    """Retiring mypy (#375) must not quietly reduce what is checked.
+
+    The retired hook nominally covered everything except `migrations/`, `tests/`
+    and the root `run_*.py` files — nominally, because it aborted before reading
+    any of it. `run_scheduler_local.py` is in this list because including it is
+    what found that `make scheduler` never ran the scheduler.
+    """
+    assert path in _include_paths(), (
+        f"{path!r} left [tool.pyright] include. pyright is the only type checker "
+        "since #375, so dropping a path here means nothing checks it at all."
     )
 
 
 def test_suppressions_stay_where_they_are_accounted_for() -> None:
     found: dict[str, int] = {}
-    for path in sorted(_SRC.rglob("*.py")):
+    for path in _checked_files():
         count = len(_SUPPRESSION.findall(path.read_text(encoding="utf-8")))
         if count:
-            found[str(path.relative_to(_SRC))] = count
+            found[str(path.relative_to(_REPO_ROOT))] = count
 
     assert found == _ALLOWED_SUPPRESSIONS, (
-        f"pyright suppressions in src/ changed: expected {_ALLOWED_SUPPRESSIONS}, "
-        f"found {found}. A suppression is the other way to keep the tree at 0 "
-        "errors without fixing anything, so each one is accounted for by file and "
-        "count. If the new one is a genuine framework limitation, add it here with "
-        "its reason; if it is not, fix the finding instead."
+        f"pyright suppressions changed: expected {_ALLOWED_SUPPRESSIONS}, found "
+        f"{found}. A suppression is the other way to keep the tree at 0 errors "
+        "without fixing anything, so each one is accounted for by file and count. "
+        "If the new one is a genuine framework limitation, add it here with its "
+        "reason; if it is not, fix the finding instead."
     )


### PR DESCRIPTION
Closes #375. mypy is retired rather than repaired, and pyright's scope is widened so retiring it does not cost coverage.

## Why retire instead of fix

The issue offered three directions. The third is right, and it is stronger now than when the issue was filed: pyright covers all of `src` at 0 errors and blocks CI, so there is nothing for a second checker to add.

Two facts settle it:

- mypy **aborted during module resolution** — two harness copies of `completion_gate.py` collapse to one top-level module name — so it reported that one error and inspected no source at all. With `stages: [manual]`, nothing ran it. One error and zero findings read as coverage for two releases.
- Even repaired, it would have been shallow. Its `additional_dependencies` were `types-requests` and `pydantic` **only**, so under `--ignore-missing-imports` every fastapi, sqlalchemy and nicegui type resolved to `Any`.

## Retiring a checker must not reduce coverage

mypy nominally covered everything except `migrations/`, `tests/` and `run_*.py`. pyright covered `src` only. So the scope is widened to everything mypy nominally had — `tools`, `scripts`, `examples` — plus two things it never had: `.agents` (the shared governor package all three harnesses import) and the root runners.

**386 files analysed → 661. Still 0 errors.**

## Including the runners found a live defect

`make scheduler` has never run the scheduler:

```
main() returned; warnings: ["coroutine 'run_scheduler' was never awaited"]
```

The file's own docstring explains how — it "mirrors `run_worker_local.py`", and it did so literally. But in taskiq **`run_worker` is sync while `run_scheduler` is a coroutine function**, so the call was made and dropped. The process exited 0 having scheduled nothing, which means `audit_cleanup_task` (`0 3 * * *`, the audit-log retention `DELETE`) never fired from the path the docs point at.

Fixed with `asyncio.run(...)` — exactly what taskiq's own `SchedulerCMD.exec` does. Verified:

```
[info] Starting scheduler.       [taskiq.cli.scheduler.run]
[info] Startup completed.        [taskiq.cli.scheduler.run]
never-awaited warnings: 0
```

Two smaller ones in the same family — mirroring a CLI and dropping part of it:

| fix | effect |
|---|---|
| all three taskiq CLI symbols imported from the modules that **define** them | the `cmd` shim re-exports none of them via `__all__`, so those imports reached through a py.typed package's private surface |
| `run_worker`'s status code propagated, not discarded | a failed worker start used to exit 0; taskiq's own `WorkerCMD.exec` returns it |

`tests/unit/test_local_runners.py` pins all of it — **4 of 5 tests fail against the old code.**

## Suppressions can no longer rot

`reportUnnecessaryTypeIgnoreComment = "error"` is on. That is what retiring mypy bought: while the hook existed the rule flagged 3, of which **2 were mypy-only `# type: ignore` comments pyright never needed**. Those are deleted, and the remaining 8 in `src/` are converted to `# pyright: ignore[rule]`, each naming the single rule it silences.

The rule per site was **measured, not guessed** — strip the comment, read what pyright then reports:

```
CONVERT rag_pipeline.py:53   -> reportAttributeAccessIssue
CONVERT admin/auth.py:113    -> reportArgumentType
DELETE  admin/layout.py:272  (pyright reports nothing here)
CONVERT error_handler.py:69  -> reportAttributeAccessIssue
CONVERT error_handler.py:136 -> reportReturnType
CONVERT audit/logger.py:100  -> reportArgumentType
CONVERT audit/logger.py:101  -> reportArgumentType
DELETE  audit/logger.py:334  (pyright reports nothing here)
```

## The trap I nearly shipped

pyright's default `exclude` contains `**/.*`, so **a dot-directory named in `include` is skipped in silence**. I first measured `.claude/hooks` as "0 errors" and almost recorded it as coverage. It had analysed **0 of its 7 files**:

```
analyzed=0  py_files=7  .claude/hooks
analyzed=0  py_files=8  .antigravity/hooks
```

That is the *same illusion the mypy hook sustained*, reproduced inside its own fix. So `exclude` is set explicitly, and the scope test pins the pairing rather than a comment describing it — dropping the override takes 661 files to 644 with the error count unchanged at 0. Proven by injecting a type error into `.agents/` and confirming it is caught.

## Out of scope, with numbers

| left out | count | why |
|---|---|---|
| `tests/` | 152 | mypy excluded it too; its own piece of work |
| the three harness hook dirs | 177 | 70 unresolved imports needing `extraPaths`, 86 orphaned mypy-era ignores → **#387** |

#387 also records a hypothesis of mine that was **wrong**: the three hook directories are parallel copies, so I expected one fix to triple. Measured — **0 of 94 distinct findings appear in all three.** They have diverged.

## Verification

| gate | result |
|---|---|
| `uv run pyright` | **0 errors**, 661 files analysed |
| `make check-core` | 1936 passed, 4 skipped |
| `make check-minimal` | 7 passed |
| `pre-commit run --all-files` | 0 failed hooks |
| scheduler, live | reaches `Startup completed.`, 0 never-awaited warnings |
| `seed_demo_admin` smoke | discovers `['accounts', 'ai_usage', 'audit_log', 'docs', 'user']` |

## Governor Footer

- trigger: yes
- reviewer: self-structured
- rounds: 1
- r-points-fixed: 1
- r-points-deferred: 2
- r-points-rejected: 0
- touched-adr-consequences: none
- pr-scope-notes: Governor surfaces are .pre-commit-config.yaml, the [tool.pyright] section of pyproject.toml, docs/ai/shared/project-dna.md and docs/ai/shared/governor-paths.md; checked with tools/check_governor_footer.py locally before opening. ADR 010 decided "mypy in manual mode" but is already Superseded and archived, and no live ADR mentions mypy, so no erratum is owed. R1 = I measured three dot-directories as "0 errors" when pyright had analysed 0 files in them, which is the same failure mode as the hook being retired; Fixed by overriding exclude and pinning the pairing in test_pyright_scope.py. Deferred = tests/ (152) and the harness hook dirs (177, filed as #387). Cross-tool review not obtained: codex exec 0.147.0 answers small prompts but echoes and exits without generating for a large prompt carrying an inline diff, reproduced four times in-repo and from /tmp. Self-structured per AGENTS.md Independent Review Trigger, supplemented by adversarial probes: every new guard and both runner fixes were verified to fail against the pre-fix code rather than assumed to.
- final-verdict: merge-ready
- links: https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/388, https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/375
