### PR TITLE
test: make the repository doubles satisfy the protocols they stand in for

### DIFF
--- a/tests/support/fake_repository.py
+++ b/tests/support/fake_repository.py
@@ -1,0 +1,121 @@
+"""One place that knows the whole `BaseRepositoryProtocol` surface.
+
+Test doubles here implement only the handful of methods their test exercises,
+which is right — but every domain repository protocol *extends*
+`BaseRepositoryProtocol`, so a partial double does not satisfy the annotation it
+is passed to. Pyright says so once `tests/` is in its scope:
+
+    "MockAiUsageRepository" is incompatible with protocol "AiUsageRepositoryProtocol"
+      "insert_data" is not present
+      "insert_datas" is not present
+      "select_datas" is not present
+
+Two of those gaps were not deliberate. `MockUserRepository` and
+`MockRefreshTokenRepository` were missing exactly one member — `count_datas_by_day`,
+added to the protocol in #368 — because a protocol grew and its doubles were never
+updated. Nothing caught it: `tests/` was outside the type gate, so a double that
+could no longer stand in for the real repository kept passing.
+
+Inheriting this base fixes that class of drift structurally. Every member is
+present, so the double satisfies the protocol; every member raises, so a call the
+double was never meant to serve fails loudly instead of returning `None` or
+`MagicMock()`. And when the protocol next grows, **this file breaks once** rather
+than N doubles drifting in silence.
+
+Subclasses override what they need and nothing else:
+
+    class MockUserRepository(FakeRepositoryBase[UserDTO]):
+        async def select_data_by_id(self, data_id: int) -> UserDTO:
+            return self._rows[data_id]
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
+
+from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from src._core.domain.value_objects.daily_count import DailyCount
+    from src._core.domain.value_objects.query_filter import QueryFilter
+
+ReturnDTO = TypeVar("ReturnDTO", bound=BaseModel)
+
+
+class FakeRepositoryBase(Generic[ReturnDTO]):
+    """Every `BaseRepositoryProtocol` member, each raising until overridden.
+
+    Deliberately not a `Protocol` subclass and not abstract: it is a *double*, and
+    instantiating it directly should be possible so a test can pass one where the
+    code under test never touches the repository.
+    """
+
+    def _unsupported(self, method: str) -> NotImplementedError:
+        return NotImplementedError(
+            f"{type(self).__name__}.{method} is not implemented. This double "
+            "covers only what its test exercises — if the code under test now "
+            "calls this, implement it here rather than widening the double's "
+            "annotation."
+        )
+
+    async def insert_data(self, entity: BaseModel) -> ReturnDTO:
+        raise self._unsupported("insert_data")
+
+    async def insert_datas(self, entities: Sequence[BaseModel]) -> list[ReturnDTO]:
+        raise self._unsupported("insert_datas")
+
+    async def select_datas(self, page: int, page_size: int) -> list[ReturnDTO]:
+        raise self._unsupported("select_datas")
+
+    async def select_data_by_id(self, data_id: int) -> ReturnDTO:
+        raise self._unsupported("select_data_by_id")
+
+    async def select_datas_by_ids(self, data_ids: list[int]) -> list[ReturnDTO]:
+        raise self._unsupported("select_datas_by_ids")
+
+    async def exists_by_id(self, data_id: int) -> bool:
+        raise self._unsupported("exists_by_id")
+
+    async def exists_by_fields(
+        self,
+        filters: Mapping[str, Any],
+        *,
+        exclude_id: int | None = None,
+    ) -> bool:
+        raise self._unsupported("exists_by_fields")
+
+    async def existing_values_by_field(
+        self,
+        field: str,
+        values: list[Any],
+        *,
+        exclude_id: int | None = None,
+    ) -> set[Any]:
+        raise self._unsupported("existing_values_by_field")
+
+    async def select_datas_with_count(
+        self,
+        page: int,
+        page_size: int,
+        query_filter: QueryFilter | None = None,
+    ) -> tuple[list[ReturnDTO], int]:
+        raise self._unsupported("select_datas_with_count")
+
+    async def update_data_by_data_id(
+        self, data_id: int, entity: BaseModel
+    ) -> ReturnDTO:
+        raise self._unsupported("update_data_by_data_id")
+
+    async def delete_data_by_data_id(self, data_id: int) -> bool:
+        raise self._unsupported("delete_data_by_data_id")
+
+    async def count_datas(self) -> int:
+        raise self._unsupported("count_datas")
+
+    async def count_datas_by_day(
+        self, *, since: datetime, column_name: str = "created_at"
+    ) -> list[DailyCount]:
+        raise self._unsupported("count_datas_by_day")

--- a/tests/unit/_core/infrastructure/admin/test_base_admin_page.py
+++ b/tests/unit/_core/infrastructure/admin/test_base_admin_page.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from src._core.infrastructure.admin.base_admin_page import BaseAdminPage, ColumnConfig
@@ -59,8 +61,27 @@ def test_get_service_raises_when_provider_not_set():
         config._get_service()
 
 
+class _MinimalService:
+    """The two members `AdminCrudServiceProtocol` declares, and nothing else.
+
+    A bare `object()` was the previous sentinel. It works at runtime — the test
+    only asserts identity — but `_service_provider` is typed
+    `Callable[[], AdminCrudServiceProtocol]`, so an `object` provider claims the
+    wiring is valid when it is not. Giving the stand-in the shape of the thing it
+    stands in for keeps the identity assertion and makes the annotation true.
+    """
+
+    async def get_datas(
+        self, page: int, page_size: int, query_filter: Any
+    ) -> tuple[list[Any], Any]:
+        raise NotImplementedError
+
+    async def get_data_by_data_id(self, data_id: int) -> Any:
+        raise NotImplementedError
+
+
 def test_get_service_calls_provider():
-    sentinel = object()
+    sentinel = _MinimalService()
     config = _make_page_config()
     config._service_provider = lambda: sentinel
 

--- a/tests/unit/admin_identity/application/test_admin_account_use_case.py
+++ b/tests/unit/admin_identity/application/test_admin_account_use_case.py
@@ -25,11 +25,12 @@ from src.admin_identity.domain.services.admin_identity_service import (
     AdminIdentityService,
 )
 from tests.factories.admin_identity_factory import make_admin_identity_dto
+from tests.support.fake_repository import FakeRepositoryBase
 
 # ── Fakes ──────────────────────────────────────────────────────────────────
 
 
-class FakeAdminRepository:
+class FakeAdminRepository(FakeRepositoryBase[AdminIdentityDTO]):
     """In-memory repo satisfying AdminIdentityService + AdminAccountUseCase."""
 
     def __init__(self, admins: list[AdminIdentityDTO] | None = None) -> None:

--- a/tests/unit/admin_identity/domain/test_admin_auth_service.py
+++ b/tests/unit/admin_identity/domain/test_admin_auth_service.py
@@ -12,7 +12,10 @@ import pytest
 
 from src._core.common.jwt_codec import ACCESS_TOKEN_TYPE, JwtCodecConfig, JwtTokenCodec
 from src._core.common.security import hash_password
-from src.admin_identity.domain.dtos.admin_identity_dto import AdminRefreshTokenDTO
+from src.admin_identity.domain.dtos.admin_identity_dto import (
+    AdminIdentityDTO,
+    AdminRefreshTokenDTO,
+)
 from src.admin_identity.domain.exceptions.admin_identity_exceptions import (
     AdminInvalidCredentialsException,
     AdminInvalidTokenException,
@@ -24,9 +27,10 @@ from tests.factories.admin_identity_factory import (
     make_admin_token_config,
 )
 from tests.factories.auth_factory import make_auth_token_config
+from tests.support.fake_repository import FakeRepositoryBase
 
 
-class MockAdminRepository:
+class MockAdminRepository(FakeRepositoryBase[AdminIdentityDTO]):
     def __init__(self, admins=None) -> None:
         self._admins = {a.id: a for a in (admins or [])}
 
@@ -39,8 +43,25 @@ class MockAdminRepository:
     async def select_data_by_id(self, data_id: int):
         return self._admins[data_id]
 
+    # The domain half of AdminIdentityRepositoryProtocol. Present so the double
+    # satisfies the protocol it is passed as, raising so a call this test was
+    # never written to serve fails loudly — same convention as FakeRepositoryBase.
+    async def has_real_admin(self) -> bool:
+        raise self._unsupported("has_real_admin")
 
-class MockAdminRefreshTokenRepository:
+    async def delete_data_by_username(self, username: str) -> bool:
+        raise self._unsupported("delete_data_by_username")
+
+    async def count_accounts_permission_holders(
+        self, exclude_admin_id: int | None = None
+    ) -> int:
+        raise self._unsupported("count_accounts_permission_holders")
+
+    async def select_all_admins(self) -> list[AdminIdentityDTO]:
+        raise self._unsupported("select_all_admins")
+
+
+class MockAdminRefreshTokenRepository(FakeRepositoryBase[AdminRefreshTokenDTO]):
     def __init__(self) -> None:
         self._store: dict[str, AdminRefreshTokenDTO] = {}
         self._id = 0

--- a/tests/unit/ai_usage/domain/test_ai_usage_service.py
+++ b/tests/unit/ai_usage/domain/test_ai_usage_service.py
@@ -4,6 +4,7 @@ import pytest
 
 from src.ai_usage.domain.dtos.ai_usage_dto import (
     AiUsageByOrgDTO,
+    AiUsageDTO,
     AiUsageSummaryDTO,
 )
 from src.ai_usage.domain.exceptions.ai_usage_exceptions import (
@@ -15,9 +16,10 @@ from tests.factories.ai_usage_factory import (
     make_ai_usage_dto,
     make_create_ai_usage_request,
 )
+from tests.support.fake_repository import FakeRepositoryBase
 
 
-class MockAiUsageRepository:
+class MockAiUsageRepository(FakeRepositoryBase[AiUsageDTO]):
     def __init__(self) -> None:
         self.inserted = []
 

--- a/tests/unit/auth/domain/test_auth_service.py
+++ b/tests/unit/auth/domain/test_auth_service.py
@@ -17,9 +17,10 @@ from src.auth.domain.services.auth_service import AuthService
 from src.user.domain.dtos.user_dto import UserDTO
 from tests.factories.auth_factory import make_auth_token_config
 from tests.factories.user_factory import make_user_dto
+from tests.support.fake_repository import FakeRepositoryBase
 
 
-class MockUserRepository:
+class MockUserRepository(FakeRepositoryBase[UserDTO]):
     def __init__(self, users: list[UserDTO] | None = None) -> None:
         self._users = {user.id: user for user in users or []}
 
@@ -72,7 +73,7 @@ class MockUserRepository:
         return len(self._users)
 
 
-class MockRefreshTokenRepository:
+class MockRefreshTokenRepository(FakeRepositoryBase[RefreshTokenDTO]):
     def __init__(self) -> None:
         self._store: dict[str, RefreshTokenDTO] = {}
         self._next_id = 1

--- a/tests/unit/url_shortener/test_cleanup_task.py
+++ b/tests/unit/url_shortener/test_cleanup_task.py
@@ -4,9 +4,10 @@ import pytest
 
 from examples.url_shortener.domain.dtos.link_dto import LinkDTO
 from examples.url_shortener.domain.services.link_service import LinkService
+from tests.support.fake_repository import FakeRepositoryBase
 
 
-class InMemoryLinkRepository:
+class InMemoryLinkRepository(FakeRepositoryBase[LinkDTO]):
     def __init__(self, links: list[LinkDTO]) -> None:
         self.links = {link.short_code: link for link in links}
 
@@ -19,6 +20,15 @@ class InMemoryLinkRepository:
         for short_code in expired_codes:
             self.links.pop(short_code)
         return len(expired_codes)
+
+    # The domain half of LinkRepositoryProtocol; this test only exercises
+    # delete_expired. Raising rather than absent, so the double satisfies the
+    # protocol and a future caller fails loudly.
+    async def select_data_by_short_code(self, short_code: str) -> LinkDTO:
+        raise self._unsupported("select_data_by_short_code")
+
+    async def delete_data_by_short_code(self, short_code: str) -> bool:
+        raise self._unsupported("delete_data_by_short_code")
 
 
 def make_link(short_code: str, expires_at: datetime | None) -> LinkDTO:

--- a/tests/unit/user/domain/test_user_service.py
+++ b/tests/unit/user/domain/test_user_service.py
@@ -12,9 +12,10 @@ from src.user.domain.exceptions.user_exceptions import UserAlreadyExistsExceptio
 from src.user.domain.services.user_service import UserService
 from src.user.interface.server.schemas.user_schema import UpdateUserRequest
 from tests.factories.user_factory import make_create_user_request, make_user_dto
+from tests.support.fake_repository import FakeRepositoryBase
 
 
-class MockUserRepository:
+class MockUserRepository(FakeRepositoryBase[UserDTO]):
     """Protocol-based Mock — no need to inherit UserRepository"""
 
     def __init__(self):


### PR DESCRIPTION
Second step of typing `tests/`. **Protocol-conformance failures: 14 → 0**, of the 155 that widening the gate would surface. `src/` stays at 0, and the include path is still not added — that is the last step of this arc.

## Two of the fourteen were not deliberate

`MockUserRepository` and `MockRefreshTokenRepository` were missing **exactly one member**:

```
"MockUserRepository" is incompatible with protocol "UserRepositoryProtocol"
  "count_datas_by_day" is not present
```

`count_datas_by_day` was added to `BaseRepositoryProtocol` in **#368**. A protocol grew and its doubles were never updated, so those tests were exercising a stand-in that could no longer stand in for the real repository. Nothing caught it because `tests/` was outside the type gate — the same shape as the mypy hook and the dot-directory include, one level down.

## The rest were partial by design, so the surface is declared once

Every domain repository protocol extends `BaseRepositoryProtocol`, which has **13 members**. A double that implements the three methods its test needs cannot satisfy the annotation it is passed to. Adding ten no-op methods to each of eight doubles is not the answer, so `tests/support/fake_repository.py` declares that surface once:

- **every member present**, so the double satisfies the protocol — no `cast`, no suppression
- **every member raising**, so a call the double was never written to serve fails loudly instead of returning `None` or a `MagicMock()`
- and when the protocol next grows, **this file breaks once** rather than N doubles drifting in silence — precisely the #368 failure above

Eight doubles inherit it and keep only their own behaviour. Four domain-specific members on `MockAdminRepository` (`has_real_admin`, `delete_data_by_username`, `count_accounts_permission_holders`, `select_all_admins`) and two on `InMemoryLinkRepository` are declared with the same raising convention, because those belong to the domain protocol rather than the shared surface.

## One non-repository case

`test_base_admin_page.py` used a bare `object()` as its provider sentinel. It works at runtime — the test asserts identity — while `_service_provider` is typed `Callable[[], AdminCrudServiceProtocol]`, so the provider claimed valid wiring that was not. Replaced with a two-member stand-in: identity assertion unchanged, annotation now true.

## Verified rather than assumed

The base double's whole value rests on one claim, so it was probed directly:

```
takes_base(FakeRepositoryBase[UserDTO]())   # no error — satisfies BaseRepositoryProtocol
takes_domain(Partial())                     # 1 error — domain members still missing
```

The second line is the boundary the file is meant to draw: the base removes the 13-member boilerplate and nothing more.

| gate | result |
|---|---|
| protocol-shape errors | 14 → **0** |
| total (with `tests/` in the gate) | 155 → **139** |
| `uv run pyright` (shipped config) | 0 errors |
| `make check-core` | 1951 passed, 4 skipped |
| the 178 tests touching reworked doubles | pass individually |

Two placement mistakes in my own scripted edits were caught by ruff before they could land — an import inserted inside a parenthesised `from ... import (` block, and stubs appended past the end of a class. Noting it because the value of the linters in this loop is the reason both were cheap.

## Remaining, by cause

| count | cause | note |
|---|---|---|
| 64 | `reportArgumentType` | test-helper annotations, factory callables, and doubles passed where production names a **concrete class** (`FakeFastAPI` → `FastAPI`, `_RecordingRepository` → `AdminAuditLogRepository`, `_FakeButton` → `Button`) — the last group may be production findings |
| 30 | optional accesses | want an `assert x is not None`, which is better test code |
| 17 | attribute access | private container attributes reached from tests |
| 13 | mypy-era ignores | delete |
| 11 | missing imports | hook modules imported by name; `extraPaths` |

## Governor Footer

- trigger: no
- reviewer: self-structured
- rounds: 1
- r-points-fixed: 2
- r-points-deferred: 1
- r-points-rejected: 0
- touched-adr-consequences: none
- pr-scope-notes: No governor path is touched — `tests/` only; check_governor_footer.py was run against the changed-file list and does not require a footer, and one is included because the change establishes a test-support convention future work will follow. R1/R2 = my two scripted-edit placement mistakes (import inside a parenthesised block; stubs appended outside a class), both caught by ruff and fixed before commit. Deferred-with-rationale = the 139 remaining findings, split by cause above; the concrete-class group is deferred deliberately because its fix may be a production change (introducing a protocol) rather than a test change, which deserves its own PR. Cross-tool review not obtained: codex exec 0.147.0 answers small prompts but echoes and exits without generating for a large prompt carrying an inline diff, reproduced four times in-repo and from /tmp. Self-structured per AGENTS.md Independent Review Trigger, supplemented by a direct probe that the base double satisfies the base protocol and that a subclass still fails a domain protocol — the two halves of the boundary this PR introduces.
- final-verdict: merge-ready
- links: https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/395, n/a
