### PR TITLE
refactor(admin): ask for the method, not the class

### DIFF
--- a/src/_apps/admin/bootstrap.py
+++ b/src/_apps/admin/bootstrap.py
@@ -1,4 +1,6 @@
 import importlib
+from collections.abc import Callable
+from typing import Any, Protocol
 
 import structlog
 from fastapi import FastAPI
@@ -139,7 +141,21 @@ def bootstrap_admin(fastapi_app: FastAPI) -> None:
     )
 
 
-def _install_bootstrap_admin_seed(fastapi_app: FastAPI, admin_container) -> None:
+class _SupportsEventHandler(Protocol):
+    """The one method this function needs, declared where it is needed.
+
+    It registers a `startup` handler and touches nothing else on the app, so
+    asking for `FastAPI` over-states the requirement and forces a test to build a
+    real application (or pass a double the type checker rejects) to exercise one
+    line of registration.
+    """
+
+    def add_event_handler(self, event_type: str, func: Callable[..., Any]) -> None: ...
+
+
+def _install_bootstrap_admin_seed(
+    fastapi_app: _SupportsEventHandler, admin_container
+) -> None:
     if not settings.admin_bootstrap_enabled:
         return
 

--- a/src/_core/infrastructure/admin/audit/logger.py
+++ b/src/_core/infrastructure/admin/audit/logger.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import functools
 import inspect
 from collections.abc import Awaitable, Callable
-from typing import Any, ParamSpec, TypeVar
+from typing import Any, ParamSpec, Protocol, TypeVar
 
 import structlog
 from asgi_correlation_id import correlation_id as _correlation_id
@@ -63,12 +63,25 @@ def _loggable(value: Any) -> Any:
     return "<unset>" if value is _UNSET else value
 
 
+class _AuditLogSink(Protocol):
+    """The one method this logger needs, declared where it is needed.
+
+    `AdminAuditLogRepository` was the annotation, which asks a caller for the
+    whole repository — including its read side, which the logger never touches —
+    and makes a write-only test double unusable without lying about its type. The
+    narrow protocol is also the accurate description of the seam: an audit sink
+    is something you can hand an entry to.
+    """
+
+    async def insert(self, dto: AuditLogDTO) -> None: ...
+
+
 class AuditLogger:
     """Thin facade callers use to record an audit entry."""
 
     def __init__(
         self,
-        repository: AdminAuditLogRepository,
+        repository: _AuditLogSink,
         error_notifier: Any | None = None,
     ) -> None:
         self._repository = repository

--- a/src/_core/infrastructure/admin/layout.py
+++ b/src/_core/infrastructure/admin/layout.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Protocol
 
 from nicegui import app, ui
 
@@ -22,8 +22,26 @@ if TYPE_CHECKING:
     from src._core.infrastructure.admin.base_admin_page import BaseAdminPage
 
 
+class _SupportsProps(Protocol):
+    """What this helper actually needs: something with callable Quasar props.
+
+    `ui.button` was the annotation, and it is *nominal* — no test double can ever
+    satisfy it, however faithful, which is why the one in `test_loading_states.py`
+    had to be passed against the type. Only `.props()` is used here, so the narrow
+    protocol is both accurate and testable.
+
+    Declared as a read-only attribute of type `Any` rather than a method, because
+    NiceGUI's own shape is neither: `Element.props` is a *property* returning a
+    callable `Props` wrapper. A method signature here would exclude the real
+    button, which is worse than the annotation it replaced.
+    """
+
+    @property
+    def props(self) -> Any: ...
+
+
 @asynccontextmanager
-async def button_loading(button: ui.button) -> AsyncIterator[None]:
+async def button_loading(button: _SupportsProps) -> AsyncIterator[None]:
     """Show Quasar ``loading`` + ``disable`` on a button while an async op runs.
 
     Gives immediate feedback on slow admin write actions and blocks duplicate


### PR DESCRIPTION
Third step of typing `tests/`: **139 → 128** findings, `src/` unchanged at 0.

## Three functions named a class while using one member of it

```python
AuditLogger(repository: AdminAuditLogRepository)     # uses repository.insert
_install_bootstrap_admin_seed(fastapi_app: FastAPI)  # uses add_event_handler
button_loading(button: ui.button)                    # uses button.props
```

Every test therefore had to pass a double the annotation rejects. Each now takes a consumer-local `Protocol`, following the `_UsageSummaryService` precedent in `ai_usage_page.py` — declared next to its consumer, underscore-prefixed, reason in the docstring.

For the audit logger this is also the ADR 042 convention it had opted out of: the annotation asked callers for the whole repository, **read side included**, which the logger never touches.

## One of the three was my own over-reach, and the type checker said so

The first `_SupportsProps` declared `props` as a method with NiceGUI's documented keyword signature. That is not NiceGUI's shape — `Element.props` is a **property** returning a callable `Props` wrapper — so the protocol excluded the real `Button` at all eight call sites:

```
src/_apps/admin/pages/accounts.py:87
  Argument of type "Button" cannot be assigned to parameter "button" of type "_SupportsProps"
    "props" is an incompatible type
```

**A protocol that excludes the real implementation is worse than the concrete annotation it replaced.** It is now a read-only `Any` attribute, which accepts both the real button and a double, with that history recorded where the next person will look.

Worth keeping about that seam: `ui.button` is a **nominal** type, so no double can ever satisfy it however faithful. A local protocol is the only way that helper is testable at all — which is the argument for the change, independent of the numbers.

## And one placement mistake

An earlier revision put the protocol declaration between `@asynccontextmanager` and `button_loading`. Python accepts that — decorating a class is legal — so the helper was left **undecorated**, returning a bare `AsyncIterator[None]`:

```
Object of type "AsyncIterator[None]" cannot be used with "async with"   × 18 call sites
3 failed, 196 passed
```

Ruff was silent because the file is valid Python. The type checker and the suite named it immediately. Structural insertion above a decorated function has to target the decorator, not the `def` — the third such placement slip in this arc, all caught before commit.

## Verification

| gate | result |
|---|---|
| `uv run pyright` (shipped config) | 0 errors |
| with `tests/` in the gate | 139 → **128** |
| `make check-core` | 1951 passed, 4 skipped |
| the 199 tests covering the three consumers | pass individually |

## Remaining: 128

| count | cause |
|---|---|
| ~54 | `reportArgumentType` — test-helper annotations (`list[EventDict]` into helpers typed `list[dict]`), factory callables |
| 30 | optional accesses wanting an `assert x is not None` |
| 17 | attribute access — private container attributes reached from tests |
| 13 | mypy-era ignores to delete |
| 11 | hook modules imported by name; `extraPaths` |

The next step is the mechanical bulk, and the one after it adds the include path plus the scope-test entry.

## Governor Footer

- trigger: no
- reviewer: self-structured
- rounds: 2
- r-points-fixed: 2
- r-points-deferred: 1
- r-points-rejected: 1
- touched-adr-consequences: none
- pr-scope-notes: No governor path is touched — three `src/` modules; check_governor_footer.py was run against the changed-file list and does not require a footer, and one is included because the change alters three production signatures and follows an ADR 042 convention. Two rounds because the first attempt regressed `src/` from 0 to 18 errors. R1 = the protocol whose method signature excluded the real `Button`; Fixed by matching NiceGUI's actual property-returning-callable shape. R2 = the declaration inserted between a decorator and its function; Fixed by targeting the decorator. Rejected = my initial framing that all three were straightforwardly "production demands a concrete class where a protocol belongs" — for the button seam the concrete annotation was accurate and the protocol needed to be shaped around the framework, not against it. Deferred-with-rationale = the remaining 128, split by cause above. Cross-tool review not obtained: codex exec 0.147.0 answers small prompts but echoes and exits without generating for a large prompt carrying an inline diff, reproduced four times in-repo and from /tmp. Self-structured per AGENTS.md Independent Review Trigger, supplemented by re-running the full suite after each protocol change rather than at the end — which is what caught the decorator slip while it was still one edit old.
- final-verdict: merge-ready
- links: https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/396, n/a
