### PR TITLE
refactor(core): take Sequence where a list was only iterated

### DIFF
--- a/src/_core/domain/protocols/repository_protocol.py
+++ b/src/_core/domain/protocols/repository_protocol.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar
 
 from pydantic import BaseModel
@@ -17,7 +17,10 @@ ReturnDTO = TypeVar("ReturnDTO", bound=BaseModel)
 class BaseRepositoryProtocol(Protocol, Generic[ReturnDTO]):
     async def insert_data(self, entity: BaseModel) -> ReturnDTO: ...
 
-    async def insert_datas(self, entities: list[BaseModel]) -> list[ReturnDTO]: ...
+    # `Sequence`, not `list`: the parameter is only iterated, and `list` is
+    # invariant — a caller holding `list[MyDTO]` could not pass it without a
+    # cast, which is exactly what `BaseService.create_datas` used to do.
+    async def insert_datas(self, entities: Sequence[BaseModel]) -> list[ReturnDTO]: ...
 
     async def select_datas(self, page: int, page_size: int) -> list[ReturnDTO]: ...
 

--- a/src/_core/domain/services/base_service.py
+++ b/src/_core/domain/services/base_service.py
@@ -29,9 +29,12 @@ class BaseService(Generic[CreateDTO, UpdateDTO, ReturnDTO]):
 
     async def create_datas(self, entities: list[CreateDTO]) -> list[ReturnDTO]:
         await self._validate_create_many(entities)
-        return await self.repository.insert_datas(
-            entities=cast(list[BaseModel], entities)
-        )
+        # No cast: the repository takes `Sequence[BaseModel]`, and `Sequence` is
+        # covariant, so `list[CreateDTO]` is one directly. While it took
+        # `list[BaseModel]` this line needed `cast(list[BaseModel], entities)` —
+        # a claim that would also have permitted appending an unrelated BaseModel
+        # to the caller's list.
+        return await self.repository.insert_datas(entities=entities)
 
     async def get_datas(
         self,

--- a/src/_core/infrastructure/persistence/nosql/dynamodb/base_dynamo_repository.py
+++ b/src/_core/infrastructure/persistence/nosql/dynamodb/base_dynamo_repository.py
@@ -6,7 +6,7 @@ import binascii
 import json
 import random
 from abc import ABC
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 import structlog
@@ -283,7 +283,7 @@ class BaseDynamoRepository(Generic[ReturnDTO], ABC):
     # ------------------------------------------------------------------
 
     async def batch_put_items(
-        self, entities: list[BaseModel], *, max_retries: int = 3
+        self, entities: Sequence[BaseModel], *, max_retries: int = 3
     ) -> list[ReturnDTO]:
         """Batch write items (auto-chunks to 25, retries UnprocessedItems)."""
         results: list[ReturnDTO] = []

--- a/src/_core/infrastructure/persistence/rdb/base_repository.py
+++ b/src/_core/infrastructure/persistence/rdb/base_repository.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from datetime import date, datetime
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
@@ -48,7 +48,7 @@ class BaseRepository(Generic[ReturnDTO], ABC):
             await session.refresh(data)
             return self.return_entity.model_validate(data, from_attributes=True)
 
-    async def insert_datas(self, entities: list[BaseModel]) -> list[ReturnDTO]:
+    async def insert_datas(self, entities: Sequence[BaseModel]) -> list[ReturnDTO]:
         async with self.database.session() as session:
             datas = [
                 self.model(**entity.model_dump(exclude_none=True))

--- a/src/user/infrastructure/repositories/user_repository.py
+++ b/src/user/infrastructure/repositories/user_repository.py
@@ -1,3 +1,5 @@
+from collections.abc import Sequence
+
 from pydantic import BaseModel
 from sqlalchemy import select
 
@@ -27,7 +29,7 @@ class UserRepository(BaseRepository[UserDTO]):
             await self._raise_user_unique_conflict_if_present(entity, exc)
             raise
 
-    async def insert_datas(self, entities: list[BaseModel]) -> list[UserDTO]:
+    async def insert_datas(self, entities: Sequence[BaseModel]) -> list[UserDTO]:
         try:
             return await super().insert_datas(entities=entities)
         except DatabaseException as exc:

--- a/tests/unit/_core/domain/services/test_base_service.py
+++ b/tests/unit/_core/domain/services/test_base_service.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from datetime import date, datetime
 from typing import Any
 
@@ -37,7 +37,7 @@ class FakeRepository:
         self.next_id += 1
         return item
 
-    async def insert_datas(self, entities: list[BaseModel]) -> list[ItemDTO]:
+    async def insert_datas(self, entities: Sequence[BaseModel]) -> list[ItemDTO]:
         return [await self.insert_data(entity) for entity in entities]
 
     async def select_datas(self, page: int, page_size: int) -> list[ItemDTO]:

--- a/tests/unit/admin_identity/application/test_admin_account_use_case.py
+++ b/tests/unit/admin_identity/application/test_admin_account_use_case.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 import pytest
@@ -113,7 +113,9 @@ class FakeAdminRepository:
             and getattr(dto, field) in value_set
         }
 
-    async def insert_datas(self, entities: list[BaseModel]) -> list[AdminIdentityDTO]:
+    async def insert_datas(
+        self, entities: Sequence[BaseModel]
+    ) -> list[AdminIdentityDTO]:
         return [await self.insert_data(e) for e in entities]
 
     async def count_datas(self) -> int:

--- a/tests/unit/user/domain/test_user_service.py
+++ b/tests/unit/user/domain/test_user_service.py
@@ -1,4 +1,4 @@
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 import pytest
@@ -27,7 +27,7 @@ class MockUserRepository:
         self._next_id += 1
         return dto
 
-    async def insert_datas(self, entities: list[BaseModel]) -> list[UserDTO]:
+    async def insert_datas(self, entities: Sequence[BaseModel]) -> list[UserDTO]:
         return [await self.insert_data(e) for e in entities]
 
     async def select_datas(self, page: int, page_size: int) -> list[UserDTO]:


### PR DESCRIPTION
Found while measuring what it would take to type-check `tests/`. **The `tests/` sweep itself is not in this PR** — this is the production finding it turned up, which stands on its own.

## Three sibling backends, three spellings of the same parameter

```python
BaseS3VectorStore.upsert(entities: Sequence[BaseModel])          # correct
BaseRepository.insert_datas(entities: list[BaseModel])
BaseDynamoRepository.batch_put_items(entities: list[BaseModel])
```

`list` is invariant, so `list[MyDTO]` is not a `list[BaseModel]` — a caller holding a list of its own DTOs cannot pass it. `BaseService.create_datas` was already paying that toll:

```python
entities=cast(list[BaseModel], entities)
```

**That cast is the finding.** It exists only because of the invariance, and it asserts something untrue: that a `list[CreateDTO]` may be treated as a `list[BaseModel]` — which would also permit appending an unrelated `BaseModel` into the caller's list. `Sequence` is covariant, so widening the parameter **deletes** the cast rather than relocating it.

Both bodies only iterate the parameter (a comprehension in each), so `Sequence` is the accurate type, not merely the permissive one.

## Widened in lockstep

Per the pairing rule in `architecture-conventions.md`: `BaseRepositoryProtocol`, `BaseRepository`, the one domain override in `user_repository.py`, and the DynamoDB sibling. No caller breaks — every `list` that used to be accepted still is.

The three test doubles that implement `insert_datas` widened with it, because an implementation with a **narrower** parameter does not satisfy the protocol. Pyright reported it precisely, which is the argument for having tests inside the gate eventually:

```
"FakeRepository" is incompatible with protocol "BaseRepositoryProtocol[ItemDTO]"
  "insert_datas" is an incompatible type
    Type "(entities: list[BaseModel]) -> ..." is not assignable to type
         "(entities: Sequence[BaseModel]) -> ..."
```

## Verification

| gate | result |
|---|---|
| `uv run pyright` | 0 errors (`src/` unchanged at 0) |
| `make check-core` | 1951 passed, 4 skipped |
| affected suites (`services`, `user`, `auth`, `admin_identity`, `persistence`) | 172 passed |

## Why `tests/` is not in the gate yet

Adding the include path is the **last** step of that work, not the first. 146 findings remain, and the measurement corrected my own initial guess about them: they are **not** mostly dependency-injector `Provider[Any]` (that was one example I over-generalised). The real distribution is ~30 test doubles that have drifted from the interfaces they impersonate, ~30 `Optional` accesses that want an `assert`, 13 mypy-era ignores to delete, 11 imports needing `extraPaths`, and a misc tail. Several will be production findings like this one.

## Governor Footer

- trigger: no
- reviewer: self-structured
- rounds: 1
- r-points-fixed: 1
- r-points-deferred: 1
- r-points-rejected: 0
- touched-adr-consequences: none
- pr-scope-notes: No governor path is touched — `src/` runtime code plus three test doubles; check_governor_footer.py was run against the changed-file list and does not require a footer here, and one is included anyway because the change alters a documented base-class signature that `architecture-conventions.md` describes. R1 = the widening initially broke the protocol conformance of three test doubles, which is the change being self-inconsistent rather than a separate defect; Fixed by widening them in the same commit. Deferred-with-rationale = the remaining 146 `tests/` findings and the include-path widening, which is its own piece of work with its own production findings likely inside it. Cross-tool review not obtained: codex exec 0.147.0 answers small prompts but echoes and exits without generating for a large prompt carrying an inline diff, reproduced four times in-repo and from /tmp. Self-structured per AGENTS.md Independent Review Trigger, supplemented by confirming neither widened body mutates its parameter — `Sequence` would be wrong, not merely wider, if either appended.
- final-verdict: merge-ready
- links: https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/394, n/a
