### PR TITLE
feat(types): type-check the harness hook directories

### DIFF
--- a/.antigravity/hooks/_shared.py
+++ b/.antigravity/hooks/_shared.py
@@ -38,7 +38,7 @@ try:
     _CHANGED_FILES_OK = True
 except Exception as exc:  # noqa: BLE001 — fail-open import
     debug_log("antigravity shared changed-files import failed", exc)
-    _shared_changed_files = None  # type: ignore[assignment]
+    _shared_changed_files = None
     _CHANGED_FILES_OK = False
 
 

--- a/.antigravity/hooks/completion_gate.py
+++ b/.antigravity/hooks/completion_gate.py
@@ -33,26 +33,26 @@ except Exception:  # noqa: BLE001
     EXPLORATION_TOKENS = frozenset()
     GOVERNOR_REMINDER_WITH_PR = ""
     GOVERNOR_REMINDER_NO_PR = ""
-    MarkerLifecycle = None  # type: ignore[assignment,misc]
+    MarkerLifecycle = None
     _shared_read_latest_token = None
     _shared_consume_phase2_markers = None
     _shared_governor_subset = None
     _shared_is_sync_cosmetic_only = None
     _SHARED_OK = False
 
-    def parse_trigger_globs(md_path: Path = GOVERNOR_PATHS_MD) -> list[str]:  # type: ignore[no-redef]
+    def parse_trigger_globs(md_path: Path = GOVERNOR_PATHS_MD) -> list[str]:
         return []
 
-    def is_log_only_backfill(changed: list[str]) -> bool:  # type: ignore[no-redef]
+    def is_log_only_backfill(changed: list[str]) -> bool:
         return False
 
-    def is_governor_changing(changed: list[str], globs: list[str]) -> bool:  # type: ignore[no-redef]
+    def is_governor_changing(changed: list[str], globs: list[str]) -> bool:
         return False
 
-    def match_log_entry(changed: list[str], current_pr: int | None) -> str:  # type: ignore[no-redef]
+    def match_log_entry(changed: list[str], current_pr: int | None) -> str:
         return "missing"
 
-    def pr_number_from_branch() -> int | None:  # type: ignore[no-redef]
+    def pr_number_from_branch() -> int | None:
         return None
 
 
@@ -62,7 +62,7 @@ try:
     )
 except Exception:  # noqa: BLE001
 
-    def _resolve_locale_string(key: str) -> str:  # type: ignore[no-redef]
+    def _resolve_locale_string(key: str) -> str:
         return ""
 
 

--- a/.antigravity/hooks/pre-tool-security.py
+++ b/.antigravity/hooks/pre-tool-security.py
@@ -11,8 +11,8 @@ try:
 
     _SHARED_OK = True
 except Exception:  # noqa: BLE001
-    check_code_safety = None  # type: ignore[assignment]
-    check_bash_command = None  # type: ignore[assignment]
+    check_code_safety = None
+    check_bash_command = None
     _SHARED_OK = False
 
 

--- a/.antigravity/hooks/stop-sync-reminder.py
+++ b/.antigravity/hooks/stop-sync-reminder.py
@@ -17,7 +17,7 @@ try:
     )
 except Exception:  # noqa: BLE001
 
-    def _resolve_locale_string(key: str) -> str:  # type: ignore[no-redef]
+    def _resolve_locale_string(key: str) -> str:
         return ""
 
 
@@ -28,7 +28,7 @@ try:
 
     _SYNC_OK = True
 except Exception:  # noqa: BLE001
-    _classify_advisory = None  # type: ignore[assignment]
+    _classify_advisory = None
     _SYNC_OK = False
 
 try:
@@ -46,11 +46,11 @@ try:
 except Exception:  # noqa: BLE001
     PLAN_EXECUTE_REMINDER = ""
     STAGE_GATE_REMINDER = ""
-    default_ledger_path = None  # type: ignore[assignment]
-    is_implementation_source = None  # type: ignore[assignment]
-    mark_fired = None  # type: ignore[assignment]
-    should_plan_execute_gate = None  # type: ignore[assignment]
-    should_stage_gate = None  # type: ignore[assignment]
+    default_ledger_path = None
+    is_implementation_source = None
+    mark_fired = None
+    should_plan_execute_gate = None
+    should_stage_gate = None
     _STAGE_GATE_OK = False
 
 
@@ -66,7 +66,17 @@ def stage_gate_segment(
     ledger_path: Path | None = None,
     repo_root: Path = REPO_ROOT,
 ) -> str | None:
-    if not _STAGE_GATE_OK:
+    # The names are checked individually, not just via the `_OK` flag: the flag
+    # and the sentinels are set in the same `except` branch, but nothing links them
+    # for a reader or a type checker — the guard reads as "the import group
+    # succeeded" while the call sites depend on "these three names are not None".
+    # Same form as the shared-import guards in .claude/hooks/completion_gate.py.
+    if (
+        not _STAGE_GATE_OK
+        or is_implementation_source is None
+        or default_ledger_path is None
+        or should_stage_gate is None
+    ):
         return None
     impl = next(
         (path for path in changed if is_implementation_source(path, repo_root)),
@@ -96,7 +106,12 @@ def plan_execute_segment(
     is the parity surface for Claude's PreToolUse hard block — advisory-only,
     reusing the shared single-file policy unchanged. The ``mark_fired`` claim is
     the caller's job (see ``main``) so it dedupes with ``stage_gate_segment``."""
-    if not _STAGE_GATE_OK:
+    if (
+        not _STAGE_GATE_OK
+        or is_implementation_source is None
+        or default_ledger_path is None
+        or should_plan_execute_gate is None
+    ):
         return None
     impl = next(
         (path for path in changed if is_implementation_source(path, repo_root)),
@@ -213,7 +228,11 @@ def main() -> int:
         # Stage-gate (mid-task, ADR 050) OR plan->execute boundary (ADR 054)
         # fire at most once per session via the shared exclusive-create marker.
         segment = stage_gate_segment(changed, sid) or plan_execute_segment(changed, sid)
-        if segment is not None and mark_fired(STATE_DIR, sid) is not None:
+        if (
+            segment is not None
+            and mark_fired is not None
+            and mark_fired(STATE_DIR, sid) is not None
+        ):
             segments.append(segment)
 
     with contextlib.suppress(Exception):

--- a/.antigravity/hooks/user-prompt-submit.py
+++ b/.antigravity/hooks/user-prompt-submit.py
@@ -19,9 +19,9 @@ try:
 
     _SHARED_OK = True
 except Exception:  # noqa: BLE001
-    Blocked = None  # type: ignore[assignment,misc]
-    ParsedToken = None  # type: ignore[assignment,misc]
-    safe_parse_exception_token = None  # type: ignore[assignment]
+    Blocked = None
+    ParsedToken = None
+    safe_parse_exception_token = None
     _shared_write_marker = None
     _SHARED_OK = False
 

--- a/.antigravity/hooks/verify_first.py
+++ b/.antigravity/hooks/verify_first.py
@@ -20,7 +20,7 @@ try:
 except Exception:  # noqa: BLE001
     EXPLORATION_TOKENS = frozenset()
     REMINDER_TEXT = ""
-    MarkerLifecycle = None  # type: ignore[assignment,misc]
+    MarkerLifecycle = None
     _shared_read_latest_token = None
     _SHARED_OK = False
 
@@ -30,7 +30,7 @@ try:
     )
 except Exception:  # noqa: BLE001
 
-    def _resolve_locale_string(key: str) -> str:  # type: ignore[no-redef]
+    def _resolve_locale_string(key: str) -> str:
         return ""
 
 

--- a/.claude/hooks/completion_gate.py
+++ b/.claude/hooks/completion_gate.py
@@ -65,37 +65,37 @@ except Exception:  # noqa: BLE001 — HC-5.5 fail-open
     EXPLORATION_TOKENS = frozenset()
     GOVERNOR_REMINDER_WITH_PR = ""
     GOVERNOR_REMINDER_NO_PR = ""
-    MarkerLifecycle = None  # type: ignore[assignment,misc]
-    _shared_read_latest_token = None  # type: ignore[assignment]
-    _shared_consume_phase2_markers = None  # type: ignore[assignment]
-    _shared_changed_files = None  # type: ignore[assignment]
-    _shared_governor_subset = None  # type: ignore[assignment]
-    _shared_is_sync_cosmetic_only = None  # type: ignore[assignment]
+    MarkerLifecycle = None
+    # The sibling names above all carry the sentinel; this one did not, so on the
+    # failure path it was simply unbound and its call site below relied on
+    # `contextlib.suppress` catching the NameError. Same sentinel, explicit guard.
+    cleanup_stale_verify_logs = None
+    _shared_read_latest_token = None
+    _shared_consume_phase2_markers = None
+    _shared_changed_files = None
+    _shared_governor_subset = None
+    _shared_is_sync_cosmetic_only = None
     _SHARED_OK = False
 
-    def _within_24h(ts: str) -> bool:  # type: ignore[no-redef]
+    def _within_24h(ts: str) -> bool:
         return True
 
-    def parse_trigger_globs(md_path: Path = GOVERNOR_PATHS_MD) -> list[str]:  # type: ignore[no-redef]
+    def parse_trigger_globs(md_path: Path = GOVERNOR_PATHS_MD) -> list[str]:
         return []
 
-    def _matches_glob(path: str, glob: str) -> bool:  # type: ignore[no-redef]
+    def _matches_glob(path: str, glob: str) -> bool:
         return False
 
-    def is_log_only_backfill(changed: list[str]) -> bool:  # type: ignore[no-redef]
+    def is_log_only_backfill(changed: list[str]) -> bool:
         return False
 
-    def is_governor_changing(  # type: ignore[no-redef]
-        changed: list[str], globs: list[str]
-    ) -> bool:
+    def is_governor_changing(changed: list[str], globs: list[str]) -> bool:
         return False
 
-    def match_log_entry(  # type: ignore[no-redef, misc]
-        changed: list[str], current_pr: int | None
-    ) -> str:
+    def match_log_entry(changed: list[str], current_pr: int | None) -> str:
         return "missing"
 
-    def pr_number_from_branch() -> int | None:  # type: ignore[no-redef]
+    def pr_number_from_branch() -> int | None:
         return None
 
 
@@ -107,7 +107,7 @@ try:
     )
 except Exception:  # noqa: BLE001 — HC-5.5 fail-open
 
-    def _resolve_locale_string(key: str) -> str:  # type: ignore[no-redef]
+    def _resolve_locale_string(key: str) -> str:
         return ""
 
 
@@ -227,7 +227,7 @@ def main() -> int:
             # harnesses clean up here too. Never touches this session's file —
             # and when the session cannot be identified, nothing at all.
             _session = _verify_session_id()
-            if _session:
+            if _session and cleanup_stale_verify_logs is not None:
                 cleanup_stale_verify_logs(STATE_DIR, _session)
         if reminder:
             print(reminder)

--- a/.claude/hooks/post_tool_stage_gate.py
+++ b/.claude/hooks/post_tool_stage_gate.py
@@ -41,10 +41,10 @@ try:
     _SHARED_OK = True
 except Exception:  # noqa: BLE001 — HC-5.5 fail-open
     STAGE_GATE_REMINDER = ""
-    default_ledger_path = None  # type: ignore[assignment]
-    extract_session_id = None  # type: ignore[assignment]
-    mark_fired = None  # type: ignore[assignment]
-    should_stage_gate = None  # type: ignore[assignment]
+    default_ledger_path = None
+    extract_session_id = None
+    mark_fired = None
+    should_stage_gate = None
     _SHARED_OK = False
 
 # AGENT_LOCALE resolver (issue #133) — separate try block so a locale.py
@@ -55,12 +55,23 @@ try:
     )
 except Exception:  # noqa: BLE001 — HC-5.5 fail-open
 
-    def _resolve_locale_string(key: str) -> str:  # type: ignore[no-redef]
+    def _resolve_locale_string(key: str) -> str:
         return ""
 
 
 def main() -> int:
-    if not _SHARED_OK:
+    # The names are checked individually, not just via the `_OK` flag: the flag
+    # and the sentinels are set in the same `except` branch, but nothing links them
+    # for a reader or a type checker — the guard reads as "the import group
+    # succeeded" while the call sites depend on "these three names are not None".
+    # Same form as the shared-import guards in .claude/hooks/completion_gate.py.
+    if (
+        not _SHARED_OK
+        or default_ledger_path is None
+        or should_stage_gate is None
+        or mark_fired is None
+        or extract_session_id is None
+    ):
         return 0
     try:
         raw = sys.stdin.read()

--- a/.claude/hooks/pre_tool_security.py
+++ b/.claude/hooks/pre_tool_security.py
@@ -26,7 +26,7 @@ try:
 
     _SHARED_OK = True
 except Exception:  # noqa: BLE001 — HC-5.5 fail-open
-    check_code_safety = None  # type: ignore[assignment]
+    check_code_safety = None
     _SHARED_OK = False
 
 

--- a/.claude/hooks/pre_tool_stage_block.py
+++ b/.claude/hooks/pre_tool_stage_block.py
@@ -45,8 +45,8 @@ try:
     _SHARED_OK = True
 except Exception:  # noqa: BLE001 — HC-5.5 fail-open (ADR054-G5)
     PLAN_EXECUTE_REMINDER = ""
-    default_ledger_path = None  # type: ignore[assignment]
-    should_block_plan_execute_edit = None  # type: ignore[assignment]
+    default_ledger_path = None
+    should_block_plan_execute_edit = None
     _SHARED_OK = False
 
 # AGENT_LOCALE resolver (issue #133) — separate try block so a locale.py
@@ -57,7 +57,7 @@ try:
     )
 except Exception:  # noqa: BLE001 — HC-5.5 fail-open
 
-    def _resolve_locale_string(key: str) -> str:  # type: ignore[no-redef]
+    def _resolve_locale_string(key: str) -> str:
         return ""
 
 
@@ -67,7 +67,16 @@ _BLOCK = 2
 
 
 def main() -> int:
-    if not _SHARED_OK:
+    # The names are checked individually, not just via the `_OK` flag: the flag
+    # and the sentinels are set in the same `except` branch, but nothing links them
+    # for a reader or a type checker — the guard reads as "the import group
+    # succeeded" while the call sites depend on "these three names are not None".
+    # Same form as the shared-import guards in .claude/hooks/completion_gate.py.
+    if (
+        not _SHARED_OK
+        or default_ledger_path is None
+        or should_block_plan_execute_edit is None
+    ):
         return _ALLOW
     try:
         raw = sys.stdin.read()

--- a/.claude/hooks/user_prompt_submit.py
+++ b/.claude/hooks/user_prompt_submit.py
@@ -51,11 +51,11 @@ try:
     _SHARED_OK = True
 except Exception as exc:  # noqa: BLE001 — HC-5.5 fail-open, must not raise SystemExit
     debug_log("claude user-prompt shared import failed", exc)
-    TOKEN_REGEX = None  # type: ignore[assignment]
+    TOKEN_REGEX = None
     _shared_write_marker = None
     _SHARED_OK = False
 
-    def parse_exception_token(prompt: str) -> dict:  # type: ignore[no-redef]
+    def parse_exception_token(prompt: str) -> dict:
         return {"matched": False, "token": None, "rationale_required": False}
 
 

--- a/.claude/hooks/verify_first.py
+++ b/.claude/hooks/verify_first.py
@@ -48,17 +48,17 @@ try:
 except Exception:  # noqa: BLE001 — HC-5.5 fail-open
     EXPLORATION_TOKENS = frozenset()
     REMINDER_TEXT = ""
-    MarkerLifecycle = None  # type: ignore[assignment,misc]
-    read_latest_token = None  # type: ignore[assignment]
+    MarkerLifecycle = None
+    read_latest_token = None
     _SHARED_OK = False
 
-    def _within_24h(ts: str) -> bool:  # type: ignore[no-redef]
+    def _within_24h(ts: str) -> bool:
         return True
 
-    def extract_file_path(payload: dict) -> str | None:  # type: ignore[no-redef]
+    def extract_file_path(payload: dict) -> str | None:
         return None
 
-    def is_python_source(file_path: str | None) -> bool:  # type: ignore[no-redef]
+    def is_python_source(file_path: str | None) -> bool:
         return False
 
 
@@ -72,7 +72,7 @@ try:
     )
 except Exception:  # noqa: BLE001 — HC-5.5 fail-open
 
-    def _resolve_locale_string(key: str) -> str:  # type: ignore[no-redef]
+    def _resolve_locale_string(key: str) -> str:
         return ""
 
 

--- a/.claude/hooks/verify_log.py
+++ b/.claude/hooks/verify_log.py
@@ -41,7 +41,12 @@ try:
 except Exception:  # noqa: BLE001 — HC-5.5 fail-open
     _SHARED_OK = False
 
-    def append_verify_log(*_args, **_kwargs):  # type: ignore[misc]
+    # Same signature as the real one, not `*args, **kwargs`: a fallback whose
+    # shape differs from what it stands in for cannot be checked against its call
+    # sites, which is the one thing worth knowing about a fail-open stub.
+    def append_verify_log(
+        command: str, state_dir: Path, session_id: str
+    ) -> Path | None:
         return None
 
 

--- a/.codex/hooks/_shared.py
+++ b/.codex/hooks/_shared.py
@@ -28,7 +28,7 @@ try:
     _GATE_OK = True
 except Exception as exc:  # noqa: BLE001 — HC-5.5 fail-open
     debug_log("codex shared changed-files import failed", exc)
-    _impl = None  # type: ignore[assignment]
+    _impl = None
     _GATE_OK = False
 
 

--- a/.codex/hooks/completion_gate.py
+++ b/.codex/hooks/completion_gate.py
@@ -74,36 +74,32 @@ except Exception:  # noqa: BLE001 — HC-5.5 fail-open
     EXPLORATION_TOKENS = frozenset()
     GOVERNOR_REMINDER_WITH_PR = ""
     GOVERNOR_REMINDER_NO_PR = ""
-    MarkerLifecycle = None  # type: ignore[assignment,misc]
-    _shared_read_latest_token = None  # type: ignore[assignment]
-    _shared_consume_phase2_markers = None  # type: ignore[assignment]
-    _shared_governor_subset = None  # type: ignore[assignment]
-    _shared_is_sync_cosmetic_only = None  # type: ignore[assignment]
+    MarkerLifecycle = None
+    _shared_read_latest_token = None
+    _shared_consume_phase2_markers = None
+    _shared_governor_subset = None
+    _shared_is_sync_cosmetic_only = None
     _SHARED_OK = False
 
-    def _within_24h(ts: str) -> bool:  # type: ignore[no-redef]
+    def _within_24h(ts: str) -> bool:
         return True
 
-    def parse_trigger_globs(md_path: Path = GOVERNOR_PATHS_MD) -> list[str]:  # type: ignore[no-redef]
+    def parse_trigger_globs(md_path: Path = GOVERNOR_PATHS_MD) -> list[str]:
         return []
 
-    def _matches_glob(path: str, glob: str) -> bool:  # type: ignore[no-redef]
+    def _matches_glob(path: str, glob: str) -> bool:
         return False
 
-    def is_log_only_backfill(changed: list[str]) -> bool:  # type: ignore[no-redef]
+    def is_log_only_backfill(changed: list[str]) -> bool:
         return False
 
-    def is_governor_changing(  # type: ignore[no-redef]
-        changed: list[str], globs: list[str]
-    ) -> bool:
+    def is_governor_changing(changed: list[str], globs: list[str]) -> bool:
         return False
 
-    def match_log_entry(  # type: ignore[no-redef, misc]
-        changed: list[str], current_pr: int | None
-    ) -> str:
+    def match_log_entry(changed: list[str], current_pr: int | None) -> str:
         return "missing"
 
-    def pr_number_from_branch() -> int | None:  # type: ignore[no-redef]
+    def pr_number_from_branch() -> int | None:
         return None
 
 
@@ -115,7 +111,7 @@ try:
     )
 except Exception:  # noqa: BLE001 — HC-5.5 fail-open
 
-    def _resolve_locale_string(key: str) -> str:  # type: ignore[no-redef]
+    def _resolve_locale_string(key: str) -> str:
         return ""
 
 

--- a/.codex/hooks/pre-tool-security.py
+++ b/.codex/hooks/pre-tool-security.py
@@ -34,7 +34,7 @@ try:
     _SHARED_OK = True
 except Exception as exc:  # noqa: BLE001 — HC-5.5 fail-open
     debug_log("codex pre-tool shared import failed", exc)
-    check_bash_command = None  # type: ignore[assignment]
+    check_bash_command = None
     _SHARED_OK = False
 
 

--- a/.codex/hooks/stop-sync-reminder.py
+++ b/.codex/hooks/stop-sync-reminder.py
@@ -68,7 +68,7 @@ try:
     )
 except Exception:  # noqa: BLE001 — HC-5.5 fail-open
 
-    def _resolve_locale_string(key: str) -> str:  # type: ignore[no-redef]
+    def _resolve_locale_string(key: str) -> str:
         return ""
 
 
@@ -79,7 +79,7 @@ try:
 
     _SYNC_OK = True
 except Exception:  # noqa: BLE001 — HC-5.5 fail-open
-    _classify_advisory = None  # type: ignore[assignment]
+    _classify_advisory = None
     _SYNC_OK = False
 
 
@@ -102,11 +102,11 @@ try:
 except Exception:  # noqa: BLE001 — HC-5.5 fail-open
     PLAN_EXECUTE_REMINDER = ""
     STAGE_GATE_REMINDER = ""
-    default_ledger_path = None  # type: ignore[assignment]
-    is_implementation_source = None  # type: ignore[assignment]
-    mark_fired = None  # type: ignore[assignment]
-    should_plan_execute_gate = None  # type: ignore[assignment]
-    should_stage_gate = None  # type: ignore[assignment]
+    default_ledger_path = None
+    is_implementation_source = None
+    mark_fired = None
+    should_plan_execute_gate = None
+    should_stage_gate = None
     _STAGE_GATE_OK = False
 
 
@@ -145,7 +145,17 @@ def stage_gate_segment(
     (see ``main``) so a race-losing concurrent hook stays silent (R1.3).
     Returns the locale-rendered reminder text when the gate fires, else None.
     """
-    if not _STAGE_GATE_OK:
+    # The names are checked individually, not just via the `_OK` flag: the flag
+    # and the sentinels are set in the same `except` branch, but nothing links them
+    # for a reader or a type checker — the guard reads as "the import group
+    # succeeded" while the call sites depend on "these three names are not None".
+    # Same form as the shared-import guards in .claude/hooks/completion_gate.py.
+    if (
+        not _STAGE_GATE_OK
+        or is_implementation_source is None
+        or default_ledger_path is None
+        or should_stage_gate is None
+    ):
         return None
     impl = next(
         (path for path in changed if is_implementation_source(path, repo_root)),
@@ -187,7 +197,12 @@ def plan_execute_segment(
     (see ``main``) so a race-losing concurrent hook stays silent (R1.3).
     Returns the locale-rendered reminder text when the gate fires, else None.
     """
-    if not _STAGE_GATE_OK:
+    if (
+        not _STAGE_GATE_OK
+        or is_implementation_source is None
+        or default_ledger_path is None
+        or should_plan_execute_gate is None
+    ):
         return None
     impl = next(
         (path for path in changed if is_implementation_source(path, repo_root)),
@@ -348,7 +363,11 @@ def main() -> int:
 
         sid = verify_first.session_id()
         seg = stage_gate_segment(changed, sid) or plan_execute_segment(changed, sid)
-        if seg is not None and mark_fired(STATE_DIR, sid) is not None:
+        if (
+            seg is not None
+            and mark_fired is not None
+            and mark_fired(STATE_DIR, sid) is not None
+        ):
             segments.append(seg)
 
     # (4) Phase 2 marker consumption + (5) stale verify-log cleanup.

--- a/.codex/hooks/user-prompt-submit.py
+++ b/.codex/hooks/user-prompt-submit.py
@@ -52,15 +52,15 @@ try:
     _SHARED_OK = True
 except Exception as exc:  # noqa: BLE001 — HC-5.5 fail-open
     debug_log("codex user-prompt shared import failed", exc)
-    PROMPT_RULES = []  # type: ignore[assignment]
-    TOKEN_REGEX = None  # type: ignore[assignment]
-    Blocked = None  # type: ignore[assignment,misc]
-    ParsedToken = None  # type: ignore[assignment,misc]
-    safe_parse_exception_token = None  # type: ignore[assignment]
+    PROMPT_RULES = []
+    TOKEN_REGEX = None
+    Blocked = None
+    ParsedToken = None
+    safe_parse_exception_token = None
     _shared_write_marker = None
     _SHARED_OK = False
 
-    def parse_exception_token(prompt: str) -> dict:  # type: ignore[no-redef]
+    def parse_exception_token(prompt: str) -> dict:
         return {"matched": False, "token": None, "rationale_required": False}
 
 

--- a/.codex/hooks/verify_first.py
+++ b/.codex/hooks/verify_first.py
@@ -47,11 +47,11 @@ try:
 except Exception:  # noqa: BLE001 — HC-5.5 fail-open
     EXPLORATION_TOKENS = frozenset()
     REMINDER_TEXT = ""
-    MarkerLifecycle = None  # type: ignore[assignment,misc]
-    _shared_read_latest_token = None  # type: ignore[assignment]
+    MarkerLifecycle = None
+    _shared_read_latest_token = None
     _SHARED_OK = False
 
-    def _within_24h(ts: str) -> bool:  # type: ignore[no-redef]
+    def _within_24h(ts: str) -> bool:
         return True
 
 
@@ -64,7 +64,7 @@ try:
     )
 except Exception:  # noqa: BLE001 — HC-5.5 fail-open
 
-    def _resolve_locale_string(key: str) -> str:  # type: ignore[no-redef]
+    def _resolve_locale_string(key: str) -> str:
         return ""
 
 

--- a/docs/ai/shared/project-dna.md
+++ b/docs/ai/shared/project-dna.md
@@ -610,9 +610,10 @@ class {Name}Container(containers.DeclarativeContainer):
   a dot-directory named in `include` is skipped in silence. Measured: `.claude/hooks`
   reported `0 errors` while analysing **0 of its 7 files**. `exclude` is therefore set
   explicitly, and the scope test pins that pairing — "0 errors" and "nothing checked" print
-  identically, which is the same illusion the mypy hook sustained. Still out of scope by
-  decision: `tests/` (152 errors) and the three harness hook directories (91, mostly
-  unresolved imports needing `extraPaths`).
+  identically, which is the same illusion the mypy hook sustained. The three harness hook
+  directories joined in #387 — `extraPaths = [".agents/shared"]` resolved 70 of their 177
+  findings outright, 88 were `# type: ignore` comments orphaned by retiring mypy, and 19
+  were real. `tests/` (152 errors) stays out by decision, as its own piece of work.
 - **pip-audit — advisory** (`continue-on-error`), writing to the job summary. A newly
   published CVE would otherwise redden a PR that changed nothing, which the §0
   advisory-first direction rules out. It installs the shipped extras before scanning so

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,12 +113,17 @@ otel = [
 # and "nothing checked" print the same way, which is the exact failure that let
 # the mypy hook look like coverage for two releases.
 #
+# The three harness hook directories joined in #387. 177 errors became 0, and the
+# split was not what it looked like: 70 were unresolved imports that `extraPaths`
+# fixed outright, 88 were `# type: ignore` comments left orphaned by retiring
+# mypy, and the 19 that remained were real — a fallback stub whose signature did
+# not match what it stands in for, one name the fail-open `except` branch forgot
+# to give a sentinel, and 17 call sites guarded by an `_OK` flag that nothing
+# links to the `None` sentinels it sets.
+#
 # Deliberately still out of scope:
 #   tests/                152 errors. mypy excluded it too; widening it is its own
 #                         piece of work, not a side effect of retiring mypy.
-#   .claude/hooks/ and    91 errors, 70 of them unresolved imports because the
-#   the other two         hooks reach `.agents/shared/` through sys.path edits that
-#   harness copies        need `extraPaths`. Tracked separately.
 #
 # Never widen coverage by relaxing the rules below.
 [tool.pyright]
@@ -130,6 +135,12 @@ include = [
     # The shared governor package every harness hook imports. Clean already; it
     # had no type checker looking at it because it lives in a dot-directory.
     ".agents",
+    # The three harness hook copies (#387). They are runtime scripts, not shipped
+    # code, but the failure they risk is a hook degrading into a no-op — which is
+    # precisely what the retired mypy stage demonstrated.
+    ".claude/hooks",
+    ".antigravity/hooks",
+    ".codex/hooks",
     # mypy excluded `run_.*\.py$`. Including them found that `make scheduler` had
     # never run the scheduler: `run_scheduler` is a coroutine function and the call
     # dropped it. Pinned by tests/unit/test_local_runners.py.
@@ -138,6 +149,13 @@ include = [
     "run_scheduler_local.py",
 ]
 exclude = ["**/node_modules", "**/__pycache__", "**/.venv"]
+# The hooks reach the shared governor package by inserting `.agents/shared` on
+# `sys.path` at import time, so `harness_debug` / `governor.*` are top-level names
+# that no static resolver can find on its own. This is what turned 70 of #387's
+# findings into zero — and it also revealed two orphaned ignores in
+# `tools/check_governor_footer.py`, a file already in the gate whose imports had
+# been silently unresolved.
+extraPaths = [".agents/shared"]
 # Suppressions cannot rot: an ignore comment that stops being needed is an error.
 # Enabling this is what retiring mypy bought — it reported 3 errors while the hook
 # existed, and 2 were mypy-only `# type: ignore` comments pyright does not need.

--- a/tests/unit/tools/test_pyright_scope.py
+++ b/tests/unit/tools/test_pyright_scope.py
@@ -14,7 +14,10 @@ is the whole reason this file exists:
 - **Suppression creep.** `# pyright: ignore` is the other way to hold a tree at 0
   errors without fixing anything. 21 exist, in 10 files, each with its cause
   written at the call site. That is defensible *because* it is pinned; unpinned,
-  it is a trend.
+  it is a trend. #387 is the counter-example worth remembering: the three harness
+  hook directories carried **88** `# type: ignore` comments, every one of them
+  unnecessary, because they were written for a checker that had not run in two
+  releases. None of them was replaced by a suppression.
 
 The third one is the same illusion the retired mypy hook sustained for two
 releases: it aborted on a duplicate module name, inspected nothing, and reported
@@ -118,6 +121,22 @@ def test_every_include_path_exists(path: str) -> None:
         assert any(resolved.rglob("*.py")), f"{path!r} contains no Python to check"
 
 
+def test_the_shared_governor_package_is_on_the_resolution_path() -> None:
+    """`extraPaths` is what makes the harness hooks checkable at all (#387).
+
+    The hooks insert `.agents/shared` on `sys.path` at import time, so
+    `harness_debug` and `governor.*` are top-level names no static resolver finds
+    on its own. Dropping this line does surface as 70 unresolved-import errors
+    rather than silence — but the tempting way to quiet those is to relax
+    `reportMissingImports`, which would also blind the gate to a genuinely missing
+    module. This says which of the two is the fix.
+    """
+    assert ".agents/shared" in _pyright_config().get("extraPaths", []), (
+        "the harness hooks and tools/check_governor_footer.py resolve their shared "
+        "imports through this path; without it 70 imports go unresolved"
+    )
+
+
 def test_dot_directory_includes_require_an_explicit_exclude() -> None:
     """The trap: a dot-path in `include` is skipped unless `exclude` is overridden.
 
@@ -163,7 +182,17 @@ def test_every_src_package_is_covered(package: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "path", ["tools", "scripts", "examples", ".agents", "run_scheduler_local.py"]
+    "path",
+    [
+        "tools",
+        "scripts",
+        "examples",
+        ".agents",
+        "run_scheduler_local.py",
+        ".claude/hooks",
+        ".antigravity/hooks",
+        ".codex/hooks",
+    ],
 )
 def test_the_scope_mypy_nominally_covered_stays_covered(path: str) -> None:
     """Retiring mypy (#375) must not quietly reduce what is checked.

--- a/tools/check_governor_footer.py
+++ b/tools/check_governor_footer.py
@@ -316,12 +316,12 @@ def _is_governor_changing(changed_files: list[str]) -> bool:
 
     sys.path.insert(0, str(REPO_ROOT / ".agents" / "shared"))
     try:
-        from governor.completion_gate import (  # type: ignore[import-not-found]
+        from governor.completion_gate import (
             is_governor_changing,
             is_log_only_backfill,
             parse_trigger_globs,
         )
-        from governor.paths import GOVERNOR_PATHS_MD  # type: ignore[import-not-found]
+        from governor.paths import GOVERNOR_PATHS_MD
     finally:
         sys.path.pop(0)
     if not changed_files:


### PR DESCRIPTION
Closes #387. `[tool.pyright] include` now covers `.claude/hooks`, `.antigravity/hooks` and `.codex/hooks`. **177 errors → 0**, and the split was not what the issue predicted.

## 70 were configuration, and one line fixed all of them

The hooks insert `.agents/shared` on `sys.path` at import time, so `harness_debug` and `governor.*` are top-level names no static resolver can find:

```python
SHARED_PKG = REPO_ROOT / ".agents" / "shared"
if str(SHARED_PKG) not in sys.path:
    sys.path.insert(0, str(SHARED_PKG))
```

`extraPaths = [".agents/shared"]` resolved them — and revealed **two orphaned ignores in `tools/check_governor_footer.py`**, a file already inside the gate whose imports had been silently unresolved the whole time. Widening coverage improved coverage of something already covered.

## 88 were `# type: ignore` comments orphaned by retiring mypy

Every single `type: ignore` in those directories was unnecessary — **88 of 88** — because they were written for a checker that had not run in two releases (#375):

| count | sat on |
|---|---|
| 49 | `= None` sentinel assignments in the fail-open shims |
| 35 | `no-redef` stub definitions — a concept pyright does not have |
| 4 | misc, incl. the two now-resolved imports in `tools/` |

All deleted. **None was replaced by a `# pyright: ignore`.**

## 19 were real, and each is fixed rather than suppressed

**A fallback that could not be checked against its call sites.** `verify_log.py` had `def append_verify_log(*_args, **_kwargs)` standing in for `(command: str, state_dir: Path, session_id: str) -> Path | None`. A fail-open stub whose shape differs from what it replaces defeats the one purpose of having it in the signature position.

**A name the `except` branch forgot.** `completion_gate.py` gives six imported names the `None` sentinel and skipped `cleanup_stale_verify_logs`, so on the failure path that name was *unbound* and the call site relied on `contextlib.suppress` swallowing a `NameError`. Now the same sentinel as its siblings, with an explicit guard.

**17 call sites guarded by a flag nothing links to the sentinels.** The `_OK` flag and the `None` assignments are set in the same `except` branch, but the guard reads "the import group succeeded" while the calls depend on "these names are not None":

```python
if not _STAGE_GATE_OK:          # says nothing about the names below
    return None
...
should_stage_gate(payload, state_dir, resolved_ledger, repo_root)
```

The guards now name the callables they need — the form `.claude/hooks/completion_gate.py` already used (`if not _SHARED_OK or _shared_read_latest_token is None or MarkerLifecycle is None:`). Behaviour is unchanged: when the flag is true the names are bound, and when it is false the function already returned.

## Why the shims were not restructured

The obvious refactor — replace `None` with no-op stub functions, killing the flag correlation — is **wrong here**, and the tests say so. `tests/unit/agents_shared/test_fail_open.py` pins three tiers of degradation including subprocess runs with a scrambled `PYTHONPATH`, and `.claude/hooks` checks those sentinels *directly* (`if not _SHARED_OK or check_code_safety is None:`). Stub functions would have turned those checks into dead code and changed which branch the fail-open path takes.

## #387's own hypothesis was wrong

I filed the issue expecting one fix to triple across three parallel copies. Measured: **0 of 94 distinct `(file, line, message)` keys appeared in all three.** The copies have diverged. This was three passes, not one fix tripled — recorded in the issue at the time so nobody re-runs the guess.

## Verification

| gate | result |
|---|---|
| `uv run pyright` | **0 errors**, 684 files analysed |
| `tests/unit/agents_shared/` | **714 passed** — the fail-open contract |
| `make check-core` | 1947 passed, 4 skipped |
| all six patched hooks, run end to end | exit 0, no traceback |
| `extraPaths` guard | verified: removing the line fails the test *and* returns 72 errors |

Also corrects two claims this work falsified — the pyproject and project-dna notes saying these directories were out of scope with 91 mostly-unfixable findings.

## Governor Footer

- trigger: yes
- reviewer: self-structured
- rounds: 1
- r-points-fixed: 1
- r-points-deferred: 1
- r-points-rejected: 1
- touched-adr-consequences: none
- pr-scope-notes: Governor surfaces are the [tool.pyright] section of pyproject.toml, docs/ai/shared/project-dna.md, and the three harness hook directories themselves (Tier B tool surfaces); checked with tools/check_governor_footer.py locally before opening. R1 = my first plan was to replace the None sentinels with stub functions, which test_fail_open.py and the direct `is None` checks in .claude/hooks show would change the fail-open branch; Fixed by localising the guards instead and leaving the shim shape alone. Rejected = #387's own "one fix triples across three copies" hypothesis, on the measurement that 0 of 94 findings appear in all three. Deferred = tests/ (152 errors), unchanged from #375. Cross-tool review not obtained: codex exec 0.147.0 answers small prompts but echoes and exits without generating for a large prompt carrying an inline diff, reproduced four times in-repo and from /tmp. Self-structured per AGENTS.md Independent Review Trigger, supplemented by running every patched hook end to end, since these are runtime scripts whose failure mode is degrading into a silent no-op.
- final-verdict: merge-ready
- links: https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/390, https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/387
