### PR TITLE
test: clear the mechanical typing findings in tests

### DIFF
--- a/tests/integration/_core/test_minimal_install.py
+++ b/tests/integration/_core/test_minimal_install.py
@@ -109,8 +109,7 @@ class TestMinimalInstall:
         dashboard_paths = [
             str(route.path)  # type: ignore[attr-defined]
             for route in app.routes
-            if hasattr(route, "path")  # type: ignore[attr-defined]
-            and str(route.path).startswith("/admin")  # type: ignore[attr-defined]
+            if hasattr(route, "path") and str(route.path).startswith("/admin")  # type: ignore[attr-defined]
         ]
         assert not dashboard_paths, (
             f"Expected no NiceGUI /admin dashboard routes, found: {dashboard_paths}"

--- a/tests/unit/_apps/admin/test_admin_bootstrap.py
+++ b/tests/unit/_apps/admin/test_admin_bootstrap.py
@@ -55,6 +55,7 @@ async def test_install_bootstrap_admin_seed_registers_startup_handler(monkeypatc
     admin_bootstrap._install_bootstrap_admin_seed(app, container)
     await app.handlers["startup"]()
 
+    assert service.entity is not None
     assert service.entity.username == "admin"
     assert service.entity.password == "secret"
 

--- a/tests/unit/_core/domain/services/test_rag_pipeline.py
+++ b/tests/unit/_core/domain/services/test_rag_pipeline.py
@@ -93,8 +93,8 @@ async def test_pipeline_attaches_distance_attribute_to_chunks():
 
     _, returned = await pipeline.answer(question="q")
 
-    assert returned[0]._distance == 0.25  # type: ignore[attr-defined]
-    assert returned[1]._distance == 0.75  # type: ignore[attr-defined]
+    assert returned[0]._distance == 0.25
+    assert returned[1]._distance == 0.75
 
 
 @pytest.mark.asyncio
@@ -117,5 +117,5 @@ async def test_pipeline_handles_none_distances():
 
     _, returned = await pipeline.answer(question="q")
 
-    assert returned[0]._distance is None  # type: ignore[attr-defined]
-    assert returned[1]._distance is None  # type: ignore[attr-defined]
+    assert returned[0]._distance is None
+    assert returned[1]._distance is None

--- a/tests/unit/_core/infrastructure/admin/audit/test_audit_logger.py
+++ b/tests/unit/_core/infrastructure/admin/audit/test_audit_logger.py
@@ -67,6 +67,7 @@ def test_safe_user_snapshot_none_passthrough():
 
 def test_safe_user_snapshot_json_ready_datetime():
     snap = safe_user_snapshot(_user())
+    assert snap is not None
     assert isinstance(snap["created_at"], str)  # ISO string, not datetime
 
 

--- a/tests/unit/_core/infrastructure/llm/test_error_mapper.py
+++ b/tests/unit/_core/infrastructure/llm/test_error_mapper.py
@@ -155,6 +155,7 @@ class TestProviderExceptionsStillMap:
         )
         throttling = client.exceptions.ThrottlingException
         assert throttling.__module__.startswith("botocore")
+        assert throttling is not None
         assert issubclass(throttling, botocore.exceptions.ClientError)
 
         exc = throttling(

--- a/tests/unit/_core/infrastructure/notification/test_notification_adapters.py
+++ b/tests/unit/_core/infrastructure/notification/test_notification_adapters.py
@@ -70,6 +70,7 @@ class TestSlackNotificationAdapter:
         assert http_client.fake_session.post_calls == [
             {"url": webhook_url, "json": {"text": "boom"}}
         ]
+        assert http_client.fake_session.last_response is not None
         http_client.fake_session.last_response.raise_for_status.assert_called_once()
         http_client.fake_session.last_response.json.assert_not_called()
 
@@ -87,5 +88,6 @@ class TestDiscordNotificationAdapter:
         assert http_client.fake_session.post_calls == [
             {"url": webhook_url, "json": {"content": "boom"}}
         ]
+        assert http_client.fake_session.last_response is not None
         http_client.fake_session.last_response.raise_for_status.assert_called_once()
         http_client.fake_session.last_response.json.assert_not_called()

--- a/tests/unit/_core/infrastructure/notification/test_task_failure_notification_middleware.py
+++ b/tests/unit/_core/infrastructure/notification/test_task_failure_notification_middleware.py
@@ -383,7 +383,7 @@ class TestMiddlewareOrderingContract:
         async def _no_send(kicker, message, delay):
             return None
 
-        retry.on_send = _no_send  # type: ignore[method-assign]
+        retry.on_send = _no_send
 
         message = _make_message(labels={"max_retries": 3})
         exception = RuntimeError("connection reset")

--- a/tests/unit/_core/infrastructure/observability/test_otel_setup.py
+++ b/tests/unit/_core/infrastructure/observability/test_otel_setup.py
@@ -39,8 +39,8 @@ def reset_tracer_provider():
         if isinstance(existing, SdkTracerProvider):
             with contextlib.suppress(Exception):
                 existing.shutdown()
-        trace._TRACER_PROVIDER_SET_ONCE._done = False  # type: ignore[attr-defined]
-        trace._TRACER_PROVIDER = None  # type: ignore[attr-defined]
+        trace._TRACER_PROVIDER_SET_ONCE._done = False
+        trace._TRACER_PROVIDER = None
 
     _reset()
     yield
@@ -134,7 +134,7 @@ class TestConfigureOtel:
         with patch(
             "builtins.__import__",
             side_effect=lambda name, *a, **kw: (
-                (_ for _ in ()).throw(unrelated_err)  # type: ignore[misc]
+                (_ for _ in ()).throw(unrelated_err)
                 if name == "pydantic_ai"
                 else __import__(name, *a, **kw)
             ),

--- a/tests/unit/agents_shared/test_fail_open.py
+++ b/tests/unit/agents_shared/test_fail_open.py
@@ -11,6 +11,12 @@ Three tiers:
        subclass) is not caught by suppress(Exception).
 """
 
+# The harness hook modules below are imported by *basename* after a `sys.path`
+# insertion a few lines up, and the same basenames exist in `.claude/hooks`,
+# `.codex/hooks` and `.antigravity/hooks`. No static path can resolve them
+# unambiguously — which is the same collision that made the retired mypy hook
+# abort (#375) — so each import carries a scoped suppression rather than the
+# config pretending one directory is the answer.
 from __future__ import annotations
 
 import contextlib
@@ -107,7 +113,7 @@ def test_tier2_function_call_import_error_returns_safe_default(
 
     sys.path.insert(0, str(REPO_ROOT / ".claude" / "hooks"))
     try:
-        import user_prompt_submit as ups  # noqa: PLC0415
+        import user_prompt_submit as ups  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
 
         def boom(*_args, **_kwargs):
             raise ImportError("simulated shared failure")
@@ -141,7 +147,7 @@ def test_tier2_verify_first_read_latest_token_marker_safe_default(
     sys.path.insert(0, str(REPO_ROOT / ".claude" / "hooks"))
     sys.modules.pop("verify_first", None)
     try:
-        import verify_first as vf  # noqa: PLC0415
+        import verify_first as vf  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
 
         def boom(*_args, **_kwargs):
             raise ImportError("simulated shared reader failure")
@@ -172,7 +178,7 @@ def test_tier2_completion_gate_entry_points_safe_default(monkeypatch, tmp_path) 
     sys.path.insert(0, str(REPO_ROOT / ".claude" / "hooks"))
     sys.modules.pop("completion_gate", None)
     try:
-        import completion_gate as cg  # noqa: PLC0415
+        import completion_gate as cg  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
 
         # Force the degraded path; both entry points must short-circuit.
         monkeypatch.setattr(cg, "_SHARED_OK", False)
@@ -196,6 +202,7 @@ def test_codex_write_marker_oserror_still_returns_zero() -> None:
     codex_hook = REPO_ROOT / ".codex" / "hooks" / "user-prompt-submit.py"
     spec = importlib.util.spec_from_file_location("codex_ups_a1", str(codex_hook))
     mod = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
     spec.loader.exec_module(mod)
     try:
 
@@ -223,6 +230,7 @@ def test_codex_write_marker_oserror_does_not_silence_stderr_payload() -> None:
     codex_hook = REPO_ROOT / ".codex" / "hooks" / "user-prompt-submit.py"
     spec = importlib.util.spec_from_file_location("codex_ups_a1s", str(codex_hook))
     mod = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
     spec.loader.exec_module(mod)
     try:
 

--- a/tests/unit/agents_shared/test_governor_boundary.py
+++ b/tests/unit/agents_shared/test_governor_boundary.py
@@ -290,7 +290,7 @@ def test_gatestatus_variants_referenced_by_completion_gate_shims() -> None:
         "missing",
         "unknown",
     }
-    actual_variants = set(GateStatus.__args__)  # type: ignore[attr-defined]
+    actual_variants = set(GateStatus.__args__)
     assert actual_variants == expected_variants, (
         f"GateStatus variants changed: {actual_variants ^ expected_variants}. "
         "Update the shim flow in .{claude,codex}/hooks/completion_gate.py "

--- a/tests/unit/agents_shared/test_harness_hook_surface.py
+++ b/tests/unit/agents_shared/test_harness_hook_surface.py
@@ -1,3 +1,9 @@
+# The harness hook modules below are imported by *basename* after a `sys.path`
+# insertion a few lines up, and the same basenames exist in `.claude/hooks`,
+# `.codex/hooks` and `.antigravity/hooks`. No static path can resolve them
+# unambiguously — which is the same collision that made the retired mypy hook
+# abort (#375) — so each import carries a scoped suppression rather than the
+# config pretending one directory is the answer.
 from __future__ import annotations
 
 import json
@@ -9,7 +15,9 @@ _TOOLS_DIR = _REPO_ROOT / "tools"
 if str(_TOOLS_DIR) not in sys.path:
     sys.path.insert(0, str(_TOOLS_DIR))
 
-from check_harness_hook_surface import check_root  # noqa: E402
+from check_harness_hook_surface import (  # noqa: E402  # pyright: ignore[reportMissingImports]
+    check_root,
+)
 
 
 def _write_codex_hooks(root: Path, command: str) -> None:

--- a/tests/unit/agents_shared/test_locale.py
+++ b/tests/unit/agents_shared/test_locale.py
@@ -26,6 +26,12 @@ Coverage layers (verified through 8 rounds of Codex cross-validation, v8):
 10. Shell subprocess in temp git repo — Bash hook emits ko/en correctly.
 """
 
+# The harness hook modules below are imported by *basename* after a `sys.path`
+# insertion a few lines up, and the same basenames exist in `.claude/hooks`,
+# `.codex/hooks` and `.antigravity/hooks`. No static path can resolve them
+# unambiguously — which is the same collision that made the retired mypy hook
+# abort (#375) — so each import carries a scoped suppression rather than the
+# config pretending one directory is the answer.
 from __future__ import annotations
 
 import ast
@@ -237,7 +243,7 @@ def test_locale_py_passes_language_policy_checker() -> None:
     """find_violations() returns [] for the locale data file via
     LOCALE_DATA_FILES file-wide skip."""
     sys.path.insert(0, str(REPO_ROOT / "tools"))
-    import check_language_policy as clp  # noqa: PLC0415
+    import check_language_policy as clp  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
 
     locale_path = SHARED_DIR / "governor" / "locale.py"
     assert clp.find_violations(locale_path, repo_root=REPO_ROOT) == []

--- a/tests/unit/agents_shared/test_shared_delegation.py
+++ b/tests/unit/agents_shared/test_shared_delegation.py
@@ -5,6 +5,12 @@ when available, falls back to inline logic when not, and is exception-safe
 in all paths (HC-5.5 execution fail-open).
 """
 
+# The harness hook modules below are imported by *basename* after a `sys.path`
+# insertion a few lines up, and the same basenames exist in `.claude/hooks`,
+# `.codex/hooks` and `.antigravity/hooks`. No static path can resolve them
+# unambiguously — which is the same collision that made the retired mypy hook
+# abort (#375) — so each import carries a scoped suppression rather than the
+# config pretending one directory is the answer.
 from __future__ import annotations
 
 import sys
@@ -16,7 +22,7 @@ _HOOKS = REPO_ROOT / ".codex" / "hooks"
 if str(_HOOKS) not in sys.path:
     sys.path.insert(0, str(_HOOKS))
 
-import _shared as shared_module
+import _shared as shared_module  # pyright: ignore[reportMissingImports]
 
 # ---------------------------------------------------------------------------
 # Delegation path (_GATE_OK=True)

--- a/tests/unit/agents_shared/test_stop_advisory_inline_guard.py
+++ b/tests/unit/agents_shared/test_stop_advisory_inline_guard.py
@@ -40,7 +40,7 @@ def _load_module(name: str, path: Path) -> types.ModuleType:
     assert spec is not None and spec.loader is not None
     mod = importlib.util.module_from_spec(spec)
     sys.modules[name] = mod
-    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    spec.loader.exec_module(mod)
     return mod
 
 

--- a/tests/unit/agents_shared/test_sync_cosmetic.py
+++ b/tests/unit/agents_shared/test_sync_cosmetic.py
@@ -25,7 +25,7 @@ def _import(name: str, path: Path):
 def gov():
     sys.path.insert(0, str(SHARED))
     try:
-        from governor import (  # type: ignore[import-not-found]
+        from governor import (
             completion_gate,
             sync_cosmetic,
         )

--- a/tests/unit/agents_shared/test_verify_log.py
+++ b/tests/unit/agents_shared/test_verify_log.py
@@ -80,6 +80,7 @@ class TestAppendVerifyLog:
         path = append_verify_log("pytest tests/ -q", tmp_path, _SESSION)
 
         assert path == verify_log_path(tmp_path, _SESSION)
+        assert path is not None
         record = json.loads(path.read_text(encoding="utf-8").strip())
         assert record["cmd"] == "pytest tests/ -q"
         assert isinstance(record["ts_epoch_ns"], int)
@@ -96,6 +97,7 @@ class TestAppendVerifyLog:
         append_verify_log("pytest a", tmp_path, _SESSION)
         path = append_verify_log("pytest b", tmp_path, _SESSION)
 
+        assert path is not None
         lines = path.read_text(encoding="utf-8").strip().splitlines()
         assert [json.loads(line)["cmd"] for line in lines] == ["pytest a", "pytest b"]
 

--- a/tests/unit/agents_shared/test_work_ledger.py
+++ b/tests/unit/agents_shared/test_work_ledger.py
@@ -142,6 +142,7 @@ def test_update_last_prompt_empty_string_stores_none():
 def test_update_goal_scope_plan_all_fields():
     wl.update_goal_scope_plan(goal="g", scope="s", plan="p")
     ledger = wl.read_ledger()
+    assert ledger is not None
     assert ledger["goal"] == "g"
     assert ledger["scope"] == "s"
     assert ledger["plan"] == "p"
@@ -151,6 +152,7 @@ def test_update_goal_scope_plan_partial_does_not_overwrite():
     wl.update_goal_scope_plan(goal="original", scope="orig-scope")
     wl.update_goal_scope_plan(scope="new-scope")  # goal untouched
     ledger = wl.read_ledger()
+    assert ledger is not None
     assert ledger["goal"] == "original"
     assert ledger["scope"] == "new-scope"
 
@@ -193,6 +195,7 @@ def test_update_verification_from_git_sets_pending_when_py_files(monkeypatch):
     monkeypatch.setattr(wl, "_changed_py_files", lambda: ["src/foo/bar.py"])
     wl.update_verification_from_git()
     ledger = wl.read_ledger()
+    assert ledger is not None
     assert ledger["verification"]["changed_py_files"] == ["src/foo/bar.py"]
     assert ledger["verification"]["status"] == "pending"
 
@@ -202,12 +205,14 @@ def test_update_verification_from_git_keeps_passed_status(monkeypatch):
     # demote it back to "pending" just because files exist.
     wl.update_goal_scope_plan(goal="g")  # initialise ledger
     ledger = wl.read_ledger()
+    assert ledger is not None
     ledger["verification"]["status"] = "passed"
     wl.write_ledger(ledger)
 
     monkeypatch.setattr(wl, "_changed_py_files", lambda: ["src/x.py"])
     wl.update_verification_from_git()
     ledger2 = wl.read_ledger()
+    assert ledger2 is not None
     assert ledger2["verification"]["status"] == "passed"
 
 
@@ -215,6 +220,7 @@ def test_update_verification_from_git_no_files(monkeypatch):
     monkeypatch.setattr(wl, "_changed_py_files", lambda: [])
     wl.update_verification_from_git()
     ledger = wl.read_ledger()
+    assert ledger is not None
     assert ledger["verification"]["changed_py_files"] == []
     assert ledger["verification"]["status"] == "unknown"
 
@@ -227,11 +233,13 @@ def test_update_verification_from_git_no_files(monkeypatch):
 def test_mark_verified_passed_clears_changed_files():
     wl.update_goal_scope_plan(goal="x")
     ledger = wl.read_ledger()
+    assert ledger is not None
     ledger["verification"]["changed_py_files"] = ["a.py"]
     wl.write_ledger(ledger)
 
     wl.mark_verified("pytest tests/", passed=True)
     ledger2 = wl.read_ledger()
+    assert ledger2 is not None
     assert ledger2["verification"]["status"] == "passed"
     assert ledger2["verification"]["changed_py_files"] == []
     assert ledger2["verification"]["last_command"] == "pytest tests/"
@@ -240,6 +248,7 @@ def test_mark_verified_passed_clears_changed_files():
 def test_mark_verified_failed():
     wl.mark_verified("pytest tests/", passed=False)
     ledger = wl.read_ledger()
+    assert ledger is not None
     assert ledger["verification"]["status"] == "failed"
 
 

--- a/tests/unit/auth/domain/test_auth_service.py
+++ b/tests/unit/auth/domain/test_auth_service.py
@@ -33,7 +33,7 @@ class MockUserRepository(FakeRepositoryBase[UserDTO]):
     async def select_data_by_id(self, data_id: int) -> UserDTO:
         return self._users[data_id]
 
-    async def insert_data(self, entity) -> UserDTO:  # type: ignore[override]
+    async def insert_data(self, entity) -> UserDTO:
         raise NotImplementedError
 
     async def insert_datas(self, entities) -> list[UserDTO]:

--- a/tests/unit/blog/domain/test_post_service.py
+++ b/tests/unit/blog/domain/test_post_service.py
@@ -1,16 +1,27 @@
+# `src.author.*` / `src.post.*` do not exist on disk. `conftest.py` in this
+# directory builds a temp-directory shadow of `examples/blog` and registers it
+# under those names, because that is the layout the example runs in after
+# `cp -r examples/blog/* src/`. Unresolvable statically by construction; the same
+# suppression the example's own production imports carry (#386).
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock
 
 import pytest
-from src.author.domain.dtos.author_dto import AuthorDTO
-from src.author.domain.protocols.author_repository_protocol import (
+from src.author.domain.dtos.author_dto import (  # pyright: ignore[reportMissingImports]
+    AuthorDTO,
+)
+from src.author.domain.protocols.author_repository_protocol import (  # pyright: ignore[reportMissingImports]
     AuthorRepositoryProtocol,
 )
-from src.post.domain.protocols.post_repository_protocol import (
+from src.post.domain.protocols.post_repository_protocol import (  # pyright: ignore[reportMissingImports]
     PostRepositoryProtocol,
 )
-from src.post.domain.services.post_service import PostService
-from src.post.interface.server.schemas.post_schema import CreatePostRequest
+from src.post.domain.services.post_service import (  # pyright: ignore[reportMissingImports]
+    PostService,
+)
+from src.post.interface.server.schemas.post_schema import (  # pyright: ignore[reportMissingImports]
+    CreatePostRequest,
+)
 
 from src._core.domain.validation import ValidationFailed
 


### PR DESCRIPTION
Fourth step of typing `tests/`: **128 → 71** findings, `src/` unchanged at 0. Three whole causes reach zero. **No production code changes.**

## Unresolvable imports (11 → 0) — suppressed with the reason, not papered over by config

Both kinds are genuinely unresolvable rather than misconfigured:

- **Six harness hook modules** are imported by *basename* after a `sys.path` insertion a few lines above, and those basenames exist in `.claude/hooks`, `.codex/hooks` **and** `.antigravity/hooks`. That is the same collision that made the retired mypy hook abort (#375), so `extraPaths` cannot name one directory as the answer.
- **Five `src.author.*` / `src.post.*` imports** in `tests/unit/blog/` point at a temp-directory shadow that `conftest.py` builds from `examples/blog` — the layout the example runs in after being copied into `src/`. The same suppression its own production imports already carry (#386).

## mypy-era ignores (13 → 0)

Deleted, driven by pyright's own `reportUnnecessaryTypeIgnoreComment` output rather than by grepping — the same method as #388, so the list cannot be stale.

## Optional accesses (30 → 0) — asserted, not cast

`assert x is not None` before use is better test code: it names the precondition and fails there, instead of two lines later on an attribute of `None`. Nine of them follow `read_ledger()`, whose signature is `dict | None` and which **the same file already asserted on in places** — the convention existed, it was applied unevenly.

## Two of my own mistakes, caught by re-measuring rather than assuming

**Suppressions landed on the member line of parenthesised imports**, where the diagnostic is reported on the `from ... import (` line:

```python
from src.author.domain.dtos.author_dto import (
    AuthorDTO,  # pyright: ignore[reportMissingImports]   ← does nothing here
)
```

Result: four imports still unresolved *and* four suppressions reported as unnecessary — a net zero that would have looked like progress if I had not read the count.

**`assert spec.loader is not None` is itself an optional access** when `spec` is `ModuleSpec | None`. Narrowing has to start at the base: `assert spec is not None and spec.loader is not None`.

## One thing deliberately left alone

Those `sys.path.insert` calls mutate global state for the whole session, and `verify_first` is imported by **two** test modules that insert *different* harness directories. Which copy a later import resolves to therefore depends on test order. Converting them to `importlib.util.spec_from_file_location` — the shape `test_local_runners.py` uses — would fix it, but that is a refactor of the fail-open contract tests and does not belong inside a typing sweep. Recorded in the commit message so it is not lost.

## Verification

| gate | result |
|---|---|
| `uv run pyright` (shipped config) | 0 errors |
| with `tests/` in the gate | 128 → **71** |
| `make check-core` | 1951 passed, 4 skipped |
| the 1003 tests in the touched directories | pass individually |

## Remaining: 71

| count | cause |
|---|---|
| 50 | argument-type — test helpers annotated `list[dict]` receiving `list[EventDict]`, plus factory callables |
| 17 | attribute access on private container internals from tests |
| 4 | singletons: two operator, one return type, one incompatible override |

The next step is those, plus the include path and the scope-test entry — the last PR of this arc.

## Governor Footer

- trigger: no
- reviewer: self-structured
- rounds: 2
- r-points-fixed: 2
- r-points-deferred: 1
- r-points-rejected: 0
- touched-adr-consequences: none
- pr-scope-notes: No governor path is touched — `tests/` only, 19 files; check_governor_footer.py was run against the changed-file list and does not require a footer, and one is included for continuity with the rest of this arc. Two rounds because the first pass reported a lower total while leaving four imports unresolved. R1 = suppressions placed on the member line of parenthesised imports; Fixed by moving them to the reported line. R2 = an assert that was itself an optional access; Fixed by narrowing the base first. Deferred-with-rationale = the `sys.path.insert` order dependence between harness copies, which is a refactor of the fail-open contract tests rather than a typing fix. Cross-tool review not obtained: codex exec 0.147.0 answers small prompts but echoes and exits without generating for a large prompt carrying an inline diff, reproduced four times in-repo and from /tmp. Self-structured per AGENTS.md Independent Review Trigger, supplemented by driving both deletions from pyright's own diagnostics rather than from a grep, which is what makes "13" and "11" verifiable numbers rather than estimates.
- final-verdict: merge-ready
- links: https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/397, n/a
