### PR TITLE
fix(admin): recompose the dashboard into two columns

### DIFF
--- a/docs/ai/shared/admin-design-system.md
+++ b/docs/ai/shared/admin-design-system.md
@@ -131,17 +131,42 @@ Import surface: `from src._core.infrastructure.admin import components as c`.
 | `c.page_header(title, *, subtitle=, back_to=, actions=)` | leaf | Page heading; `back_to` adds a back button, `actions` a right-aligned slot |
 | `c.card(*, clickable_to=, classes=)` | context mgr | A themed card; `clickable_to` makes the whole card navigate |
 | `c.section(title=)` | context mgr | A titled content section |
-| `c.stat_card(label, value, *, icon=)` | leaf | Metric tile (caption + value) |
+| `c.stat_card(label, value, *, icon=)` | leaf | Metric tile (caption + value). Carries a minimum width (`--admin-stat-card-min-width`): a card sizes to its own content, so a row of them came out 88 / 64 / 62px wide and read as unrelated boxes rather than one row of metrics (#380) |
 | `c.field_row(label, value, *, is_empty=)` | leaf | One label/value detail row (value pre-formatted) |
 | `c.text_field / textarea_field / number_field / select_field` | leaf | Form inputs — always `outlined` |
 | `c.action_dialog(title, *, width=, subtitle=)` | context mgr | Dialog with arbitrary body; yields `(dialog, card)`; opens on exit |
 | `c.confirm_dialog(title, message, *, on_confirm, on_success=, danger=)` | async | Confirm-an-action; see contract below |
-| `c.data_grid(column_defs, row_data, *, compact=, auto_height=, row_click_to=, on_cell_click=, on_row_click=)` | leaf | AG Grid with the admin theme + shared defaults. Height: default = viewport-sized, `compact=True` = shorter, `auto_height=True` = derived from the row count (no empty space under the last row) — only for a **caller-bounded** row count. `auto_height` deliberately avoids AG Grid's `domLayout: "autoHeight"`, which breaks in the NiceGUI embed: the inner wrapper grows past the outer element and paints over the next section |
+| `c.data_grid(column_defs, row_data, *, compact=, auto_height=, row_click_to=, on_cell_click=, on_row_click=)` | leaf | AG Grid with the admin theme + shared defaults. Height: default = viewport-sized, `compact=True` = shorter, `auto_height=True` = derived from the row count (no empty space under the last row) — only for a **caller-bounded** row count. `auto_height` deliberately avoids AG Grid's `domLayout: "autoHeight"`, which breaks in the NiceGUI embed: the inner wrapper grows past the outer element and paints over the next section. **Scope:** this is the *list-page* grid and it brings list-page assumptions — `selection="single"` renders a row-selection control in every row, which on a panel with no row action is 122px of dead clickable UI, and its columns spread to fill the container (measured: 488px each for `active` / `sqlite`). For a short status list, compose rows directly (#380) |
 | `c.bar_chart(categories, values)` | leaf | ECharts vertical bar; sized by `AdminClasses.CHART` / `--admin-chart-height`, bar fill = `AdminColors.PRIMARY`, top corners rounded |
 | `c.pagination(*, current, total_pages, on_prev, on_next)` | leaf | Prev / page / next row |
 | `c.empty_state(icon=)` | context mgr | **Full-panel** empty placeholder — centred, with a large icon and `48px` vertical padding. For "this list has no rows", not for an inline note: used for a one-line remark inside a populated section it spends ~250px on one sentence (#368). Inline notes are a plain `ui.label(...).classes("admin-text-muted")` |
 | `c.toast_success / toast_warning / toast_error(message)` | leaf | Standardized `ui.notify` |
 | `c.report_error(exc, *, context)` | async | Route a caught exception through the sanitizing `AdminErrorHandler` |
+
+### Multi-column composition (and the gap that breaks it)
+
+Full-width stacked sections are the default and are wrong once a section has less
+to say than the page is wide. Measured on the dashboard at 1920px before #380: a
+1588px plot holding one bar, a 10-row status table giving 488px each to `active`
+and `sqlite`, and the stat tiles huddled in 294px to their left. The page was
+1186px tall with a mostly-unused right half — and the fix needed **no new
+content**, only two columns.
+
+Use Quasar's own column classes on a `ui.row`, not a fixed-width aside: `col-12
+col-md-8` / `col-12 col-md-4` also collapses to one column below `md`.
+
+**The trap:** NiceGUI puts `gap: var(--nicegui-default-gap)` on every
+`.nicegui-row`, and it is added *on top of* `q-col-gutter-md`. Two columns that
+sum to 12/12 then overflow by that gap and the aside wraps underneath — measured
+at y=709 instead of y=169, with the classes and widths all correct, which is why
+it does not look like a spacing bug. Set `gap: 0` on the row and let the Quasar
+gutter own the spacing. (The dashboard's populated view survived this by accident
+for one round: a `q-gutter-md` on its main column contributed a cancelling
+negative margin.)
+
+A panel that can appear both inside an aside and at full width should bound its
+own width (`max-width`) rather than trust its container — otherwise it stretches
+and puts each value ~1000px from its label.
 
 ### `confirm_dialog` contract (important)
 
@@ -180,6 +205,10 @@ closes the dialog and then awaits `on_success` (e.g. a list refresh). On
 - Call `ui.notify(str(exc))` / `c.toast_error(str(exc))` — leaks internals.
 - Put `require_auth` anywhere but the first statement of the route.
 - Add a builder that wraps a single `ui.label` with no shared behavior.
+- Reach for `c.data_grid` for a short, read-only status list — it brings row
+  selection and full-width columns that neither belong there.
+- Stack full-width sections when a section has less to say than the page is wide;
+  check the composition at 1920px before assuming the layout is fine.
 
 ## Reference
 

--- a/src/_apps/admin/pages/dashboard.py
+++ b/src/_apps/admin/pages/dashboard.py
@@ -12,6 +12,7 @@ from src._core.infrastructure.admin.auth import require_auth_allowlisted
 from src._core.infrastructure.admin.base_admin_page import BaseAdminPage
 from src._core.infrastructure.admin.error_handler import admin_error_boundary
 from src._core.infrastructure.admin.layout import admin_layout
+from src._core.infrastructure.admin.theme import AdminClasses, AdminMetrics
 
 # page_configs is injected by bootstrap_admin() after discovery
 page_configs: list[BaseAdminPage] = []
@@ -57,6 +58,28 @@ _NEXT_STEPS: dict[str, str] = {
 # with ragged right edges that read as a layout bug rather than a choice.
 _STEP_WIDTH = "max-width: 720px"
 
+# Infrastructure list geometry. Widest values today are "disabled" and
+# "inmemory"; the slots are sized for those with a little slack. The row height
+# is the shared grid rhythm rather than a new number, so this list and every
+# admin table read at the same density.
+# The panel bounds its own width rather than trusting its container. Without it
+# the onboarding view — where it is not inside the aside — stretched the list to
+# the full 1620px and put each value ~1000px from its label.
+_INFRA_WIDTH = "max-width: 480px"
+
+# `q-col-gutter-md` owns the spacing between the two columns, but NiceGUI puts a
+# `gap` on every `.nicegui-row` as well, and it is added on top. The columns sum
+# to exactly 12/12, so that extra 16px is enough to wrap the aside underneath:
+# measured at 1920px, the infrastructure column landed at y=709 instead of y=169
+# beside the main column. The populated view happened to survive it only because
+# a `q-gutter-md` on its main column contributed a cancelling negative margin —
+# an accident, not a layout. Zeroing the gap here makes both views depend on the
+# Quasar gutter alone.
+_COLUMNS_GAP = "gap: 0"
+_STATE_SLOT = "width: 72px"
+_DETAIL_SLOT = "width: 84px"
+_ROW_HEIGHT = f"min-height: {AdminMetrics.GRID_ROW_HEIGHT}px"
+
 
 @ui.page("/admin/")
 @admin_error_boundary(context="admin_dashboard")
@@ -78,11 +101,28 @@ async def dashboard_page():
 
     if metrics.has_any_data:
         c.page_header("Dashboard", subtitle=f"Last {GROWTH_WINDOW_DAYS} days")
-        _render_stat_cards(metrics)
-        _render_ai_usage(metrics.ai_usage)
-        _render_growth(metrics)
-        if show_infra:
-            _render_infrastructure(metrics.infra)
+        # Two columns, because the horizontal space was not empty — it was badly
+        # spent. Measured at 1920px before this: the growth chart was a 1588px
+        # plot holding one bar, and the infrastructure table gave 488px each to
+        # `active` and `sqlite`, while the stat tiles sat in a 294px huddle to
+        # their left (#380). Stacking those full-width sections is what made the
+        # page 1186px tall with a mostly-unused right half.
+        #
+        # Quasar's own column classes rather than new tokens: `col-md-8` /
+        # `col-md-4` also collapses to one column below `md`, which a fixed-width
+        # aside would not.
+        with (
+            ui.row()
+            .classes("full-width q-col-gutter-md items-start")
+            .style(_COLUMNS_GAP)
+        ):
+            with ui.column().classes("col-12 col-md-8 q-gutter-md"):
+                _render_stat_cards(metrics)
+                _render_ai_usage(metrics.ai_usage)
+                _render_growth(metrics)
+            if show_infra:
+                with ui.column().classes("col-12 col-md-4"):
+                    _render_infrastructure(metrics.infra)
     else:
         # Every count is 0 on a fresh install, which is what every OSS adopter
         # opens first. Charting zeros there looks broken; naming the next action
@@ -119,7 +159,7 @@ def _render_ai_usage(usage: AiUsageMetrics) -> None:
             # placeholder (48px vertical padding, centred) and using it for an
             # inline note spent ~250px on one sentence.
             ui.label(f"No agent calls in the last {GROWTH_WINDOW_DAYS} days").classes(
-                "admin-text-muted"
+                AdminClasses.MUTED
             )
             return
         # The three counters are set together by the facade — all int, or all
@@ -128,7 +168,7 @@ def _render_ai_usage(usage: AiUsageMetrics) -> None:
         # "zero", which is exactly the distinction the facade keeps.
         calls, failures, tokens = usage.calls, usage.failures, usage.total_tokens
         if failures is None or tokens is None:
-            ui.label("Agent usage unavailable").classes("admin-text-muted")
+            ui.label("Agent usage unavailable").classes(AdminClasses.MUTED)
             return
 
         with ui.row().classes("q-gutter-md"):
@@ -165,30 +205,62 @@ def _render_growth(metrics: DashboardMetrics) -> None:
         # Named rather than silently dropped: a missing domain in an aggregate is
         # invisible, and "the trend excludes X" is the actionable part.
         ui.label(f"Trend unavailable: {', '.join(unavailable)}").classes(
-            "admin-text-muted"
+            AdminClasses.MUTED
         )
+
+
+# Which state gets which hue. Keyed off the enum rather than its `.value` so a
+# renamed value cannot silently fall through to the muted default.
+_STATE_DOT_CLASS: dict[InfraState, str] = {
+    InfraState.ACTIVE: "admin-status-active",
+    InfraState.STUB: "admin-status-stub",
+    # DISABLED deliberately absent: the dot's base colour is already the muted
+    # token, and "not configured" is not an outcome worth a hue.
+}
 
 
 def _render_infrastructure(infra: list[InfraStatus]) -> None:
-    with c.section("Infrastructure"):
-        c.data_grid(
-            [
-                {"headerName": "Component", "field": "component"},
-                {"headerName": "State", "field": "state"},
-                {"headerName": "Detail", "field": "detail"},
-            ],
-            [
-                {
-                    "component": row.label,
-                    "state": row.state.value,
-                    "detail": row.detail or "—",
-                }
-                for row in infra
-            ],
-            # Bounded by the number of infra components, so deriving the height
-            # from the row count is safe (see c.data_grid).
-            auto_height=True,
-        )
+    """A status list, not an AG Grid.
+
+    This was `c.data_grid`, the builder the list pages use, and it brought their
+    assumptions with it: `selection="single"` put a **row-selection radio in every
+    row** — 122px of clickable control on a panel with no row action, so clicking
+    one did nothing — and three columns spread one-word values across 488px each.
+    A 10-row list of `label / state / detail` needs none of that; the widest cell
+    here is "OpenTelemetry".
+
+    Built inline rather than as a `components/` builder: `admin-design-system.md`
+    requires a second real call site first, and there is one panel like this.
+    """
+    with c.section("Infrastructure") as panel:
+        panel.style(_INFRA_WIDTH)
+        # No gutter on the container: each row sets its own height from the house
+        # grid rhythm, so the list matches the density of every other admin table
+        # instead of inheriting the section's inter-block spacing (which put the
+        # ten rows 48px apart, airier than anything else on the page).
+        with ui.column().classes("full-width q-gutter-none"):
+            for row in infra:
+                with (
+                    ui.row()
+                    .classes("items-center no-wrap full-width q-gutter-sm")
+                    .style(_ROW_HEIGHT)
+                ):
+                    dot = _STATE_DOT_CLASS.get(row.state, "")
+                    ui.element("span").classes(
+                        f"{AdminClasses.STATUS_DOT} {dot}".strip()
+                    )
+                    ui.label(row.label).classes("col")
+                    # Both trailing values live in fixed, right-aligned slots.
+                    # Sized by content they did not line up: with `detail` present
+                    # on 3 of 10 rows, `state` floated left on those rows and sat
+                    # at the edge on the rest, so no column had an edge. The empty
+                    # slot below is what keeps the state column straight.
+                    ui.label(row.state.value).classes(
+                        f"{AdminClasses.MUTED} text-right"
+                    ).style(_STATE_SLOT)
+                    ui.label(row.detail or "").classes(
+                        f"{AdminClasses.FIELD_VALUE} text-right"
+                    ).style(_DETAIL_SLOT)
 
 
 # ── Onboarding view (no data yet) ──
@@ -203,6 +275,21 @@ def _render_onboarding(metrics: DashboardMetrics, *, show_infra: bool) -> None:
     stubs = [row for row in metrics.infra if row.state is InfraState.STUB]
     active = [row for row in metrics.infra if row.state is InfraState.ACTIVE]
 
+    # Two columns here too. This is the screen every new adopter opens first, and
+    # it had the same unused right half as the populated view (#380).
+    with ui.row().classes("full-width q-col-gutter-md items-start").style(_COLUMNS_GAP):
+        with ui.column().classes("col-12 col-md-8"):
+            _render_next_steps(stubs, show_infra=show_infra)
+        if show_infra:
+            with ui.column().classes("col-12 col-md-4"):
+                _render_infrastructure(metrics.infra)
+                if active and not stubs:
+                    ui.label("Every optional component is configured.").classes(
+                        f"{AdminClasses.MUTED} q-mt-md"
+                    )
+
+
+def _render_next_steps(stubs: list[InfraStatus], *, show_infra: bool) -> None:
     with c.section("Next steps"):
         with ui.column().classes("q-gutter-md").style(_STEP_WIDTH):
             # Seeding data first: it is the step that turns this view into the
@@ -221,18 +308,11 @@ def _render_onboarding(metrics: DashboardMetrics, *, show_infra: bool) -> None:
                     if hint:
                         _step("build", f"{row.label} is running a stub", hint)
 
-    if show_infra:
-        _render_infrastructure(metrics.infra)
-        if active and not stubs:
-            ui.label("Every optional component is configured.").classes(
-                "admin-text-muted q-mt-md"
-            )
-
 
 def _step(icon: str, title: str, detail: str) -> None:
     with c.card(classes="full-width"):
         with ui.row().classes("items-center no-wrap q-gutter-md"):
-            ui.icon(icon).classes("text-h5 admin-accent-icon")
+            ui.icon(icon).classes(f"text-h5 {AdminClasses.ACCENT_ICON}")
             with ui.column().classes("q-gutter-none"):
                 ui.label(title).classes("text-subtitle2")
-                ui.label(detail).classes("text-caption admin-text-muted")
+                ui.label(detail).classes(f"text-caption {AdminClasses.MUTED}")

--- a/src/_core/infrastructure/admin/components/containers.py
+++ b/src/_core/infrastructure/admin/components/containers.py
@@ -36,8 +36,13 @@ def section(title: str | None = None, *, classes: str = "") -> Iterator[ui.colum
 
 
 def stat_card(label: str, value: str | int, *, icon: str | None = None) -> ui.card:
-    """A metric tile: caption label + large value (replaces ai_usage tiles)."""
-    with ui.card().classes("q-pa-md") as element:
+    """A metric tile: caption label + large value (replaces ai_usage tiles).
+
+    Carries a minimum width because a card sizes to its own content: without it a
+    row of tiles came out ragged — 88px / 64px / 62px for "AI Usage" / "Docs" /
+    "User" — which reads as three unrelated boxes instead of one row of metrics.
+    """
+    with ui.card().classes(f"q-pa-md {AdminClasses.STAT_CARD}") as element:
         if icon is not None:
             ui.icon(icon).classes("text-h5 text-primary")
         ui.label(str(label)).classes(f"text-caption {AdminClasses.MUTED}")

--- a/src/_core/infrastructure/admin/theme.py
+++ b/src/_core/infrastructure/admin/theme.py
@@ -113,6 +113,7 @@ class AdminVars:
     GRID_HEIGHT_COMPACT: Final = "--admin-grid-height-compact"
     CHART_HEIGHT: Final = "--admin-chart-height"
     LABEL_COL_WIDTH: Final = "--admin-label-col-width"
+    STAT_CARD_MIN_WIDTH: Final = "--admin-stat-card-min-width"
     FONT: Final = "--admin-font"
     # Flat login backdrop. Was ``--admin-login-gradient`` before #365; renamed
     # because the value is no longer a gradient and a lying token name is worse
@@ -128,6 +129,11 @@ class AdminMetrics:
     # one base_admin_page.py reads).
     GRID_ROW_HEIGHT: Final = 36
     GRID_MIN_COL_WIDTH: Final = 120
+
+    # Stat tiles size to their own text otherwise, so a row of them came out
+    # ragged — measured 88px / 64px / 62px for "AI Usage" / "Docs" / "User",
+    # which reads as three unrelated boxes rather than one row of metrics.
+    STAT_CARD_MIN_WIDTH: Final = 150
 
 
 class AdminClasses:
@@ -145,12 +151,16 @@ class AdminClasses:
     FIELD_VALUE: Final = "admin-field-value"
     MUTED: Final = "admin-text-muted"
     EMPTY_VALUE: Final = "admin-empty-value"
+    STAT_CARD: Final = "admin-stat-card"
+    STATUS_DOT: Final = "admin-status-dot"
     SUCCESS_SURFACE: Final = "admin-success-surface"
     GRID: Final = "admin-grid"
     GRID_COMPACT: Final = "admin-grid-compact"
-    # Sets no height — AG Grid owns it via ``domLayout: "autoHeight"``, which
-    # requires the container div to have no height of its own. Paired with
-    # ``c.data_grid(auto_height=True)``; see _HELPER_CSS.
+    # Sets no height on purpose: ``c.data_grid(auto_height=True)`` derives one
+    # from the row count and sets it inline. Deliberately *not* AG Grid's
+    # ``domLayout: "autoHeight"`` — that grows the inner wrapper while the outer
+    # NiceGUI element keeps Quasar's computed height, so the grid paints over
+    # whatever follows it (#368). See _HELPER_CSS and components/data.py.
     GRID_AUTO: Final = "admin-grid-auto"
     CHART: Final = "admin-chart"
     PAGINATION: Final = "admin-pagination"
@@ -173,6 +183,7 @@ _LAYOUT_TOKENS: Final = {
     AdminVars.GRID_HEIGHT_COMPACT: "calc(100vh - 360px)",
     AdminVars.CHART_HEIGHT: "260px",
     AdminVars.LABEL_COL_WIDTH: "140px",
+    AdminVars.STAT_CARD_MIN_WIDTH: f"{AdminMetrics.STAT_CARD_MIN_WIDTH}px",
     # System font stack — no bundled webfont (#365 dropped the self-hosted
     # Wanted Sans and the /admin-static mount that existed only to serve it).
     # Order matters: Latin UI fonts first, then Hangul fallbacks for platforms
@@ -365,6 +376,30 @@ body {
 .admin-text-muted,
 .admin-empty-value {
   color: var(--admin-text-muted);
+}
+
+.admin-stat-card {
+  min-width: var(--admin-stat-card-min-width);
+}
+
+/* Replaces the row-selection radio that `c.data_grid` put in this column
+   position on the dashboard's infrastructure panel: same glance, but it means
+   something and cannot be clicked to no effect. Colour is not the only signal —
+   the state word sits beside it. */
+.admin-status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex: 0 0 8px;
+  background-color: var(--admin-text-muted);
+}
+
+.admin-status-dot.admin-status-active {
+  background-color: var(--q-positive);
+}
+
+.admin-status-dot.admin-status-stub {
+  background-color: var(--q-warning);
 }
 .admin-success-surface {
   background-color: var(--admin-success-bg) !important;

--- a/tests/unit/_apps/admin/test_dashboard_metrics.py
+++ b/tests/unit/_apps/admin/test_dashboard_metrics.py
@@ -14,7 +14,9 @@ from __future__ import annotations
 from datetime import date, datetime
 
 from src._apps.admin import dashboard_metrics as dm
+from src._apps.admin.operational_status import InfraState
 from src._core.domain.value_objects.daily_count import DailyCount
+from src._core.infrastructure.admin.theme import AdminClasses
 
 
 class _FakeService:
@@ -311,3 +313,52 @@ class TestInfrastructurePanelGate:
         )
 
         assert AdminPermissionRegistry().is_valid_key(_INFRA_PERMISSION)
+
+
+class TestEveryInfraStateHasADecidedAppearance:
+    """A new `InfraState` must not inherit a hue by omission (#380).
+
+    The dashboard's infrastructure panel stopped being an AG Grid — the list-page
+    builder brought `selection="single"`, which put a row-selection radio in every
+    row of a panel with no row action, and spread one-word values across 488px
+    columns. It is now a status list whose leading dot carries the state, mapped
+    per enum member.
+
+    `DISABLED` is deliberately absent from that map: the dot's base colour is
+    already the muted token, and "not configured" is not an outcome worth a hue.
+    That is a decision, so it is asserted rather than left to look like an
+    oversight — and a member added later fails here until someone decides.
+    """
+
+    def test_the_map_covers_exactly_the_states_with_a_hue(self):
+        from src._apps.admin.pages.dashboard import _STATE_DOT_CLASS
+
+        assert set(_STATE_DOT_CLASS) == {InfraState.ACTIVE, InfraState.STUB}
+
+    def test_disabled_falls_through_to_the_muted_default(self):
+        from src._apps.admin.pages.dashboard import _STATE_DOT_CLASS
+
+        assert _STATE_DOT_CLASS.get(InfraState.DISABLED, "") == ""
+
+    def test_every_enum_member_is_accounted_for(self):
+        """Mapped with a hue, or explicitly listed as intentionally unmapped."""
+        from src._apps.admin.pages.dashboard import _STATE_DOT_CLASS
+
+        deliberately_unmapped = {InfraState.DISABLED}
+        unaccounted = set(InfraState) - set(_STATE_DOT_CLASS) - deliberately_unmapped
+        assert not unaccounted, (
+            f"{sorted(s.value for s in unaccounted)} would render with the muted "
+            "default by accident. Give each a hue in _STATE_DOT_CLASS, or add it "
+            "to this test's deliberately_unmapped set with a reason."
+        )
+
+    def test_the_hue_classes_exist_in_the_emitted_css(self):
+        """A class name typo would silently render the muted default."""
+        from src._apps.admin.pages.dashboard import _STATE_DOT_CLASS
+        from src._core.infrastructure.admin.theme import build_admin_css
+
+        css = build_admin_css()
+        for state, cls in _STATE_DOT_CLASS.items():
+            assert f".{AdminClasses.STATUS_DOT}.{cls}" in css, (
+                f"{state.value} maps to .{cls}, which theme.py does not emit"
+            )


### PR DESCRIPTION
Closes #380.

## The issue's premise does not survive measurement

#380 says widening the layout "while the dashboard has nothing more to show would only make an empty screen wider", and gates the work on naming a fourth question nobody has named. Measured at 1920px, the horizontal space was **not empty — it was badly spent**, by content that already exists:

| element | size | holds |
|---|---|---|
| growth chart | **1588 × 260** | one bar |
| infra table | **1588 × 411** | 488px each for `active` and `sqlite` |
| selection column | **122px** | radio buttons that do nothing |
| stat tiles | **294px total** | three cards at 88 / 64 / 62px |
| page content | **1186px tall** | with a mostly-unused right half |

Two opposite failures on one page: full-width where there is nothing to fill it, content-width where a row should line up. So this needed **no new metric and no new question** — only two columns. The first acceptance criterion is met by not introducing a fourth question at all.

| | before | after |
|---|---|---|
| populated view content | 1186px | **771px** |
| onboarding view content | 1148px | **640px** |
| chart width | 1588px | 1043px |
| AG Grid instances on the landing page | 1 | **0** |

## The infrastructure panel stops being an AG Grid

It was `c.data_grid`, the **list-page** builder, and it brought list-page assumptions:

- `selection="single"` renders a row-selection control in every row. On a panel with no row action that is 122px of clickable UI that does nothing — worse than waste, since it invites the click.
- Columns spread to fill the container: three one-word values at 488px each, on a panel whose widest cell is "OpenTelemetry".

Now a status list whose leading dot carries the state — which puts something meaningful in the column position the dead radio occupied. Colour is never the only signal; the state word sits beside it. Built inline, not as a builder: `admin-design-system.md` requires a second real call site and there is one panel like this.

## Two defects of my own, both found only by screenshotting the result

**The trailing values did not line up.** With `detail` present on 3 of 10 rows, `state` floated left on those and sat at the edge on the rest — so no column had an edge. Both now live in fixed right-aligned slots; the empty slot is what keeps the state column straight.

**On the onboarding view the aside wrapped underneath the main column** — at `y=709` instead of `y=169`, with the classes and widths all correct:

```
box=[316, 169, 1059, 524]  'nicegui-column col-12 col-md-8'   'Next steps'
box=[316, 709,  529, 492]  'nicegui-column col-12 col-md-4'   'Infrastructure'   ← wrapped
```

NiceGUI puts `gap: var(--nicegui-default-gap)` on every `.nicegui-row` and it is added *on top of* `q-col-gutter-md`, so two columns summing to 12/12 overflow by that gap. **The populated view had survived it by accident** — a `q-gutter-md` on its main column contributed a cancelling negative margin. Both rows now set `gap: 0` and let the Quasar gutter own the spacing:

```
box=[ 316, 169, 1059, 524]  col-12 col-md-8   'Next steps'
box=[1375, 169,  529, 492]  col-12 col-md-4   'Infrastructure'   ← beside it
```

## What is pinned by test

`_STATE_DOT_CLASS` is keyed on the enum, not its `.value`. Tests assert every `InfraState` is either given a hue or listed as deliberately unmapped (`DISABLED` inherits the muted base on purpose), and that **each hue class is actually emitted by `theme.py`** — a typo'd class name would otherwise render the muted default in silence. Verified the guard fails when one is introduced:

```
1 failed, 25 passed   # after renaming admin-status-stub -> admin-status-stubb
```

## Acceptance criteria

- [x] The added content answers a question someone stated — **no content added**; the existing answers are rearranged
- [x] The zero-data path still renders the onboarding view — verified against an empty database, and it now uses both columns too
- [x] Light and dark verified by screenshot, both views — geometry identical between modes
- [x] No new `components/` builder without a second call site — the status list is inline in `dashboard.py`
- [x] Page height does not regress — 1186 → 771px populated, 1148 → 640px onboarding

## Verification

| gate | result |
|---|---|
| `make check-core` | 1940 passed, 4 skipped |
| `uv run pyright` | 0 errors |
| screenshots | populated + onboarding, light + dark, 1920px |
| empty-database boot | onboarding view renders, seeded admin only |

## Governor Footer

- trigger: yes
- reviewer: self-structured
- rounds: 1
- r-points-fixed: 2
- r-points-deferred: 0
- r-points-rejected: 1
- touched-adr-consequences: none
- pr-scope-notes: Governor surface is docs/ai/shared/admin-design-system.md, which gains the multi-column composition rule, the c.data_grid scope warning and the NiceGUI gap trap; checked with tools/check_governor_footer.py locally before opening. R1/R2 = the two defects above, both mine and both invisible to unit tests (mis-aligned trailing slots; the aside wrapping under the main column). Rejected = the issue's own premise that this work must be paired with new content, on the measurements in the first table: the width was already being consumed by existing sections. Cross-tool review not obtained: codex exec 0.147.0 answers small prompts but echoes and exits without generating for a large prompt carrying an inline diff, reproduced four times in-repo and from /tmp. Self-structured per AGENTS.md Independent Review Trigger, supplemented by a light/dark screenshot pass on both dashboard views — the mechanism #368 and #365 established as the only one that catches these.
- final-verdict: merge-ready
- links: https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/389, https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/380
