### PR TITLE
test: close the drift between doubles and the interfaces they impersonate

### DIFF
--- a/src/_core/infrastructure/admin/auth.py
+++ b/src/_core/infrastructure/admin/auth.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from typing import Protocol
 
 import structlog
 from nicegui import app, ui
@@ -33,11 +34,24 @@ _admin_auth_provider: AdminAuthProvider | None = None
 _admin_account_use_case_provider: Callable[[], AdminAccountUseCase] | None = None
 
 
+class _AdminAuthOperations(Protocol):
+    """The two use-case methods this provider calls, declared where it calls them.
+
+    `AdminAuthUseCase` was the annotation, which asks a caller for the whole use
+    case — and makes a two-method test double unusable without lying about its
+    type. Same reasoning as `_UsageSummaryService` in `ai_usage_page.py`.
+    """
+
+    async def admin_login(self, request: AdminLoginRequest) -> AdminSessionDTO: ...
+
+    async def get_admin_session(self, admin_id: int) -> AdminSessionDTO: ...
+
+
 class AdminAuthProvider:
     """admin_identity-domain backed admin authentication provider."""
 
     def __init__(
-        self, admin_auth_use_case_provider: Callable[[], AdminAuthUseCase]
+        self, admin_auth_use_case_provider: Callable[[], _AdminAuthOperations]
     ) -> None:
         self._admin_auth_use_case_provider = admin_auth_use_case_provider
 

--- a/tests/integration/_core/infrastructure/llm/test_adversarial_prompts.py
+++ b/tests/integration/_core/infrastructure/llm/test_adversarial_prompts.py
@@ -26,6 +26,8 @@ from __future__ import annotations
 
 import base64
 import codecs
+from collections.abc import Mapping, Sequence
+from typing import Any
 
 import pytest
 from structlog.testing import capture_logs
@@ -67,11 +69,15 @@ def _classifier() -> PydanticAIClassifier:
     return PydanticAIClassifier(llm_model=TestModel(), guardrails_enabled=True)
 
 
-def _guardrail_events(logs: list[dict]) -> list[dict]:
+def _guardrail_events(
+    logs: Sequence[Mapping[str, Any]],
+) -> list[Mapping[str, Any]]:
     return [e for e in logs if e.get("event") == "guardrail_triggered"]
 
 
-def _assert_no_raw_payload_in_logs(logs: list[dict], payload: str) -> None:
+def _assert_no_raw_payload_in_logs(
+    logs: Sequence[Mapping[str, Any]], payload: str
+) -> None:
     """The defining safety property: the raw attacker string never leaks."""
     blob = repr(logs)
     assert payload not in blob

--- a/tests/unit/_apps/admin/test_admin_bootstrap.py
+++ b/tests/unit/_apps/admin/test_admin_bootstrap.py
@@ -11,8 +11,10 @@ class FakeFastAPI:
     def __init__(self) -> None:
         self.handlers = {}
 
-    def add_event_handler(self, event_type: str, handler) -> None:
-        self.handlers[event_type] = handler
+    # `func`, not `handler`: protocol conformance compares parameter *names*
+    # for anything not positional-only, and Starlette calls it `func`.
+    def add_event_handler(self, event_type: str, func) -> None:
+        self.handlers[event_type] = func
 
 
 class FakeAdminIdentityService:

--- a/tests/unit/_core/exceptions/test_exception_handler_logging.py
+++ b/tests/unit/_core/exceptions/test_exception_handler_logging.py
@@ -20,6 +20,9 @@ of them". Either way the two that *do* log — `dynamodb_client` and
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
+from typing import Any
+
 import pytest
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
@@ -58,7 +61,7 @@ def _app() -> FastAPI:
     return app
 
 
-def _exception_records(logs: list[dict]) -> list[dict]:
+def _exception_records(logs: Sequence[Mapping[str, Any]]) -> list[Mapping[str, Any]]:
     """Records that carry exception identity — the thing an operator greps for."""
     return [
         r

--- a/tests/unit/_core/infrastructure/admin/audit/test_audit_auth_instrumentation.py
+++ b/tests/unit/_core/infrastructure/admin/audit/test_audit_auth_instrumentation.py
@@ -43,6 +43,12 @@ class _FakeUseCase:
             raise self.exc
         return self.session
 
+    # Present so the double satisfies what AdminAuthProvider asks for; raising
+    # because this file exercises the login path only. An absent method left the
+    # double unable to stand in at all.
+    async def get_admin_session(self, admin_id: int) -> AdminSessionDTO:
+        raise NotImplementedError("this double covers the login path only")
+
 
 @pytest.fixture
 def audit_recorder(monkeypatch):

--- a/tests/unit/_core/infrastructure/admin/test_auth.py
+++ b/tests/unit/_core/infrastructure/admin/test_auth.py
@@ -39,8 +39,12 @@ class FakeUseCase:
             raise self.exc
         return self.session
 
-    async def get_admin_session(self, user_id: int) -> AdminSessionDTO:
-        self.session_user_ids.append(user_id)
+    # `admin_id`, not `user_id`: protocol conformance compares parameter names,
+    # and the real use case renamed this when the admin realm split from the
+    # customer one (#218). The double kept the old name until tests entered the
+    # type gate.
+    async def get_admin_session(self, admin_id: int) -> AdminSessionDTO:
+        self.session_user_ids.append(admin_id)
         if self.exc:
             raise self.exc
         return self.session


### PR DESCRIPTION
Fifth step of typing `tests/`: **71 → 48** findings, `src/` unchanged at 0. One theme — every finding here is a stand-in whose shape no longer matches what it stands in for, or a helper asking for a container type it does not need.

## Two real drifts in the auth doubles, invisible until now

`AdminAuthProvider` calls exactly two use-case methods, so it now takes a consumer-local `_AdminAuthOperations` protocol rather than `AdminAuthUseCase` — the same pattern as `_UsageSummaryService` and the three protocols in #396. That immediately exposed what the concrete annotation had been hiding:

```
"_FakeUseCase" is incompatible with protocol "_AdminAuthOperations"
  "get_admin_session" is not present

"FakeUseCase" is incompatible with protocol "_AdminAuthOperations"
  "get_admin_session" is an incompatible type
    Type "(user_id: int) -> ..." is not assignable to type "(admin_id: int) -> ..."
```

- `_FakeUseCase` has **no `get_admin_session` at all**, so it could not stand in for what the provider needs. Added, raising, because that file exercises the login path only.
- `FakeUseCase` declares `get_admin_session(user_id: int)` while the real method takes `admin_id` — **renamed when the admin realm split from the customer one (#218)**, and the double kept the old name. Protocol conformance compares parameter names for anything not positional-only, so this is a genuine mismatch. Safe to rename: the one production call site passes positionally.

A third of the same kind: `FakeFastAPI.add_event_handler` named its second parameter `handler`; Starlette calls it `func`. That alone was why the protocol from #396 rejected it.

## Three log helpers asked for `list[dict]` and got `list[EventDict]`

`list` is invariant, so structlog's captured events could not be passed to helpers that only iterate them — **the same invariance that produced the `cast` in `BaseService.create_datas`** (#394). They now take `Sequence[Mapping[str, Any]]`: wider, and an accurate description of what they do.

## Two of mine on the way

- An import inserted above `from __future__ import annotations` — F404, caught by ruff.
- I expected the new protocol to fix all ten factory-callable findings by itself. It fixed the annotation and **revealed the drift underneath**, which is the better outcome but took a second pass to see.

## Verification

| gate | result |
|---|---|
| `uv run pyright` (shipped config) | 0 errors |
| with `tests/` in the gate | 71 → **48** |
| `make check-core` | 1951 passed, 4 skipped |
| `tests/unit/_core/infrastructure/admin` | 148 passed |

## Remaining 48 — a long tail with no shared cause

| count | examples |
|---|---|
| 27 argument-type | five on one `data_grid` call, two Starlette handlers, a `Provider[Any]`, assorted literals |
| 17 attribute access | `importlib.util` unimported, DTO attributes read off a `BaseModel`-typed value, `error_code` on a bare `Exception` |
| 4 | two operator, one return type, one incompatible override |

Those, plus the `include` path and the scope-test entry, are the last step. Splitting them off because they share no theme with this PR — roughly twenty individual judgment calls rather than one pattern.

## Governor Footer

- trigger: no
- reviewer: self-structured
- rounds: 2
- r-points-fixed: 2
- r-points-deferred: 1
- r-points-rejected: 0
- touched-adr-consequences: none
- pr-scope-notes: One `src/` module (`_core/infrastructure/admin/auth.py`) plus five test files; no governor path is touched and check_governor_footer.py does not require a footer here, included for continuity with this arc. Two rounds because the first pass added the protocol and the count did not move — the doubles failed it too. R1 = the import placed above `__future__`; Fixed. R2 = assuming the protocol alone would clear the ten findings; Fixed by reading the new messages, which named the two drifts. Deferred-with-rationale = the 48-item tail and the gate flip, which share no theme with this change. Cross-tool review not obtained: codex exec 0.147.0 answers small prompts but echoes and exits without generating for a large prompt carrying an inline diff, reproduced four times in-repo and from /tmp. Self-structured per AGENTS.md Independent Review Trigger, supplemented by checking that the renamed parameter is passed positionally at its only production call site before renaming it — the one change here that could have broken runtime behaviour.
- final-verdict: merge-ready
- links: https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/398, n/a
