### PR TITLE
test: load harness hooks by path, not by colliding basename

### DIFF
--- a/tests/unit/agents_shared/test_fail_open.py
+++ b/tests/unit/agents_shared/test_fail_open.py
@@ -42,6 +42,27 @@ CODEX_HOOKS = [
 ]
 
 
+def _load_claude_hook(stem: str):
+    """Load a Claude hook by path, under a harness-qualified alias.
+
+    `verify_first` and `completion_gate` exist in all three harness directories,
+    so `import verify_first` names three files and `sys.modules` picks one. The
+    tier-2 tests below used to guard against that with `sys.modules.pop(...)`
+    plus a `sys.path` insert, which does work — measured — but only while every
+    future test remembers both halves. Loading by path removes the bare key from
+    the question entirely, and it is what tier 3 and the Codex tests in this same
+    file already do.
+    """
+    path = REPO_ROOT / ".claude" / "hooks" / f"{stem}.py"
+    alias = f"claude_{stem}"
+    spec = importlib.util.spec_from_file_location(alias, str(path))
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[alias] = module
+    spec.loader.exec_module(module)
+    return module
+
+
 # ---------------------------------------------------------------------------
 # Tier 1 — top-level shared import failure (PYTHONPATH scrambled)
 # ---------------------------------------------------------------------------
@@ -113,7 +134,7 @@ def test_tier2_function_call_import_error_returns_safe_default(
 
     sys.path.insert(0, str(REPO_ROOT / ".claude" / "hooks"))
     try:
-        import user_prompt_submit as ups  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
+        ups = _load_claude_hook("user_prompt_submit")
 
         def boom(*_args, **_kwargs):
             raise ImportError("simulated shared failure")
@@ -129,9 +150,7 @@ def test_tier2_function_call_import_error_returns_safe_default(
         assert ups.main() == 0
     finally:
         sys.path.pop(0)
-        for mod in list(sys.modules):
-            if mod == "user_prompt_submit":
-                del sys.modules[mod]
+        sys.modules.pop("claude_user_prompt_submit", None)
 
 
 # ---------------------------------------------------------------------------
@@ -145,9 +164,8 @@ def test_tier2_verify_first_read_latest_token_marker_safe_default(
     the shared reader raises rather than propagating to the Stop hook."""
 
     sys.path.insert(0, str(REPO_ROOT / ".claude" / "hooks"))
-    sys.modules.pop("verify_first", None)
     try:
-        import verify_first as vf  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
+        vf = _load_claude_hook("verify_first")
 
         def boom(*_args, **_kwargs):
             raise ImportError("simulated shared reader failure")
@@ -167,7 +185,7 @@ def test_tier2_verify_first_read_latest_token_marker_safe_default(
         assert isinstance(result, bool)
     finally:
         sys.path.pop(0)
-        sys.modules.pop("verify_first", None)
+        sys.modules.pop("claude_verify_first", None)
 
 
 def test_tier2_completion_gate_entry_points_safe_default(monkeypatch, tmp_path) -> None:
@@ -176,9 +194,8 @@ def test_tier2_completion_gate_entry_points_safe_default(monkeypatch, tmp_path) 
     silent rather than propagating to the Stop hook."""
 
     sys.path.insert(0, str(REPO_ROOT / ".claude" / "hooks"))
-    sys.modules.pop("completion_gate", None)
     try:
-        import completion_gate as cg  # noqa: PLC0415  # pyright: ignore[reportMissingImports]
+        cg = _load_claude_hook("completion_gate")
 
         # Force the degraded path; both entry points must short-circuit.
         monkeypatch.setattr(cg, "_SHARED_OK", False)
@@ -187,7 +204,7 @@ def test_tier2_completion_gate_entry_points_safe_default(monkeypatch, tmp_path) 
         cg.consume_phase2_markers(tmp_path)
     finally:
         sys.path.pop(0)
-        sys.modules.pop("completion_gate", None)
+        sys.modules.pop("claude_completion_gate", None)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/agents_shared/test_fail_open.py
+++ b/tests/unit/agents_shared/test_fail_open.py
@@ -11,12 +11,11 @@ Three tiers:
        subclass) is not caught by suppress(Exception).
 """
 
-# The harness hook modules below are imported by *basename* after a `sys.path`
-# insertion a few lines up, and the same basenames exist in `.claude/hooks`,
-# `.codex/hooks` and `.antigravity/hooks`. No static path can resolve them
-# unambiguously — which is the same collision that made the retired mypy hook
-# abort (#375) — so each import carries a scoped suppression rather than the
-# config pretending one directory is the answer.
+# The harness hook modules here are loaded *by path* under harness-qualified
+# aliases, because the same basenames exist in `.claude/hooks`, `.codex/hooks` and
+# `.antigravity/hooks` — `import verify_first` names three files and `sys.modules`
+# picks one (#401). The suppressions this comment used to explain are gone with the
+# bare imports that needed them.
 from __future__ import annotations
 
 import contextlib

--- a/tests/unit/agents_shared/test_hook_module_resolution.py
+++ b/tests/unit/agents_shared/test_hook_module_resolution.py
@@ -1,0 +1,135 @@
+"""A test must load the harness copy its name claims (#401).
+
+Eight hook basenames exist in more than one harness directory — `verify_first.py`
+and `completion_gate.py` in all three — so `import verify_first` after a
+`sys.path.insert` is ambiguous, and `sys.modules` decides it. Measured before this
+guard existed: after a full `tests/unit/agents_shared` run,
+
+    verify_first     -> .codex/hooks/verify_first.py
+    completion_gate  -> .codex/hooks/completion_gate.py
+
+while `test_fail_open.py` had inserted `.claude/hooks` and imported both by name.
+Its tier-2 tests were asserting the Codex fail-open behaviour under Claude names;
+the two copies of `verify_first.py` differ by 228 lines.
+
+**The pollution is not the tests' fault and cannot be fixed by renaming.** The hook
+files import their own siblings by bare name — `.codex/hooks/completion_gate.py`
+does `import _shared` and `import verify_first` — which is correct for a standalone
+hook process, where one harness directory is on `sys.path`. It only collides inside
+a shared pytest process that loads more than one harness's copies. So the invariant
+this file pins is the one a test *can* control: load by path, never by bare name.
+
+Two tests, in the order they matter:
+
+1. No test in this directory imports a colliding harness basename. That is the
+   structural rule; the AST check cannot be satisfied by accident.
+2. The tier-2 fail-open tests actually receive `.claude/hooks` modules. That is the
+   behaviour the rule exists to protect, checked directly rather than inferred.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_TESTS_DIR = Path(__file__).resolve().parent
+_HARNESS_DIRS = (
+    _REPO_ROOT / ".claude" / "hooks",
+    _REPO_ROOT / ".codex" / "hooks",
+    _REPO_ROOT / ".antigravity" / "hooks",
+)
+
+
+def _colliding_basenames() -> set[str]:
+    """Module names that exist in more than one harness directory."""
+    seen: dict[str, int] = {}
+    for directory in _HARNESS_DIRS:
+        for path in directory.glob("*.py"):
+            seen[path.stem] = seen.get(path.stem, 0) + 1
+    return {stem for stem, count in seen.items() if count > 1}
+
+
+def test_more_than_one_harness_copy_exists() -> None:
+    """The precondition. If this ever fails the rest of the file is moot."""
+    colliding = _colliding_basenames()
+
+    assert "verify_first" in colliding, (
+        "verify_first no longer exists in multiple harness directories — if the "
+        "copies were consolidated, this whole file can go"
+    )
+    assert len(colliding) >= 2, f"expected several colliding basenames, got {colliding}"
+
+
+def test_no_test_imports_a_colliding_harness_module_by_name() -> None:
+    """`import verify_first` cannot say which copy it means.
+
+    Checked by AST rather than by grep, so a mention inside a docstring or a
+    subprocess script string — both of which exist in this directory and are
+    correct, because a subprocess gets its own `sys.modules` — does not count.
+    """
+    colliding = _colliding_basenames()
+    offenders: list[str] = []
+
+    for path in sorted(_TESTS_DIR.glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name in colliding:
+                        offenders.append(
+                            f"{path.name}:{node.lineno} import {alias.name}"
+                        )
+            elif isinstance(node, ast.ImportFrom) and node.module in colliding:
+                offenders.append(
+                    f"{path.name}:{node.lineno} from {node.module} import ..."
+                )
+
+    assert not offenders, (
+        "these imports name a module that exists in more than one harness copy, so "
+        f"`sys.modules` decides which one arrives: {offenders}. Load it by path "
+        "instead — `importlib.util.spec_from_file_location('claude_verify_first', "
+        "path)` — which is what the rest of this directory already does."
+    )
+
+
+@pytest.mark.parametrize(
+    "stem", ["user_prompt_submit", "verify_first", "completion_gate"]
+)
+def test_claude_hooks_load_from_the_claude_directory(stem: str) -> None:
+    """The behaviour the rule protects, for the three modules tier 2 exercises.
+
+    Loading by path under a harness-qualified alias must yield a module whose
+    `__file__` is the Claude copy, no matter what a previously-run test left in
+    `sys.modules` under the bare name. Asserted on `__file__` because that is the
+    thing that was wrong: the tests passed while exercising the other copy.
+    """
+    path = _REPO_ROOT / ".claude" / "hooks" / f"{stem}.py"
+    assert path.is_file(), f"{path} is missing"
+
+    # Poison the bare key first — this is the state a real suite run produces.
+    codex_copy = _REPO_ROOT / ".codex" / "hooks" / f"{stem}.py"
+    if codex_copy.is_file():
+        poisoned = importlib.util.spec_from_file_location(stem, str(codex_copy))
+        assert poisoned is not None
+        sys.modules[stem] = importlib.util.module_from_spec(poisoned)
+
+    try:
+        spec = importlib.util.spec_from_file_location(f"claude_{stem}", str(path))
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[f"claude_{stem}"] = module
+        spec.loader.exec_module(module)
+
+        assert module.__file__ is not None
+        assert Path(module.__file__).parent == path.parent, (
+            f"loaded {module.__file__} while asking for {path} — path-based loading "
+            "is supposed to be immune to whatever occupies the bare name"
+        )
+    finally:
+        sys.modules.pop(stem, None)
+        sys.modules.pop(f"claude_{stem}", None)

--- a/tests/unit/agents_shared/test_hook_module_resolution.py
+++ b/tests/unit/agents_shared/test_hook_module_resolution.py
@@ -2,15 +2,19 @@
 
 Eight hook basenames exist in more than one harness directory — `verify_first.py`
 and `completion_gate.py` in all three — so `import verify_first` after a
-`sys.path.insert` is ambiguous, and `sys.modules` decides it. Measured before this
-guard existed: after a full `tests/unit/agents_shared` run,
+`sys.path.insert` is ambiguous, and `sys.modules` decides it. The suite leaves
+those keys pointing at the Codex copies:
 
     verify_first     -> .codex/hooks/verify_first.py
     completion_gate  -> .codex/hooks/completion_gate.py
 
-while `test_fail_open.py` had inserted `.claude/hooks` and imported both by name.
-Its tier-2 tests were asserting the Codex fail-open behaviour under Claude names;
-the two copies of `verify_first.py` differ by 228 lines.
+**No test was getting the wrong copy.** #401 was filed claiming they were, on a
+misreading — the end state of `sys.modules` is not what an earlier test received —
+and the tier-2 tests in `test_fail_open.py` had guarded themselves with a
+`sys.modules.pop` plus `sys.path[0]`. What was missing is that nothing said so and
+nothing enforced it: the next test to import a colliding basename without both
+halves gets whichever copy is cached, and would pass while exercising another
+harness. The two copies of `verify_first.py` differ by 228 lines.
 
 **The pollution is not the tests' fault and cannot be fixed by renaming.** The hook
 files import their own siblings by bare name — `.codex/hooks/completion_gate.py`
@@ -33,6 +37,7 @@ import ast
 import importlib.util
 import sys
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
@@ -52,6 +57,27 @@ def _colliding_basenames() -> set[str]:
         for path in directory.glob("*.py"):
             seen[path.stem] = seen.get(path.stem, 0) + 1
     return {stem for stem, count in seen.items() if count > 1}
+
+
+def _real_loader():
+    """`test_fail_open._load_claude_hook`, loaded by path.
+
+    By path rather than `from test_fail_open import ...` so this guard does not
+    depend on the directory being an importable package, and so the module it pulls
+    in cannot be shadowed by anything already in `sys.modules`.
+    """
+    target = _TESTS_DIR / "test_fail_open.py"
+    spec = importlib.util.spec_from_file_location("fail_open_under_guard", str(target))
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["fail_open_under_guard"] = module
+    spec.loader.exec_module(module)
+    loader = getattr(module, "_load_claude_hook", None)
+    assert loader is not None, (
+        "test_fail_open._load_claude_hook is gone — if the loading helper was "
+        "renamed, point this guard at the new one; do not delete the check"
+    )
+    return loader
 
 
 def test_more_than_one_harness_copy_exists() -> None:
@@ -106,12 +132,17 @@ def test_claude_hooks_load_from_the_claude_directory(stem: str) -> None:
     Loading by path under a harness-qualified alias must yield a module whose
     `__file__` is the Claude copy, no matter what a previously-run test left in
     `sys.modules` under the bare name. Asserted on `__file__` because that is the
-    thing that was wrong: the tests passed while exercising the other copy.
+    thing a wrong resolution would silently change, and the reason a passing test
+        is not evidence of which copy ran.
     """
     path = _REPO_ROOT / ".claude" / "hooks" / f"{stem}.py"
     assert path.is_file(), f"{path} is missing"
 
     # Poison the bare key first — this is the state a real suite run produces.
+    # Saved and restored, not just popped: dropping a key another test cached would
+    # let this guard mask the very misresolution it exists to catch. Same discipline
+    # as `test_locale.py::_load_codex_completion_gate`.
+    saved = sys.modules.get(stem)
     codex_copy = _REPO_ROOT / ".codex" / "hooks" / f"{stem}.py"
     if codex_copy.is_file():
         poisoned = importlib.util.spec_from_file_location(stem, str(codex_copy))
@@ -119,11 +150,11 @@ def test_claude_hooks_load_from_the_claude_directory(stem: str) -> None:
         sys.modules[stem] = importlib.util.module_from_spec(poisoned)
 
     try:
-        spec = importlib.util.spec_from_file_location(f"claude_{stem}", str(path))
-        assert spec is not None and spec.loader is not None
-        module = importlib.util.module_from_spec(spec)
-        sys.modules[f"claude_{stem}"] = module
-        spec.loader.exec_module(module)
+        # The *real* loader, not a copy of it. Reproducing the correct logic here
+        # would let `_load_claude_hook` regress to a dynamic `import_module(stem)` —
+        # invisible to the AST rule above, since it is not an import statement —
+        # while this test kept passing on its own private implementation.
+        module = _real_loader()(stem)
 
         assert module.__file__ is not None
         assert Path(module.__file__).parent == path.parent, (
@@ -131,5 +162,8 @@ def test_claude_hooks_load_from_the_claude_directory(stem: str) -> None:
             "is supposed to be immune to whatever occupies the bare name"
         )
     finally:
-        sys.modules.pop(stem, None)
+        if isinstance(saved, ModuleType):
+            sys.modules[stem] = saved
+        else:
+            sys.modules.pop(stem, None)
         sys.modules.pop(f"claude_{stem}", None)

--- a/tests/unit/agents_shared/test_shared_delegation.py
+++ b/tests/unit/agents_shared/test_shared_delegation.py
@@ -13,6 +13,7 @@ in all paths (HC-5.5 execution fail-open).
 # config pretending one directory is the answer.
 from __future__ import annotations
 
+import importlib.util
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -22,7 +23,26 @@ _HOOKS = REPO_ROOT / ".codex" / "hooks"
 if str(_HOOKS) not in sys.path:
     sys.path.insert(0, str(_HOOKS))
 
-import _shared as shared_module  # pyright: ignore[reportMissingImports]
+
+def _load_codex_shared():
+    """Load the Codex `_shared` by path, under a harness-qualified alias.
+
+    `_shared.py` exists in `.codex/hooks` and `.antigravity/hooks`, so a bare
+    `import _shared` names two files and `sys.modules` picks one. Nothing was
+    getting the wrong copy — this module is imported at collection time, before
+    anything else registers that key — but the correctness depended on that
+    ordering rather than on anything stated. Loading by path does not.
+    """
+    path = _HOOKS / "_shared.py"
+    spec = importlib.util.spec_from_file_location("codex_shared", str(path))
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["codex_shared"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+shared_module = _load_codex_shared()
 
 # ---------------------------------------------------------------------------
 # Delegation path (_GATE_OK=True)

--- a/tests/unit/agents_shared/test_shared_delegation.py
+++ b/tests/unit/agents_shared/test_shared_delegation.py
@@ -5,12 +5,11 @@ when available, falls back to inline logic when not, and is exception-safe
 in all paths (HC-5.5 execution fail-open).
 """
 
-# The harness hook modules below are imported by *basename* after a `sys.path`
-# insertion a few lines up, and the same basenames exist in `.claude/hooks`,
-# `.codex/hooks` and `.antigravity/hooks`. No static path can resolve them
-# unambiguously — which is the same collision that made the retired mypy hook
-# abort (#375) — so each import carries a scoped suppression rather than the
-# config pretending one directory is the answer.
+# The harness hook modules here are loaded *by path* under harness-qualified
+# aliases, because the same basenames exist in `.claude/hooks`, `.codex/hooks` and
+# `.antigravity/hooks` — `import verify_first` names three files and `sys.modules`
+# picks one (#401). The suppressions this comment used to explain are gone with the
+# bare imports that needed them.
 from __future__ import annotations
 
 import importlib.util

--- a/tests/unit/tools/test_pyright_scope.py
+++ b/tests/unit/tools/test_pyright_scope.py
@@ -16,7 +16,7 @@ is the whole reason this file exists:
   first. Two of those findings were doubles that had silently stopped matching the
   protocols they impersonate, which is the coverage this buys.
 - **Suppression creep.** `# pyright: ignore` is the other way to hold a tree at 0
-  errors without fixing anything. 52 exist, in 27 files, each with its cause
+  errors without fixing anything. 48 exist, in 26 files, each with its cause
   written at the call site. That is defensible *because* it is pinned; unpinned,
   it is a trend. #387 is the counter-example worth remembering: the three harness
   hook directories carried **88** `# type: ignore` comments, every one of them
@@ -74,10 +74,9 @@ _ALLOWED_SUPPRESSIONS = {
     "tests/unit/_core/infrastructure/vectors/s3/test_base_store.py": 1,
     "tests/unit/_core/test_dead_code_stays_deleted.py": 1,
     "tests/unit/agents_shared/test_antigravity_hardening.py": 1,
-    "tests/unit/agents_shared/test_fail_open.py": 5,
+    "tests/unit/agents_shared/test_fail_open.py": 2,
     "tests/unit/agents_shared/test_harness_hook_surface.py": 1,
     "tests/unit/agents_shared/test_locale.py": 1,
-    "tests/unit/agents_shared/test_shared_delegation.py": 1,
     "tests/unit/blog/domain/test_post_service.py": 5,
 }
 


### PR DESCRIPTION
Closes #401 — **as prevention, not as a fix.** The defect I filed that issue for does not exist, and establishing that is most of what this change is worth.

## What I got wrong

I measured `sys.modules` after a full suite run, saw `verify_first -> .codex/hooks/verify_first.py`, and read it as what `test_fail_open.py`'s tier-2 tests had received. It is not — later tests re-cache the Codex copies after tier 2 has finished.

Replaying the exact tier-2 sequence against a deliberately poisoned cache:

```
1. poison bare key   -> .codex/hooks/verify_first.py
2. tier-2 sequence   -> .claude/hooks/verify_first.py     ← correct
```

Two of those tests already did `sys.modules.pop(...)` with `.claude/hooks` at `sys.path[0]`, so they resolved correctly all along. The third imports `user_prompt_submit`, which **does not collide**: `.codex` and `.antigravity` spell that file `user-prompt-submit.py`. **No test was exercising the wrong copy.**

**"The value left in `sys.modules` at the end" is not "the value that test used."** I filed the issue on that conflation; #401's title and a comment now say so.

## What is real

```
leftover verify_first     -> .codex/hooks/verify_first.py
leftover completion_gate  -> .codex/hooks/completion_gate.py
leftover _shared          -> .codex/hooks/_shared.py
```

The suite leaves bare keys pointing at Codex copies, and the correctness of those two tests rested on a `pop` + `sys.path.insert` pair that nothing stated and nothing enforced. The next test to import a colliding basename without both halves gets whichever copy is cached — and would pass while exercising another harness. Eight basenames collide; the two `verify_first.py` copies differ by **228 lines**.

The pollution cannot be removed on the test side. The hook files import their own siblings by bare name:

```
.codex/hooks/completion_gate.py:36  imports bare '_shared'
.codex/hooks/completion_gate.py:37  imports bare 'verify_first'
```

which is correct for a standalone hook process, where one harness directory is on `sys.path`. It only collides inside a shared pytest process. So the invariant pinned here is the one a test *can* control: **load by path, never by bare name.**

## The change

- **`test_hook_module_resolution.py`** — an AST guard that no test in the directory imports a colliding harness basename (AST, so a mention in a docstring or a subprocess script string does not count — both exist there and are correct), plus a direct check that a path-based load beats a poisoned bare key. **Verified to fail first**, naming exactly the three offenders:

```
AssertionError: ['test_fail_open.py:150 import verify_first',
                 'test_fail_open.py:181 import completion_gate',
                 'test_shared_delegation.py:25 import _shared']
```

- Those three now load by path under harness-qualified aliases — which is what tier 3 and the Codex tests **in the same file** already did. The `sys.modules.pop` calls that used to carry the correctness are gone with them, and the `finally` blocks pop the alias each test created rather than a key it never touched.
- Three `reportMissingImports` suppressions left with the imports that needed them; the guard's own avoidable one became an `assert`. Pin: **52 → 48**.

## What the survey found and did not need

Task 1 of the plan was to convert the *registrars* to harness-qualified names. **No work was needed** — `test_completion_gate.py`, `test_verify_first.py` and `test_token_parser.py` already use `claude_*` / `codex_*` aliases, and `test_locale.py` has a docstring describing this exact hazard and restoring the keys in a `finally`. The convention existed in four places; it was three sites short of universal.

## Verification

| gate | result |
|---|---|
| guard before the conversion | **fails**, naming the 3 offenders |
| guard after | 5 passed |
| `tests/unit/agents_shared` | 719 passed (714 + 5 new) |
| same, `-p no:randomly` | 719 passed — order-independent |
| path-load under a poisoned bare key | resolves `.claude/hooks/verify_first.py` |
| `make check-core` | 1958 passed, 4 skipped |
| `uv run pyright` | 0 errors, 945 files |

The fail-open contract's assertions are untouched; only the loading mechanism changed, which is the constraint the plan set for this suite.


## Round 2 — cross-tool review

Run with the path-based prompt form (no inlined diff). Four findings, all legitimate, all fixed:

| # | finding | fix |
|---|---|---|
| 1 | The guard **reproduced** the loading logic instead of calling `_load_claude_hook`, so a regression to a dynamic `importlib.import_module(stem)` would pass both checks | loads `test_fail_open.py` by path and calls the real helper — verified: regressing it fails **3 of 5** guard tests |
| 2 | The guard poisoned the bare key and popped it without saving, so it could mask the misresolution it exists to catch | saved and restored, the discipline `test_locale.py` already applies |
| 3 | **My own docstring resurrected the disproved premise** in two places | rewritten to say what is actually true |
| 4 | Stale comments in two files still described basename imports carrying suppressions | replaced |

Codex also confirmed three things I had asserted: the alias load preserves the monkeypatched module object, removing the `sys.modules.pop` calls is safe because the three Claude hooks have no colliding bare sibling imports, and the fail-open assertions are untouched. It rejected the original bug claim as a non-issue — agreeing with the correction this PR is built on.

## Governor Footer

- trigger: no
- reviewer: codex-cli 0.147.0
- rounds: 2
- r-points-fixed: 5
- r-points-deferred: 0
- r-points-rejected: 0
- touched-adr-consequences: none
- pr-scope-notes: `tests/` only — no governor path is touched and check_governor_footer.py does not require a footer here; included because this PR adjoins the fail-open contract suite (Tier 3 harness behaviour). Two rounds because round 1 was my own execution of the plan, which falsified the plan's premise at task 4 and returned to the user for a scope decision before implementing. R1 = the issue's symptom claim, disproved by replaying the tier-2 sequence against a poisoned cache; Fixed by reframing the work as prevention and correcting #401 rather than shipping a "fix" that fixed nothing. R2-R5 = the four review findings above, all Fixed. Cross-tool review obtained from codex (path-based prompt, no inlined diff — the form verified in #400); it found a real gap in my own guard, which is the second time today that running the review rather than assuming it unavailable changed the outcome.
- final-verdict: merge-ready
- links: https://github.com/Mr-DooSun/fastapi-agent-blueprint/pull/402, https://github.com/Mr-DooSun/fastapi-agent-blueprint/issues/401

